### PR TITLE
Add Endpoint to return currency data.

### DIFF
--- a/api/class-wc-calypso-bridge-currencies-controller.php
+++ b/api/class-wc-calypso-bridge-currencies-controller.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * REST API WC Calypso Bridge Currencies
+ *
+ * Adds an endpoint for returning WooCommerce Currency Data
+ *
+ * @author   Automattic
+ * @category API
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * @package WooCommerce/API
+ */
+class WC_Calypso_Bridge_Currencies_Controller extends WC_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'currencies';
+
+	/**
+	 * Register Currency route
+	 */
+	public function register_routes() {
+		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_currencies' ),
+				'permission_callback' => array( $this, 'permissions_check' ),
+			)
+		) );
+	}
+
+	/**
+	 * Makes sure the current user has permissions.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_edit', __( 'Sorry, you cannot view this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get WooCommerce Currencies.
+	 *
+	 * @param WP_REST_Request
+	 * @return WP_REST_Response
+	 *
+	 */
+	public function get_currencies( $request ) {
+        $currencies = array();
+        foreach ( get_woocommerce_currencies() as $code => $name ) {
+            $currencies[] = array(
+                'code'   => $code,
+                'name'   => $name,
+                'symbol' => html_entity_decode( get_woocommerce_currency_symbol( $code ) ),
+            );
+        }
+        
+		return rest_ensure_response( $currencies );
+	}
+
+}

--- a/api/class-wc-calypso-bridge-currencies-controller.php
+++ b/api/class-wc-calypso-bridge-currencies-controller.php
@@ -66,15 +66,15 @@ class WC_Calypso_Bridge_Currencies_Controller extends WC_REST_Controller {
 	 *
 	 */
 	public function get_currencies( $request ) {
-        $currencies = array();
-        foreach ( get_woocommerce_currencies() as $code => $name ) {
-            $currencies[] = array(
-                'code'   => $code,
-                'name'   => $name,
-                'symbol' => html_entity_decode( get_woocommerce_currency_symbol( $code ) ),
-            );
-        }
-        
+		$currencies = array();
+		foreach ( get_woocommerce_currencies() as $code => $name ) {
+			$currencies[] = array(
+				'code'   => $code,
+				'name'   => $name,
+				'symbol' => html_entity_decode( get_woocommerce_currency_symbol( $code ) ),
+			);
+		}
+
 		return rest_ensure_response( $currencies );
 	}
 

--- a/tests/unit-tests/currencies-controller.php
+++ b/tests/unit-tests/currencies-controller.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Tests for Currencies Controller in the REST API.
+ */
+
+class Currencies_Controller extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Setup our test server, endpoints, and user info.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->endpoint = new WC_Calypso_Bridge_Currencies_Controller();
+		$this->user = $this->factory->user->create( array(
+			'role' => 'administrator',
+		) );
+	}
+
+	/**
+	 * Test getting currencies when authed
+	 * which defaults to an empty array.
+	 *
+	 * @since 3.0.0
+	 */
+	public function test_get_currencies() {
+		wp_set_current_user( $this->user );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/currencies' ) );
+        $data = $response->get_data();
+        
+        $currencies = array();
+        foreach ( get_woocommerce_currencies() as $code => $name ) {
+            $currencies[] = array(
+                'code'   => $code,
+                'name'   => $name,
+                'symbol' => html_entity_decode( get_woocommerce_currency_symbol( $code ) ),
+            );
+        }
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( $currencies, $data );
+	}
+
+	/**
+	 * Test non authed requests fail
+	 */
+	public function test_unauthed_get_currencies() {
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/currencies' ) );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+}

--- a/tests/unit-tests/currencies-controller.php
+++ b/tests/unit-tests/currencies-controller.php
@@ -17,8 +17,7 @@ class Currencies_Controller extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Test getting currencies when authed
-	 * which defaults to an empty array.
+	 * Test getting currencies when authed.
 	 *
 	 * @since 3.0.0
 	 */
@@ -26,7 +25,7 @@ class Currencies_Controller extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/currencies' ) );
-        $data = $response->get_data();
+		$data = $response->get_data();
         
         $currencies = array();
         foreach ( get_woocommerce_currencies() as $code => $name ) {

--- a/tests/unit-tests/currencies-controller.php
+++ b/tests/unit-tests/currencies-controller.php
@@ -27,14 +27,14 @@ class Currencies_Controller extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/currencies' ) );
 		$data = $response->get_data();
         
-        $currencies = array();
-        foreach ( get_woocommerce_currencies() as $code => $name ) {
-            $currencies[] = array(
-                'code'   => $code,
-                'name'   => $name,
-                'symbol' => html_entity_decode( get_woocommerce_currency_symbol( $code ) ),
-            );
-        }
+		$currencies = array();
+		foreach ( get_woocommerce_currencies() as $code => $name ) {
+			$currencies[] = array(
+				'code'   => $code,
+				'name'   => $name,
+				'symbol' => html_entity_decode( get_woocommerce_currency_symbol( $code ) ),
+			);
+		}
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( $currencies, $data );

--- a/wc-calypso-bridge-class.php
+++ b/wc-calypso-bridge-class.php
@@ -77,10 +77,12 @@ class WC_Calypso_Bridge {
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-paypal-defaults.php' );
 
 		/** API includes */
+		include_once( dirname( __FILE__ ) . '/api/class-wc-calypso-bridge-currencies-controller.php' );
+		include_once( dirname( __FILE__ ) . '/api/class-wc-calypso-bridge-settings-email-groups-controller.php' );
+		
 		if ( class_exists( 'MailChimp_Woocommerce' ) ) {
 			include_once( dirname( __FILE__ ) . '/api/class-wc-calypso-bridge-mailchimp-settings-controller.php' );
 		}
-		include_once( dirname( __FILE__ ) . '/api/class-wc-calypso-bridge-settings-email-groups-controller.php' );
 	}
 
 	/**
@@ -89,13 +91,14 @@ class WC_Calypso_Bridge {
 	 * New endpoints/controllers can be added here.
 	 */
 	public function register_routes() {
-		$controllers = array();
+		$controllers = array(
+			'WC_Calypso_Bridge_Currencies_Controller',
+			'WC_Calypso_Bridge_Settings_Email_Groups_Controller',
+		);
 
 		if ( class_exists( 'MailChimp_Woocommerce' ) ) {
 				$controllers[] = 'WC_Calypso_Bridge_MailChimp_Settings_Controller';
 		}
-
-		$controllers[] = 'WC_Calypso_Bridge_Settings_Email_Groups_Controller';
 
 		foreach ( $controllers as $controller ) {
 			$controller_instance = new $controller();


### PR DESCRIPTION
This branch is for https://github.com/Automattic/wp-calypso/issues/20675 - which calls for adding in a currency selector to the address page in the setup wizard. While there is some [currency data](https://github.com/Automattic/wp-calypso/blob/master/client/lib/format-currency/currencies.js) available in Calypso, it is lacking the descriptive name that is shown in the Woo Setup wizard.

__To Test__
Install this branch as a plugin on a test site and using something like Postman App, visit `/wc/v3/currencies` with a valid auth token. Verify currency data is returned. Perform the same request without an auth token and verify no data is returned.