### PR TITLE
Add 'rating' to the Jetpack Sync comment meta whitelist

### DIFF
--- a/inc/wc-calypso-bridge-jetpack-sync.php
+++ b/inc/wc-calypso-bridge-jetpack-sync.php
@@ -31,6 +31,10 @@ function wc_calypso_bridge_add_comment_meta_whitelist( $list ) {
 		return false;
 	}
 
+	if ( ! is_array( $list ) ) {
+		return $list;
+	}
+
 	$additional_meta = array(
 		'rating',
 	);

--- a/inc/wc-calypso-bridge-jetpack-sync.php
+++ b/inc/wc-calypso-bridge-jetpack-sync.php
@@ -22,3 +22,19 @@ function wc_calypso_bridge_add_post_meta_whitelist( $list ) {
 }
 
 add_filter( 'jetpack_sync_post_meta_whitelist', 'wc_calypso_bridge_add_post_meta_whitelist', 10 );
+
+// There is no Jetpack sync filter for the comment meta whitelist like there is for postmeta
+// We can still hook into the return value of the option where the whitelist is stored.
+// @TODO We can update this when https://github.com/Automattic/jetpack/issues/8170 is resolved.
+function wc_calypso_bridge_add_comment_meta_whitelist( $list ) {
+	if ( false === $list ) {
+		return false;
+	}
+
+	$additional_meta = array(
+		'rating',
+	);
+	return array_merge( $list, $additional_meta );
+}
+
+add_filter( 'option_jetpack_sync_settings_comment_meta_whitelist', 'wc_calypso_bridge_add_comment_meta_whitelist', 10 );


### PR DESCRIPTION
This PR adds 'rating' to the list of allowed comment meta. This allows us to show a users rating in the product review notification.

To Test:
* On your WordPress.com sandbox, open `wp-content/mu-plugins/jetpack/sync/class.jetpack-sync-defaults.php`.
* Add `rating` to the `$comment_meta_whitelist` array.
* Download this branch and upload it as a plugin.
* Point your Jetpack installation to your WordPress.com sandbox. You can use [this gist](https://gist.github.com/justinshreve/48ad53e075884195a8f5f87f620ea368).
* Using a non admin account, leave a product review on a product.
* Using your WordPress.com Sandbox, use `wpsh`:
   * Switch to your site. `switch_to_blog( ID.. );`
   * Return the synced value for your comment: `echo get_comment_meta( COMMENT_ID, 'rating', true )`
   * Verify that a value is returned.