### PR TITLE
Sync additional post meta back to WordPress.com

### DIFF
--- a/inc/wc-calypso-bridge-jetpack-sync.php
+++ b/inc/wc-calypso-bridge-jetpack-sync.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Adds additional WooCommerce options to the sync whitelist.
+ * See Jetpack's `class.jetpack-sync-module-woocommerce.php`.
+ * Some fields are already synced back. This adds a few additional ones for the
+ * Store on .com experience.
+ *
+ * @since 0.1.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+function wc_calypso_bridge_add_post_meta_whitelist( $list ) {
+	$additional_meta = array(
+		'_billing_email',
+		'_billing_first_name',
+		'_billing_last_name',
+	);
+	return array_merge( $list, $additional_meta );
+}
+
+add_filter( 'jetpack_sync_post_meta_whitelist', 'wc_calypso_bridge_add_post_meta_whitelist', 10 );

--- a/wc-calypso-bridge-class.php
+++ b/wc-calypso-bridge-class.php
@@ -68,6 +68,7 @@ class WC_Calypso_Bridge {
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-email-site-title.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-enable-auto-update-db.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-jetpack-hotfixes.php' );
+		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-jetpack-sync.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-mailchimp-no-redirect.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-masterbar-menu.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-paypal-defaults.php' );


### PR DESCRIPTION
Jetpack has a WooCommerce module for syncing certain information back to WordPress.com (some billing details, payment method, total, etc) and line items.

To display everything we want in the New Order Notification, I need a few more pieces of meta synced back. I imagine we might need other sync handling in the future (i.e. additional options or constants), so I made the file more general for all Jetpack sync related hooks to live.

Basic Test:
* Run this branch with https://github.com/woocommerce/wc-api-dev/pull/66
* Create a new order and observe your debug log to make sure no errors occur from this branch.

Full test (WordPress.com sandbox required, with a permanent WP.com subdomain pointed to it):

* Run this branch with https://github.com/woocommerce/wc-api-dev/pull/66
* On your WordPress.com sandbox, edit `wp-content/mu-plugins/jetpack/sync/class.jetpack-sync-defaults.php` and add `'_billing_email'`, `'_billing_first_name'`, and `'_billing_last_name'` to `$post_meta_whitelist`.
* On your Jetpack site, edit `jetpack.php` and update `JETPACK__API_BASE` to direct to your sandbox. I.e.: `defined( 'JETPACK__API_BASE' )               or define( 'JETPACK__API_BASE', 'https://sandboxjustin.wordpress.com/jetpack.' );` The period at the end is required.
* Create a new order on your site.
* Using the `wpsh` command on your WordPress.com sandbox, enter `switch_to_blog( ID );`. You can get your site ID from the developer console.
* Then, using `wpsh`enter `echo get_post_meta( ORDER_ID, '_billing_email', true );` for the new order. You should see the billing email address be returned.
