### PR TITLE
BACS Account Updates

### DIFF
--- a/inc/wc-calypso-bridge-add-bacs-accounts.php
+++ b/inc/wc-calypso-bridge-add-bacs-accounts.php
@@ -25,3 +25,81 @@ function wc_calypso_bridge_add_bacs_accounts( $response, $gateway, $request ) {
 }
 
 add_filter( 'woocommerce_rest_prepare_payment_gateway', 'wc_calypso_bridge_add_bacs_accounts', 10, 3 );
+
+function wc_calypso_bridge_validate_bacs_accounts( $accounts ) {
+	$valid_keys = array(
+		'account_name',
+		'account_number',
+		'bank_name',
+		'bic',
+		'iban',
+		'sort_code',
+	);
+
+	foreach ( $accounts as $account ) {
+		if ( ! is_array( $account ) ) {
+			return false;
+		}
+
+		$account_keys = array_keys( $account );
+		sort( $account_keys );
+		if ( $account_keys !== $valid_keys ) {
+			return false;
+		}
+	}
+	return true;
+}
+
+function wc_calypso_bridge_format_bacs_accounts( $accounts ) {
+	$formatted_accounts = array();
+
+	foreach ( $accounts as $account ) {
+		$formatted_accounts[] = array(
+			'account_name'    => (string) $account[ 'account_name' ],
+			'account_number'  => (string) $account[ 'account_number' ],
+			'bank_name'       => (string) $account[ 'bank_name' ],
+			'bic'             => (string) $account[ 'bic' ],
+			'iban'            => (string) $account[ 'iban' ],
+			'sort_code'       => (string) $account[ 'sort_code' ],
+		);
+	}
+	return $formatted_accounts;
+}
+
+function wc_calypso_bridge_update_bacs_accounts( $response, $handler, $request ) {
+	if ( is_wp_error( $response ) ) {
+		return $response;
+	}
+
+	if (
+		isset( $handler[ 'callback' ] ) &&
+		is_callable( $handler[ 'callback' ], false, $callable_name )
+	) {
+		switch ( $callable_name ) {
+			case 'WC_REST_Dev_Payment_Gateways_Controller::update_item':
+				$controller = new WC_REST_Payment_Gateways_Controller;
+				$gateway = $controller->get_gateway( $request );
+
+				if (
+					$gateway &&
+					'bacs' === $gateway->id &&
+					isset( $request[ 'settings' ] ) &&
+					isset( $request[ 'settings' ][ 'accounts' ] )
+				) {
+					$new_accounts = (array) $request[ 'settings' ][ 'accounts' ];
+
+					if ( ! wc_calypso_bridge_validate_bacs_accounts( $new_accounts ) ) {
+						return new WP_Error( 'rest_setting_value_invalid', __( 'An invalid setting value was passed.', 'woocommerce' ), array( 'status' => 400 ) );
+					}
+
+					$formatted_accounts = wc_calypso_bridge_format_bacs_accounts( $new_accounts );
+					update_option( 'woocommerce_bacs_accounts', $formatted_accounts );
+				}
+				break;
+		}
+	}
+
+	return $response;
+}
+
+add_filter( 'rest_request_before_callbacks', 'wc_calypso_bridge_update_bacs_accounts', 10, 3 );

--- a/tests/unit-tests/bacs-accounts.php
+++ b/tests/unit-tests/bacs-accounts.php
@@ -148,4 +148,114 @@ class BACS_Accounts extends WC_REST_Unit_Test_Case {
 		}
 		return $settings;
 	}
+
+	/**
+	 * Test updating bacs gateway with no account data supplied.
+	 */
+	public function test_update_bacs_payment_gateway_with_no_account_data() {
+		wp_set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/payment_gateways/bacs' );
+		$request->set_body_params( array(
+			'settings' => array(
+				'title' => 'Pay with bank transfer!',
+			),
+		) );
+		$response = $this->server->dispatch( $request );
+		$bacs = $response->get_data();
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'Pay with bank transfer!', $bacs['settings']['title']['value'] );
+		$this->assertEquals( array(), $bacs['settings']['accounts']['value'] );
+	}
+
+	/**
+	 * Test updating bacs gateway with account data supplied.
+	 */
+	public function test_update_bacs_payment_gateway_with_account_data() {
+		wp_set_current_user( $this->user );
+
+		$new_accounts = array(
+			array(
+				'account_name'   => 'scrooge mcduck',
+				'account_number' => 'bling',
+				'bank_name'      => 'disney bank',
+				'sort_code'      => '111',
+				'iban'           => '222',
+				'bic'            => 'wat',
+			),
+			array(
+				'sort_code'      => '111',
+				'iban'           => '222',
+				'bic'            => 'wat',
+				'account_name'   => 'something else',
+				'account_number' => '123134844584548',
+				'bank_name'      => 'blaaaaahhhh',
+			)
+		);
+
+		$accounts_request = new WP_REST_Request( 'POST', '/wc/v3/payment_gateways/bacs' );
+		$accounts_request->set_body_params( array(
+			'settings' => array(
+				'accounts' => $new_accounts,
+			),
+		) );
+		$accounts_response = $this->server->dispatch( $accounts_request );
+		$bacs_accounts = $accounts_response->get_data();
+		$this->assertEquals( 200, $accounts_response->get_status() );
+		$this->assertEquals( $new_accounts, $bacs_accounts['settings']['accounts']['value'] );
+	}
+
+	/**
+	 * Test updating bacs gateway with account data supplied.
+	 */
+	public function test_update_bacs_payment_gateway_with_account_data_and_title() {
+		wp_set_current_user( $this->user );
+
+		$new_accounts = array(
+			array(
+				'account_name'   => 'scrooge mcduck',
+				'account_number' => 'bling',
+				'bank_name'      => 'disney bank',
+				'sort_code'      => '111',
+				'iban'           => '222',
+				'bic'            => 'wat',
+			)
+		);
+
+		$accounts_request = new WP_REST_Request( 'POST', '/wc/v3/payment_gateways/bacs' );
+		$accounts_request->set_body_params( array(
+			'settings' => array(
+				'accounts' => $new_accounts,
+				'title'    => 'Give me money',
+			),
+		) );
+		$accounts_response = $this->server->dispatch( $accounts_request );
+		$bacs_accounts = $accounts_response->get_data();
+		$this->assertEquals( 200, $accounts_response->get_status() );
+		$this->assertEquals( $new_accounts, $bacs_accounts['settings']['accounts']['value'] );
+		$this->assertEquals( 'Give me money', $bacs_accounts['settings']['title']['value'] );
+	}
+
+	/**
+	 * Test updating bacs gateway with account invalid data supplied.
+	 */
+	public function test_update_bacs_payment_gateway_with_malformed_account_data() {
+		wp_set_current_user( $this->user );
+
+		$new_accounts = array(
+			array(
+				'bad' => 'data',
+				'omg' => 'jibberish',
+			)
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/payment_gateways/bacs' );
+		$request->set_body_params( array(
+			'settings' => array(
+				'accounts' => $new_accounts,
+			),
+		) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+	}
 }

--- a/tests/unit-tests/bacs-accounts.php
+++ b/tests/unit-tests/bacs-accounts.php
@@ -206,7 +206,7 @@ class BACS_Accounts extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Test updating bacs gateway with account data supplied.
+	 * Test updating bacs gateway with account, and non-account data supplied.
 	 */
 	public function test_update_bacs_payment_gateway_with_account_data_and_title() {
 		wp_set_current_user( $this->user );


### PR DESCRIPTION
This branch adds the ability to update BACS account data via the current `WC_REST_Dev_Payment_Gateways_Controller::update_item` API logic. This will allow for updating BACS account data via calypso store settings page.

__To Test__
You can test out most scenarios of this endpoint update via Postman, via `POST`ing to the following endpoint:

`https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/$siteID/rest-api`

With a body of:

```
{
    "path": "/wc/v3/payment_gateways/bacs&_method=put",
    {"settings":{"accounts":[{ ... }]}}
}
```

I hit some issues when trying to test via the proxy'ed Jetpack request via the wpcom API - specifically around passing an empty accounts array ( ` {"settings":{"accounts":[]}}` ). `http_build_query` strips out the empty array, and results in `Jetpack_Error( 'invalid_body_hash', 'The body hash exists and does not match.' )` being thrown by the wpcom API. As such, I have added in some test cases around that in this PR to show that the request would work if called directly.

For the time-being, to "delete" account data via Calypso, we will have to pass in empty strings for the BACS account object.

- With this branch installed as a plugin, you should be able to test that POST'ing account data is persisted as expected.
- Note that you must pass a proper object with all fields in order for the update to work, otherwise a validation error should be thrown. A proper account object looks like:

```
{
    "account_name": "yo",
    "account_number": "yoo",
    "bank_name": "yo yo",
    "bic": "lighter",
    "iban": "niba",
    "sort_code": "1337"
}
```

An example body payload to use in Postman would be

```
{"settings":{"accounts":[{"sort_code": "1337", "iban": "neat", "bic": "wow", "account_name":"yo","account_number":"yoo","bank_name":"yo yo"}]}}
```
