### PR TITLE
Add/settings email groups endpoint

### DIFF
--- a/api/class-wc-calypso-bridge-settings-email-groups-controller.php
+++ b/api/class-wc-calypso-bridge-settings-email-groups-controller.php
@@ -69,7 +69,6 @@ class WC_Calypso_Bridge_Settings_Email_Groups_Controller extends WC_REST_Setting
 
 		foreach ( $items as $item ) {
 			$wanted_keys = array(
-				'group_id' => '',
 				'id'       => '',
 				'value'    => '',
 			);
@@ -82,7 +81,10 @@ class WC_Calypso_Bridge_Settings_Email_Groups_Controller extends WC_REST_Setting
 							'error'    => array( 'code' => $_response->get_error_code(), 'message' => $_response->get_error_message(), 'data' => $_response->get_error_data() ),
 					);
 			} else {
-					$response[] = array_intersect_key( $wp_rest_server->response_to_data( $_response, '' ), $wanted_keys );
+					// Filter out unneded fields
+					$option = array_intersect_key( $wp_rest_server->response_to_data( $_response, '' ), $wanted_keys );
+					$option['group_id'] = $item['group_id'];
+					$response[] = $option;
 			}
 		}
 

--- a/api/class-wc-calypso-bridge-settings-email-groups-controller.php
+++ b/api/class-wc-calypso-bridge-settings-email-groups-controller.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * REST API Settings controller
+ *
+ * Handles requests to the /settings/batch_email endpoint.
+ *
+ * @author   Automattic
+ * @category API
+ * @package  WooCommerce/API
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * REST API Settings controller class.
+ *
+ * @package WooCommerce/API
+ */
+class WC_Calypso_Bridge_Settings_Email_Groups_Controller extends WC_REST_Settings_Controller {
+
+	/**
+	 * WP REST API namespace/version.
+	 */
+	protected $namespace = 'wc/v3';
+	protected $rest_base = 'settings_email_groups';
+
+	/**
+	 * Register routes.
+	 *
+	 */
+	public function register_routes() {
+		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_all_email_settings' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+			),
+		) );
+	}
+
+	/**
+	 * Bulk read email setings;
+	 *
+	 * @return array Of WP_Error or WP_REST_Response.
+	 */
+	public function get_all_email_settings() {
+		/** @var WP_REST_Server $wp_rest_server */
+		global $wp_rest_server;
+
+		// List of all items returned by the settings/batch_email endpoint.
+		$items = [
+			[ 'group_id' => 'email',                           'id' => 'woocommerce_email_from_name' ],
+			[ 'group_id' => 'email',                           'id' => 'woocommerce_email_from_address' ],
+			[ 'group_id' => 'email_new_order',                 'id' => 'enabled' ],
+			[ 'group_id' => 'email_new_order',                 'id' => 'recipient' ],
+			[ 'group_id' => 'email_cancelled_order',           'id' => 'enabled' ],
+			[ 'group_id' => 'email_cancelled_order',           'id' => 'recipient' ],
+			[ 'group_id' => 'email_failed_order',              'id' => 'enabled' ],
+			[ 'group_id' => 'email_failed_order',              'id' => 'recipient' ],
+			[ 'group_id' => 'email_customer_on_hold_order',    'id' => 'enabled' ],
+			[ 'group_id' => 'email_customer_processing_order', 'id' => 'enabled' ],
+			[ 'group_id' => 'email_customer_completed_order',  'id' => 'enabled' ],
+			[ 'group_id' => 'email_customer_refunded_order',   'id' => 'enabled' ],
+			[ 'group_id' => 'email_customer_new_account',      'id' => 'enabled' ],
+		];
+		$response = [];
+
+		foreach ( $items as $item ) {
+				$_response = $this->get_option( $item );
+				if ( is_wp_error( $_response ) ) {
+						$response[] = array(
+								'group_id' => $item['group_id'],
+								'id'       => $item['id'],
+								'error'    => array( 'code' => $_response->get_error_code(), 'message' => $_response->get_error_message(), 'data' => $_response->get_error_data() ),
+						);
+				} else {
+						$response[] = $wp_rest_server->response_to_data( $_response, '' );
+				}
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Get single settings option
+	 *
+	 * @param  Object with group_id and id
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_option( $request ) {
+		$options_controller = new WC_REST_Setting_Options_Controlle;
+		$response = $options_controller->get_item( $request );
+		return $response;
+	}
+
+}

--- a/api/class-wc-calypso-bridge-settings-email-groups-controller.php
+++ b/api/class-wc-calypso-bridge-settings-email-groups-controller.php
@@ -67,13 +67,15 @@ class WC_Calypso_Bridge_Settings_Email_Groups_Controller extends WC_REST_Setting
 		];
 		$response = [];
 
+		$options_controller = new WC_REST_Setting_Options_Controller;
+
 		foreach ( $items as $item ) {
 			$wanted_keys = array(
 				'id'       => '',
 				'value'    => '',
 			);
 
-			$_response = $this->get_option( $item );
+			$_response = $options_controller->get_item( $item );
 			if ( is_wp_error( $_response ) ) {
 					$response[] = array(
 							'group_id' => $item['group_id'],
@@ -88,19 +90,6 @@ class WC_Calypso_Bridge_Settings_Email_Groups_Controller extends WC_REST_Setting
 			}
 		}
 
-		return $response;
-	}
-
-	/**
-	 * Get single settings option
-	 *
-	 * @param  Object with group_id and id
-	 * @return WP_Error|WP_REST_Response
-	 */
-	public function get_option( $request ) {
-
-		$options_controller = new WC_REST_Setting_Options_Controller;
-		$response =  $options_controller->get_item( $request );
 		return $response;
 	}
 

--- a/api/class-wc-calypso-bridge-settings-email-groups-controller.php
+++ b/api/class-wc-calypso-bridge-settings-email-groups-controller.php
@@ -49,7 +49,7 @@ class WC_Calypso_Bridge_Settings_Email_Groups_Controller extends WC_REST_Setting
 		/** @var WP_REST_Server $wp_rest_server */
 		global $wp_rest_server;
 
-		// List of all items returned by the settings/batch_email endpoint.
+		// List of all items returned by the settings_email_groups endpoint.
 		$items = [
 			[ 'group_id' => 'email',                           'id' => 'woocommerce_email_from_name' ],
 			[ 'group_id' => 'email',                           'id' => 'woocommerce_email_from_address' ],

--- a/api/class-wc-calypso-bridge-settings-email-groups-controller.php
+++ b/api/class-wc-calypso-bridge-settings-email-groups-controller.php
@@ -90,8 +90,14 @@ class WC_Calypso_Bridge_Settings_Email_Groups_Controller extends WC_REST_Setting
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_option( $request ) {
+		$wanted_keys = array(
+			'group_id' => '',
+			'id'       => '',
+			'value'    => '',
+		);
+		
 		$options_controller = new WC_REST_Setting_Options_Controller;
-		$response = $options_controller->get_item( $request );
+		$response = array_intersect_key( $options_controller->get_item( $request ), $wanted_keys );
 		return $response;
 	}
 

--- a/api/class-wc-calypso-bridge-settings-email-groups-controller.php
+++ b/api/class-wc-calypso-bridge-settings-email-groups-controller.php
@@ -90,7 +90,7 @@ class WC_Calypso_Bridge_Settings_Email_Groups_Controller extends WC_REST_Setting
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_option( $request ) {
-		$options_controller = new WC_REST_Setting_Options_Controlle;
+		$options_controller = new WC_REST_Setting_Options_Controller;
 		$response = $options_controller->get_item( $request );
 		return $response;
 	}

--- a/api/class-wc-calypso-bridge-settings-email-groups-controller.php
+++ b/api/class-wc-calypso-bridge-settings-email-groups-controller.php
@@ -76,16 +76,16 @@ class WC_Calypso_Bridge_Settings_Email_Groups_Controller extends WC_REST_Setting
 		foreach ( $items as $item ) {
 			$_response = $options_controller->get_item( $item );
 			if ( is_wp_error( $_response ) ) {
-					$response[] = array(
-							'group_id' => $item['group_id'],
-							'id'       => $item['id'],
-							'error'    => array( 'code' => $_response->get_error_code(), 'message' => $_response->get_error_message(), 'data' => $_response->get_error_data() ),
-					);
+				$response[] = array(
+					'group_id' => $item['group_id'],
+					'id'       => $item['id'],
+					'error'    => array( 'code' => $_response->get_error_code(), 'message' => $_response->get_error_message(), 'data' => $_response->get_error_data() ),
+				);
 			} else {
-					// Filter out unneeded fields
-					$option = array_intersect_key( $wp_rest_server->response_to_data( $_response, '' ), $wanted_keys );
-					$option['group_id'] = $item['group_id'];
-					$response[] = $option;
+				// Filter out unneeded fields
+				$option = array_intersect_key( $wp_rest_server->response_to_data( $_response, '' ), $wanted_keys );
+				$option['group_id'] = $item['group_id'];
+				$response[] = $option;
 			}
 		}
 

--- a/api/class-wc-calypso-bridge-settings-email-groups-controller.php
+++ b/api/class-wc-calypso-bridge-settings-email-groups-controller.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * REST API Settings controller
+ * REST API Settings Email Groups controller
  *
- * Handles requests to the /settings/batch_email endpoint.
+ * Handles requests to the /settings_email_groups endpoint.
  *
  * @author   Automattic
  * @category API
@@ -68,13 +68,12 @@ class WC_Calypso_Bridge_Settings_Email_Groups_Controller extends WC_REST_Setting
 		$response = [];
 
 		$options_controller = new WC_REST_Setting_Options_Controller;
+		$wanted_keys = array(
+			'id'       => '',
+			'value'    => '',
+		);
 
 		foreach ( $items as $item ) {
-			$wanted_keys = array(
-				'id'       => '',
-				'value'    => '',
-			);
-
 			$_response = $options_controller->get_item( $item );
 			if ( is_wp_error( $_response ) ) {
 					$response[] = array(
@@ -83,7 +82,7 @@ class WC_Calypso_Bridge_Settings_Email_Groups_Controller extends WC_REST_Setting
 							'error'    => array( 'code' => $_response->get_error_code(), 'message' => $_response->get_error_message(), 'data' => $_response->get_error_data() ),
 					);
 			} else {
-					// Filter out unneaded fields
+					// Filter out unneeded fields
 					$option = array_intersect_key( $wp_rest_server->response_to_data( $_response, '' ), $wanted_keys );
 					$option['group_id'] = $item['group_id'];
 					$response[] = $option;

--- a/api/class-wc-calypso-bridge-settings-email-groups-controller.php
+++ b/api/class-wc-calypso-bridge-settings-email-groups-controller.php
@@ -68,16 +68,22 @@ class WC_Calypso_Bridge_Settings_Email_Groups_Controller extends WC_REST_Setting
 		$response = [];
 
 		foreach ( $items as $item ) {
-				$_response = $this->get_option( $item );
-				if ( is_wp_error( $_response ) ) {
-						$response[] = array(
-								'group_id' => $item['group_id'],
-								'id'       => $item['id'],
-								'error'    => array( 'code' => $_response->get_error_code(), 'message' => $_response->get_error_message(), 'data' => $_response->get_error_data() ),
-						);
-				} else {
-						$response[] = $wp_rest_server->response_to_data( $_response, '' );
-				}
+			$wanted_keys = array(
+				'group_id' => '',
+				'id'       => '',
+				'value'    => '',
+			);
+
+			$_response = $this->get_option( $item );
+			if ( is_wp_error( $_response ) ) {
+					$response[] = array(
+							'group_id' => $item['group_id'],
+							'id'       => $item['id'],
+							'error'    => array( 'code' => $_response->get_error_code(), 'message' => $_response->get_error_message(), 'data' => $_response->get_error_data() ),
+					);
+			} else {
+					$response[] = array_intersect_key( $wp_rest_server->response_to_data( $_response, '' ), $wanted_keys );
+			}
 		}
 
 		return $response;
@@ -90,14 +96,9 @@ class WC_Calypso_Bridge_Settings_Email_Groups_Controller extends WC_REST_Setting
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_option( $request ) {
-		$wanted_keys = array(
-			'group_id' => '',
-			'id'       => '',
-			'value'    => '',
-		);
-		
+
 		$options_controller = new WC_REST_Setting_Options_Controller;
-		$response = array_intersect_key( $options_controller->get_item( $request ), $wanted_keys );
+		$response =  $options_controller->get_item( $request );
 		return $response;
 	}
 

--- a/api/class-wc-calypso-bridge-settings-email-groups-controller.php
+++ b/api/class-wc-calypso-bridge-settings-email-groups-controller.php
@@ -81,7 +81,7 @@ class WC_Calypso_Bridge_Settings_Email_Groups_Controller extends WC_REST_Setting
 							'error'    => array( 'code' => $_response->get_error_code(), 'message' => $_response->get_error_message(), 'data' => $_response->get_error_data() ),
 					);
 			} else {
-					// Filter out unneded fields
+					// Filter out unneaded fields
 					$option = array_intersect_key( $wp_rest_server->response_to_data( $_response, '' ), $wanted_keys );
 					$option['group_id'] = $item['group_id'];
 					$response[] = $option;

--- a/api/class-wc-calypso-bridge-settings-email-groups-controller.php
+++ b/api/class-wc-calypso-bridge-settings-email-groups-controller.php
@@ -71,6 +71,7 @@ class WC_Calypso_Bridge_Settings_Email_Groups_Controller extends WC_REST_Setting
 		$wanted_keys = array(
 			'id'       => '',
 			'value'    => '',
+			'default'  => '',
 		);
 
 		foreach ( $items as $item ) {

--- a/tests/unit-tests/email-groups-controller.php
+++ b/tests/unit-tests/email-groups-controller.php
@@ -27,8 +27,6 @@ class Email_Groups_controller extends WC_REST_Unit_Test_Case {
 		$response      = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/settings_email_groups' ) );
 		$response_data = $response->get_data();
 
-		var_export( $response_data );
-
 		// Create settings array to test against.
 		$settings = array( 
 			0 => array( 

--- a/tests/unit-tests/email-groups-controller.php
+++ b/tests/unit-tests/email-groups-controller.php
@@ -2,8 +2,7 @@
 /**
  * Tests for Email Groups Endpoint accounts in the REST API.
  */
-
-class Email_Groups_controller extends WC_REST_Unit_Test_Case {
+class Email_Groups_Controller extends WC_REST_Unit_Test_Case {
 
 	/**
 	 * Setup our test server, endpoints, and user info.

--- a/tests/unit-tests/email-groups-controller.php
+++ b/tests/unit-tests/email-groups-controller.php
@@ -13,6 +13,9 @@ class Email_Groups_Controller extends WC_REST_Unit_Test_Case {
 		$this->user = $this->factory->user->create( array(
 			'role' => 'administrator',
 		) );
+		$this->subscriber = $this->factory->user->create( array(
+			'role' => 'subscriber',
+		) );
 	}
 
 	/**
@@ -97,6 +100,14 @@ class Email_Groups_Controller extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( $settings, $response_data );
+	}
+
+	public function test_get_email_group_settings_invalid_credentials() {
+		wp_set_current_user( $this->subscriber );
+
+		$response      = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/settings_email_groups' ) );
+		$response_data = $response->get_data();
+		$this->assertEquals( 403, $response->get_status() );
 	}
 
 }

--- a/tests/unit-tests/email-groups-controller.php
+++ b/tests/unit-tests/email-groups-controller.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Tests for Email Groups Endpoint accounts in the REST API.
+ */
+
+class Email_Groups_controller extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Setup our test server, endpoints, and user info.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->endpoint = new WC_Calypso_Bridge_Settings_Email_Groups_Controller();
+		$this->user = $this->factory->user->create( array(
+			'role' => 'administrator',
+		) );
+	}
+
+	/**
+	 * Fetch all settings and check that the format is valid.
+	 *
+	 * @since 3.0.0
+	 */
+	public function test_get_email_group_settings() {
+		wp_set_current_user( $this->user );
+
+		$response      = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/settings_email_groups' ) );
+		$response_data = $response->get_data();
+
+		var_export( $response_data );
+
+		// Create settings array to test against.
+		$settings = array( 
+			0 => array( 
+				'id' => 'woocommerce_email_from_name',
+				'value' => 'Test Blog',
+				'group_id' => 'email',
+			),
+			1 => array( 
+				'id' => 'woocommerce_email_from_address',
+				'value' => 'admin@example.org',
+				'group_id' => 'email',
+			),  
+			2 => array(
+				'id' => 'enabled',
+				'value' => 'yes',
+				'group_id' => 'email_new_order',
+			),
+			3 => array(
+				'id' => 'recipient',
+				'value' => '',
+				'group_id' => 'email_new_order',
+			),
+			4 => array(
+				'id' => 'enabled',
+				'value' => 'yes',
+				'group_id' => 'email_cancelled_order',
+			),
+			5 => array(
+				'id' => 'recipient',
+				'value' => '',
+				'group_id' => 'email_cancelled_order',
+			),
+			6 => array(
+				'id' => 'enabled',
+				'value' => 'yes',
+				'group_id' => 'email_failed_order',
+			),
+			7 => array(
+				'id' => 'recipient',
+				'value' => '',
+				'group_id' => 'email_failed_order',
+			),
+			8 => array(
+				'id' => 'enabled',
+				'value' => 'yes',
+				'group_id' => 'email_customer_on_hold_order',
+			),
+			9 => array(
+				'id' => 'enabled',
+				'value' => 'yes',
+				'group_id' => 'email_customer_processing_order',
+			),
+			10 => array(
+				'id' => 'enabled',
+				'value' => 'yes',
+				'group_id' => 'email_customer_completed_order',
+			),
+			11 => array(
+				'id' => 'enabled',
+				'value' => 'yes',
+				'group_id' => 'email_customer_refunded_order',
+			),
+			12 => array(
+				'id' => 'enabled',
+				'value' => 'yes',
+				'group_id' => 'email_customer_new_account',
+			),
+		);
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( $settings, $response_data );
+	}
+
+}

--- a/wc-calypso-bridge-class.php
+++ b/wc-calypso-bridge-class.php
@@ -95,6 +95,8 @@ class WC_Calypso_Bridge {
 				$controllers[] = 'WC_Calypso_Bridge_MailChimp_Settings_Controller';
 		}
 
+		$controllers[] = 'WC_Calypso_Bridge_Settings_Email_Groups_Controller';
+
 		foreach ( $controllers as $controller ) {
 			$controller_instance = new $controller();
 			$controller_instance->register_routes();

--- a/wc-calypso-bridge-class.php
+++ b/wc-calypso-bridge-class.php
@@ -61,6 +61,7 @@ class WC_Calypso_Bridge {
 	 * Includes.
 	 */
 	public function includes() {
+		/** Patches includes */
 		include_once( dirname( __FILE__ ) . '/inc/class-customizer-guided-tour.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-add-bacs-accounts.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-allowed-redirect-hosts.php' );
@@ -75,9 +76,11 @@ class WC_Calypso_Bridge {
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-masterbar-menu.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-paypal-defaults.php' );
 
+		/** API includes */
 		if ( class_exists( 'MailChimp_Woocommerce' ) ) {
 			include_once( dirname( __FILE__ ) . '/api/class-wc-calypso-bridge-mailchimp-settings-controller.php' );
 		}
+		include_once( dirname( __FILE__ ) . '/api/class-wc-calypso-bridge-settings-email-groups-controller.php' );
 	}
 
 	/**


### PR DESCRIPTION
### Information

This PR adds new settings endpoints `settings_email_groups` that allows fetching all the settings required to implement https://github.com/Automattic/wp-calypso/issues/15040

### Testing
To test copy this custom version of `wc-calypso-bridge` to your site. Comment the endpoint setting line with permissions callback and issue curl call. 
` curl https://YOURSITEURL/\?rest_route\=/wc/v3/settings_email_groups`

Better testing env will be available when Calypso PR for communicating with this endpoint will be created.