### PR TITLE
Add BACS accounts to API response

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # WooCommerce Calypso Bridge
 
 This repository houses various fixes and extensions for wp-admin to enhance the experience for users of the WordPress.com Store.
+
+## Test Suite
+
+This repository does have a test suite, which depends upon `wc-api-dev`, and `woocommerce` both being present witin the same `wp-content/plugins` directory. Much like the test suite in `wc-api-dev` it borrows heavily from the base `woocommerce` API test suite to enable quick testing via all of the core helper methods.
+
+Ideally all API functionality will eventually be contained within `wc-api-dev` ( and subsequently core ), but at least now we can have unit tests around various _quick fixes_ implemented here.
+
+### Running the Test Suite
+
+From a test install of WordPress with `wc-api-dev` and `woocommerce` present, run `phpunit` from the root of this plugin directory.

--- a/inc/wc-calypso-bridge-add-bacs-accounts.php
+++ b/inc/wc-calypso-bridge-add-bacs-accounts.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Adds BACS Accounts to /wc/v3/payment_gateways response when applicable
+ *
+ * @since 0.1.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+
+function wc_calypso_bridge_add_bacs_accounts( $response, $gateway, $request ) {
+	if ( is_wp_error( $response ) ) {
+		return $response;
+	}
+
+	if ( 'bacs' == $gateway->id ) {
+		$response->data[ 'settings' ][ 'accounts' ] = array(
+			'id'    => 'accounts',
+			'value' => get_option( 'woocommerce_bacs_accounts', array() ),
+		);
+	}
+	return $response;
+}
+
+add_filter( 'woocommerce_rest_prepare_payment_gateway', 'wc_calypso_bridge_add_bacs_accounts', 10, 3 );

--- a/inc/wc-calypso-bridge-add-bacs-accounts.php
+++ b/inc/wc-calypso-bridge-add-bacs-accounts.php
@@ -15,7 +15,7 @@ function wc_calypso_bridge_add_bacs_accounts( $response, $gateway, $request ) {
 		return $response;
 	}
 
-	if ( 'bacs' == $gateway->id ) {
+	if ( 'bacs' === $gateway->id ) {
 		$response->data[ 'settings' ][ 'accounts' ] = array(
 			'id'    => 'accounts',
 			'value' => get_option( 'woocommerce_bacs_accounts', array() ),

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	verbose="true"
+	syntaxCheck="true"
+	>
+	<testsuites>
+		<testsuite name="WooCommerce Calypso Bridge Test Suite">
+			<directory suffix=".php">./tests/unit-tests</directory>
+		</testsuite>
+	</testsuites>
+	<logging>
+		<log type="coverage-html" target="./tmp/coverage" charset="UTF-8" />
+	</logging>
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -74,7 +74,6 @@ class WC_Calypso_Bridge_Unit_Tests_Bootstrap {
 	 * Load WC API Dev.
 	 */
 	public function load_wc_api_dev() {
-		define( 'WC_API_DEV_ENABLE_HOTFIXES', false );
 		require_once( $this->wc_api_dev_dir . '/wc-api-dev-class.php' );
 	}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * WooCommerce Calypso Bridge Unit Tests Bootstrap
+ */
+class WC_Calypso_Bridge_Unit_Tests_Bootstrap {
+
+	/** @var WC_Calypso_Bridge_Unit_Tests_Bootstrap instance */
+	protected static $instance = null;
+
+	/** @var string directory where wordpress-tests-lib is installed */
+	public $wp_tests_dir;
+
+	/** @var string directory where WooCommerce tests are located */
+	public $wc_tests_dir;
+
+	/** @var string WooCommerce plugin directory */
+	public $wc_dir;
+
+	/** @var string testing directory */
+	public $tests_dir;
+
+	/** @var string plugin directory */
+	public $plugin_dir;
+
+	/**
+	 * Setup the unit testing environment.
+	 */
+	public function __construct() {
+		ini_set( 'display_errors','on' );
+		error_reporting( E_ALL );
+
+		// Ensure server variable is set for WP email functions.
+		if ( ! isset( $_SERVER['SERVER_NAME'] ) ) {
+			$_SERVER['SERVER_NAME'] = 'localhost';
+		}
+
+		$this->tests_dir    = dirname( __FILE__ );
+		$this->plugin_dir   = dirname( $this->tests_dir );
+		$this->wc_dir = dirname( $this->plugin_dir ) . '/woocommerce';
+		$this->wc_api_dev_dir = dirname( $this->plugin_dir ) . '/wc-api-dev';
+		$this->wc_tests_dir = dirname( $this->plugin_dir ) . '/woocommerce/tests';
+		$this->wp_tests_dir = getenv( 'WP_TESTS_DIR' ) ? getenv( 'WP_TESTS_DIR' ) : '/tmp/wordpress-tests-lib';
+
+		// load test function so tests_add_filter() is available
+		require_once( $this->wp_tests_dir . '/includes/functions.php' );
+
+		// load WC
+		tests_add_filter( 'muplugins_loaded', array( $this, 'load_wc' ) );
+
+		// load WC API Dev
+		tests_add_filter( 'muplugins_loaded', array( $this, 'load_wc_api_dev' ) );
+
+		// load WC Calypso Bridge
+		tests_add_filter( 'muplugins_loaded', array( $this, 'load_wc_calypso_bridge' ) );
+
+		// install WC
+		tests_add_filter( 'setup_theme', array( $this, 'install_wc' ) );
+
+		// load the WP testing environment
+		require_once( $this->wp_tests_dir . '/includes/bootstrap.php' );
+
+		// load WC testing framework
+		$this->includes();
+	}
+
+	/**
+	 * Load WooCommerce.
+	 */
+	public function load_wc() {
+		require_once( $this->wc_dir . '/woocommerce.php' );
+	}
+
+	/**
+	 * Load WC API Dev.
+	 */
+	public function load_wc_api_dev() {
+		define( 'WC_API_DEV_ENABLE_HOTFIXES', false );
+		require_once( $this->wc_api_dev_dir . '/wc-api-dev-class.php' );
+	}
+
+	/**
+	 * Load WC Calypso Bridge.
+	 */
+	public function load_wc_calypso_bridge() {
+		require_once( $this->plugin_dir . '/wc-calypso-bridge-class.php' );
+	}
+
+	/**
+	 * Install WooCommerce after the test environment and WC have been loaded.
+	 */
+	public function install_wc() {
+
+		// Clean existing install first.
+		define( 'WP_UNINSTALL_PLUGIN', true );
+		define( 'WC_REMOVE_ALL_DATA', true );
+		include( $this->wc_dir . '/uninstall.php' );
+
+		WC_Install::install();
+
+		// Reload capabilities after install, see https://core.trac.wordpress.org/ticket/28374
+		if ( version_compare( $GLOBALS['wp_version'], '4.7', '<' ) ) {
+			$GLOBALS['wp_roles']->reinit();
+		} else {
+			$GLOBALS['wp_roles'] = null;
+			wp_roles();
+		}
+
+		echo 'Installing WooCommerce...' . PHP_EOL;
+	}
+
+	/**
+	 * Load WC-specific test cases and factories.
+	 * If needed, these can also be shipped with the dev plugin and a local copy can be called.
+	 */
+	public function includes() {
+
+		// factories
+		require_once( $this->wc_tests_dir . '/framework/factories/class-wc-unit-test-factory-for-webhook.php' );
+		require_once( $this->wc_tests_dir . '/framework/factories/class-wc-unit-test-factory-for-webhook-delivery.php' );
+
+		// framework
+		require_once( $this->wc_tests_dir . '/framework/class-wc-unit-test-factory.php' );
+		require_once( $this->wc_tests_dir  . '/framework/class-wc-mock-session-handler.php' );
+		require_once( $this->wc_tests_dir  . '/framework/class-wc-mock-wc-data.php' );
+		require_once( $this->wc_tests_dir  . '/framework/class-wc-mock-wc-object-query.php' );
+		require_once( $this->wc_tests_dir  . '/framework/class-wc-payment-token-stub.php' );
+		require_once( $this->wc_tests_dir  . '/framework/vendor/class-wp-test-spy-rest-server.php' );
+
+		// test cases
+		require_once( $this->wc_tests_dir  . '/framework/class-wc-unit-test-case.php' );
+		require_once( $this->wc_tests_dir  . '/framework/class-wc-api-unit-test-case.php' );
+		require_once( $this->wc_tests_dir  . '/framework/class-wc-rest-unit-test-case.php' );
+
+		// Helpers
+		require_once( $this->wc_tests_dir  . '/framework/helpers/class-wc-helper-product.php' );
+		require_once( $this->wc_tests_dir  . '/framework/helpers/class-wc-helper-coupon.php' );
+		require_once( $this->wc_tests_dir  . '/framework/helpers/class-wc-helper-fee.php' );
+		require_once( $this->wc_tests_dir  . '/framework/helpers/class-wc-helper-shipping.php' );
+		require_once( $this->wc_tests_dir  . '/framework/helpers/class-wc-helper-customer.php' );
+		require_once( $this->wc_tests_dir  . '/framework/helpers/class-wc-helper-order.php' );
+		require_once( $this->wc_tests_dir  . '/framework/helpers/class-wc-helper-shipping-zones.php' );
+		require_once( $this->wc_tests_dir  . '/framework/helpers/class-wc-helper-payment-token.php' );
+		require_once( $this->wc_tests_dir  . '/framework/helpers/class-wc-helper-settings.php' );
+	}
+
+	/**
+	 * Gets the single class instance.
+	 */
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+}
+
+WC_Calypso_Bridge_Unit_Tests_Bootstrap::instance();

--- a/tests/unit-tests/bacs-accounts.php
+++ b/tests/unit-tests/bacs-accounts.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Tests for BACS accounts in the REST API.
+ */
+
+class BACS_Accounts extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Setup our test server, endpoints, and user info.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->endpoint = new WC_REST_DEV_Payment_Gateways_Controller();
+		$this->user = $this->factory->user->create( array(
+			'role' => 'administrator',
+		) );
+	}
+
+	/**
+	 * Test getting a single BACS item has account data
+	 * which defaults to an empty array.
+	 *
+	 * @since 3.0.0
+	 */
+	public function test_get_bacs_payment_gateway() {
+		wp_set_current_user( $this->user );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/payment_gateways/bacs' ) );
+		$bacs   = $response->get_data();
+
+		// Create settings array to test against.
+		$settings = array_diff_key(
+			$this->get_settings( 'WC_Gateway_BACS' ),
+			array( 'enabled' => false, 'description' => false )
+		);
+		$settings[ 'accounts' ] = array(
+			'id'    => 'accounts',
+			'value' => array(),
+		);
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( array(
+			'id'                 => 'bacs',
+			'title'              => 'Direct bank transfer',
+			'description'        => "Make your payment directly into our bank account. Please use your Order ID as the payment reference. Your order will not be shipped until the funds have cleared in our account.",
+			'order'              => '',
+			'enabled'            => false,
+			'method_title'       => 'BACS',
+			'method_description' => 'Allows payments by BACS, more commonly known as direct bank/wire transfer.',
+			'method_supports'    => array( 'products' ),
+			'settings'           => $settings,
+		), $bacs );
+	}
+
+	/**
+	 * Test that non-BACS payment gateways do not get an
+	 * accounts key added to settings.
+	 */
+	public function test_get_non_bacs_payment_gateway() {
+		wp_set_current_user( $this->user );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/payment_gateways/paypal' ) );
+		$paypal   = $response->get_data();
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertFalse( array_key_exists( 'accounts', $paypal[ 'settings' ] ) );
+	}
+
+	/**
+	 * Test that getting all payment gateways also includes
+	 * account data on BACS
+	 */
+	public function test_get_all_payment_gateways_includes_bacs_accounts() {
+		wp_set_current_user( $this->user );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/payment_gateways' ) );
+		$gateways   = $response->get_data();
+		$this->assertEquals( 200, $response->get_status() );
+		$filtered_gateways = wp_filter_object_list( $gateways, array( 'id' => 'bacs' ) );
+		$bacs = array_pop( $filtered_gateways );
+		$this->assertTrue( array_key_exists( 'accounts', $bacs[ 'settings' ] ) );
+		$this->assertEquals( $bacs[ 'settings' ][ 'accounts' ], array(
+			'id'    => 'accounts',
+			'value' => array(),
+		) );
+	}
+
+	/**
+	 * Test actual account data is returned if set.
+	 */
+	public function test_get_all_payment_gateways_includes_actual_bacs_accounts() {
+		wp_set_current_user( $this->user );
+		$account_data = array(
+			array(
+				'account_name'   => 'chicken and ribs',
+				'account_number' => '123yummy',
+				'bank_name'      => 'tasty bbq',
+				'sort_code'      => 'half rack',
+				'iban'           => 'brisket',
+				'bic'            => 'yes',
+			)
+		);
+		update_option( 'woocommerce_bacs_accounts', $account_data );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/payment_gateways' ) );
+		$gateways   = $response->get_data();
+		$this->assertEquals( 200, $response->get_status() );
+		$filtered_gateways = wp_filter_object_list( $gateways, array( 'id' => 'bacs' ) );
+		$bacs = array_pop( $filtered_gateways );
+		$this->assertTrue( array_key_exists( 'accounts', $bacs[ 'settings' ] ) );
+		$this->assertEquals( $bacs[ 'settings' ][ 'accounts' ], array(
+			'id'    => 'accounts',
+			'value' => $account_data,
+		) );
+	}
+
+	/**
+	 * Loads a particular gateway's settings so we can correctly test API output.
+	 *
+	 * @param string $gateway_class Name of WC_Payment_Gateway class.
+	 */
+	private function get_settings( $gateway_class ) {
+		$gateway = new $gateway_class;
+		$settings = array();
+		$gateway->init_form_fields();
+		foreach ( $gateway->form_fields as $id => $field ) {
+			// Make sure we at least have a title and type
+			if ( empty( $field['title'] ) || empty( $field['type'] ) ) {
+				continue;
+			}
+			// Ignore 'title' settings/fields -- they are UI only
+			if ( 'title' === $field['type'] ) {
+				continue;
+			}
+			$data = array(
+				'id'          => $id,
+				'label'       => empty( $field['label'] ) ? $field['title'] : $field['label'],
+				'description' => empty( $field['description'] ) ? '' : $field['description'],
+				'type'        => $field['type'],
+				'value'       => $gateway->settings[ $id ],
+				'default'     => empty( $field['default'] ) ? '' : $field['default'],
+				'tip'         => empty( $field['description'] ) ? '' : $field['description'],
+				'placeholder' => empty( $field['placeholder'] ) ? '' : $field['placeholder'],
+			);
+			if ( ! empty( $field['options'] ) ) {
+				$data['options'] = $field['options'];
+			}
+			$settings[ $id ] = $data;
+		}
+		return $settings;
+	}
+}

--- a/wc-calypso-bridge-class.php
+++ b/wc-calypso-bridge-class.php
@@ -62,6 +62,7 @@ class WC_Calypso_Bridge {
 	 */
 	public function includes() {
 		include_once( dirname( __FILE__ ) . '/inc/class-customizer-guided-tour.php' );
+		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-add-bacs-accounts.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-allowed-redirect-hosts.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-cheque-defaults.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-email-order-url.php' );


### PR DESCRIPTION
This PR is for https://github.com/Automattic/wp-calypso/issues/16630 and adds BACS account data to the current `/wc/v3/payment_gateways/*` API responses. This will allow us to expose this data within Store on WPCOM. 

In this PR I have also added a test suite akin to what we have in `wc-api-dev` for adding unit test coverage for the various API bits and pieces added to this project.

__To Test__
- The easiest way to test this PR is to use Postman, and install this branch as a plugin on a test site.
- You can either call the endpoints directly on your test site via `http://testsitedomain.com/wp-json/wc/v3/payment_gateways/` and `http://testsitedomain.com/wp-json/wc/v3/payment_gateways/bacs` or by passing them through the wpcom REST API like `https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/137330147/rest-api/?http_envelope=1&path=%2Fwc%2Fv3%2Fpayment_gateways%26_method%3Dget%26json%3Dtrue%26context%3Dedit` but be sure to replace the site ID with that of your Jetpack connected blog ID.
- Regardless of method chosen, you will need to perform the API requests via an authenticated means ( i.e. a bearer token for WPCOM ).
- Verify that a new `accounts` key is present in the `settings` for the BACS payment type on both all payments response, and the singular response for only `bacs`:

<img width="667" alt="postman" src="https://user-images.githubusercontent.com/22080/32869594-b20f5d92-ca2c-11e7-92ef-18a2edaf65a0.png">

If you do not have any BACS accounts configured the `value` should be set to an empty array. After you verify the empty array is returned by default, visit https://yourtestdomain,.com/wp-admin/admin.php?page=wc-settings&tab=checkout&section=bacs, add some Account details, and verify they are returned as expected in the API requests too.
