### PR TITLE
Remove (BETA)

### DIFF
--- a/inc/wc-calypso-bridge-masterbar-menu.php
+++ b/inc/wc-calypso-bridge-masterbar-menu.php
@@ -31,7 +31,7 @@ if ( ! function_exists( 'wc_api_dev_masterbar_css' ) ) {
 			$wp_admin_bar->add_menu( array(
 				'parent' => 'blog',
 				'id'     => 'store',
-				'title'  => esc_html__( 'Store (BETA)', 'wc_calypso_bridge' ),
+				'title'  => esc_html__( 'Store', 'wc_calypso_bridge' ),
 				'href'   => $store_url,
 				'meta'   => array(
 					'class' => 'mb-icon-spacer',


### PR DESCRIPTION
The (Beta) was removed a while back in Calypso, but the change never filtered back here to `wc-calypso-bridge`

__To Test__
Just a simple change removing Beta from the nav menu string. It can be tested by uploading this branch to a test site, and opening the masterbar navigation when viewing wp-admin on an AT Store site.