### PR TITLE
Hide stripe alerts for Apple Pay, and Google Payments.

### DIFF
--- a/inc/wc-calypso-bridge-hide-alerts.php
+++ b/inc/wc-calypso-bridge-hide-alerts.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Logic to hide various alerts in wp-admin
+ *
+ * @since 0.1.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// Hide Apple Pay and Google Payment notices
+add_filter( 'pre_option_wc_stripe_show_apple_pay_notice', '__return_true' );
+add_filter( 'pre_option_wc_stripe_show_request_api_notice', '__return_true' );

--- a/wc-calypso-bridge-class.php
+++ b/wc-calypso-bridge-class.php
@@ -67,6 +67,7 @@ class WC_Calypso_Bridge {
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-email-order-url.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-email-site-title.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-enable-auto-update-db.php' );
+		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-hide-alerts.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-jetpack-hotfixes.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-jetpack-sync.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-mailchimp-no-redirect.php' );


### PR DESCRIPTION
This is for https://github.com/Automattic/wp-calypso/issues/16627

Two of the current alerts that are shown in `wp-admin` for a new store site are related to Apple Pay and Google Payment services:

![31696089-b697b542-b363-11e7-8355-d372844593fa_png__2468x724_](https://user-images.githubusercontent.com/22080/31737932-ec0f8782-b3fd-11e7-8563-0849c9450afd.png)

Both of which are displayed based upon an option [_not_ being present](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/master/woocommerce-gateway-stripe.php#L300-L338). Rather than just setting the option, I figured filtering the option value would be just as easy here.

__To Test__
- On a new Store Site, load this plugin
- Verify the Apple Pay and Google Payment alerts are no longer shown.