### PR TITLE
Hide install / setup notice.

### DIFF
--- a/inc/wc-calypso-bridge-hide-alerts.php
+++ b/inc/wc-calypso-bridge-hide-alerts.php
@@ -14,12 +14,12 @@ add_filter( 'pre_option_wc_stripe_show_apple_pay_notice', '__return_true' );
 add_filter( 'pre_option_wc_stripe_show_request_api_notice', '__return_true' );
 
 // Hide setup store notice.
-add_filter( 'woocommerce_show_admin_notice', 'wc_calypso_bridge_hide_admin_notice' );
+add_filter( 'woocommerce_show_admin_notice', 'wc_calypso_bridge_hide_admin_notice', 10, 2 );
 
-function wc_calypso_bridge_hide_admin_notice( $notice ) {
-	if ( 'install' == $notice ) {
+function wc_calypso_bridge_hide_admin_notice( $bool, $notice ) {
+	if ( 'install' === $notice ) {
 		return false;
 	}
 
-	return true;
+	return $notice;
 }

--- a/inc/wc-calypso-bridge-hide-alerts.php
+++ b/inc/wc-calypso-bridge-hide-alerts.php
@@ -21,5 +21,5 @@ function wc_calypso_bridge_hide_admin_notice( $bool, $notice ) {
 		return false;
 	}
 
-	return $notice;
+	return $bool;
 }

--- a/inc/wc-calypso-bridge-hide-alerts.php
+++ b/inc/wc-calypso-bridge-hide-alerts.php
@@ -12,3 +12,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Hide Apple Pay and Google Payment notices
 add_filter( 'pre_option_wc_stripe_show_apple_pay_notice', '__return_true' );
 add_filter( 'pre_option_wc_stripe_show_request_api_notice', '__return_true' );
+
+// Hide setup store notice.
+add_filter( 'woocommerce_show_admin_notice', 'wc_calypso_bridge_hide_admin_notice' );
+
+function wc_calypso_bridge_hide_admin_notice( $notice ) {
+	if ( 'install' == $notice ) {
+		return false;
+	}
+
+	return true;
+}


### PR DESCRIPTION
For https://github.com/Automattic/wp-calypso/issues/16627

I am still seeing the setup your store notice on a few test sites - seems like it may be shown again after an upgrade possibly - regardless, adding in some logic to ensure it is not shown to Store users.

__To Test__
- Setup a new store
- Visit `wp-admin`, and verify the following notice is not shown:

![edit_plugins_ _save_the_deschutes_ _wordpress](https://user-images.githubusercontent.com/22080/31902099-84e228ce-b7d8-11e7-8b7e-370b256a0e39.png)
