### PR TITLE
Add in email templates that were lost during initial move.

### DIFF
--- a/inc/email-templates/email-order-details.php
+++ b/inc/email-templates/email-order-details.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Order details table shown in emails.
+ *
+ * This matches version 3.0.0 of the email-order-details template.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$text_align = is_rtl() ? 'right' : 'left';
+
+do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plain_text, $email ); ?>
+
+<?php if ( ! $sent_to_admin ) : ?>
+	<h2><?php printf( __( 'Order #%s', 'wc-calypso-bridge' ), $order->get_order_number() ); ?></h2>
+<?php else : ?>
+	<h2><a class="link" href="<?php echo esc_url( wc_calypso_bridge_email_get_wpcom_order_link( $order->get_id() ) ); ?>"><?php printf( __( 'Order #%s', 'wc-calypso-bridge' ), $order->get_order_number() ); ?></a> (<?php printf( '<time datetime="%s">%s</time>', $order->get_date_created()->format( 'c' ), wc_format_datetime( $order->get_date_created() ) ); ?>)</h2>
+<?php endif; ?>
+
+<table class="td" cellspacing="0" cellpadding="6" style="width: 100%; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;" border="1">
+	<thead>
+		<tr>
+			<th class="td" scope="col" style="text-align:<?php echo $text_align; ?>;"><?php _e( 'Product', 'wc-calypso-bridge' ); ?></th>
+			<th class="td" scope="col" style="text-align:<?php echo $text_align; ?>;"><?php _e( 'Quantity', 'wc-calypso-bridge' ); ?></th>
+			<th class="td" scope="col" style="text-align:<?php echo $text_align; ?>;"><?php _e( 'Price', 'wc-calypso-bridge' ); ?></th>
+		</tr>
+	</thead>
+	<tbody>
+		<?php echo wc_get_email_order_items( $order, array(
+			'show_sku'      => $sent_to_admin,
+			'show_image'    => false,
+			'image_size'    => array( 32, 32 ),
+			'plain_text'    => $plain_text,
+			'sent_to_admin' => $sent_to_admin,
+		) ); ?>
+	</tbody>
+	<tfoot>
+		<?php
+			if ( $totals = $order->get_order_item_totals() ) {
+				$i = 0;
+				foreach ( $totals as $total ) {
+					$i++;
+					?><tr>
+						<th class="td" scope="row" colspan="2" style="text-align:<?php echo $text_align; ?>; <?php echo ( 1 === $i ) ? 'border-top-width: 4px;' : ''; ?>"><?php echo $total['label']; ?></th>
+						<td class="td" style="text-align:<?php echo $text_align; ?>; <?php echo ( 1 === $i ) ? 'border-top-width: 4px;' : ''; ?>"><?php echo $total['value']; ?></td>
+					</tr><?php
+				}
+			}
+		?>
+	</tfoot>
+</table>
+
+<?php do_action( 'woocommerce_email_after_order_table', $order, $sent_to_admin, $plain_text, $email ); ?>

--- a/inc/email-templates/plain/email-order-details.php
+++ b/inc/email-templates/plain/email-order-details.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Order details table shown in emails.
+ *
+ * This matches version 2.5.0 of the email-order-details plain template.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plain_text, $email );
+
+echo strtoupper( sprintf( __( 'Order number: %s', 'wc-calypso-bridge' ), $order->get_order_number() ) ) . "\n";
+echo wc_format_datetime( $order->get_date_created() ) . "\n";
+echo "\n" . wc_get_email_order_items( $order, array(
+	'show_sku'      => $sent_to_admin,
+	'show_image'    => false,
+	'image_size'    => array( 32, 32 ),
+	'plain_text'    => true,
+	'sent_to_admin' => $sent_to_admin,
+) );
+
+echo "==========\n\n";
+
+if ( $totals = $order->get_order_item_totals() ) {
+	foreach ( $totals as $total ) {
+		echo $total['label'] . "\t " . $total['value'] . "\n";
+	}
+}
+
+if ( $sent_to_admin ) {
+	echo "\n" . sprintf( __( 'View order: %s', 'wc-calypso-bridge' ), wc_calypso_bridge_email_get_wpcom_order_link( $order->get_id() ) ) . "\n";
+}
+
+do_action( 'woocommerce_email_after_order_table', $order, $sent_to_admin, $plain_text, $email );


### PR DESCRIPTION
This branch seeks to fix the missing order details as reported in p8yzl4-On-p2. During the initial migration from `wc-api-dev` to `wc-calypso-bridge` - I failed to move over the email over-ridden email templates from the old plugin location, which resulted in order emails missing the details.

__To Test__
- Upload this branch as a plugin to a test AT Store site
- Activate the Plugin
- Place a test order, and verify the order details are shown in the email confirmation

![your_timmy_s_flies_order_receipt_from_november_6__2017_-_timmydcrawford_gmail_com_-_gmail](https://user-images.githubusercontent.com/22080/32458920-cc8c34f2-c2e2-11e7-8c53-7050d2b841ed.png)


