### PR TITLE
Add ability to send an invoice email via API.

### DIFF
--- a/api/class-wc-calypso-bridge-send-invoice-controller.php
+++ b/api/class-wc-calypso-bridge-send-invoice-controller.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * REST API WC Calypso Bridge Send Invoice
+ *
+ * Adds an endpoint to trigger sending an order invoice email
+ *
+ * @author   Automattic
+ * @category API
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * @package WooCommerce/API
+ */
+class WC_Calypso_Bridge_Send_Invoice_Controller extends WC_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'orders/send_invoice';
+
+	/**
+	 * Post type.
+	 *
+	 * @var string
+	 */
+	protected $post_type = 'shop_order';
+
+	/**
+	 * Register Currency route
+	 */
+	public function register_routes() {
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<id>[\d]+)' , array(
+			'args' => array(
+				'id' => array(
+					'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
+					'type'        => 'integer',
+				)
+			),
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'send_invoice' ),
+				'permission_callback' => array( $this, 'permissions_check' ),
+			)
+		) );
+	}
+
+	/**
+	 * Makes sure the current user has permissions.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function permissions_check( $request ) {
+		$order = wc_get_order( (int) $request['id'] );
+		if ( $order && ! wc_rest_check_post_permissions( $this->post_type, 'read', $order->get_id() ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+    
+	/**
+	 * Prepare a single order note output for response.
+	 *
+	 * @param WP_Comment $note Order note object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response $response Response data.
+	 */
+	public function prepare_item_for_response( $note, $request ) {
+		$data = array(
+			'id'               => (int) $note->comment_ID,
+			'author'           => __( 'WooCommerce', 'woocommerce' ) === $note->comment_author ? 'system' : $note->comment_author,
+			'date_created'     => wc_rest_prepare_date_response( $note->comment_date ),
+			'date_created_gmt' => wc_rest_prepare_date_response( $note->comment_date_gmt ),
+			'note'             => $note->comment_content,
+			'customer_note'    => (bool) get_comment_meta( $note->comment_ID, 'is_customer_note', true ),
+		);
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		// Wrap the data in a response object.
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Send order invoice email.
+	 *
+	 * @param WP_REST_Request
+	 * @return WP_REST_Response
+	 *
+	 */
+	public function send_invoice( $request ) {
+		$order = wc_get_order( (int) $request['id'] );
+		if ( ! $order || $this->post_type !== $order->get_type() ) {
+			return new WP_Error( 'woocommerce_rest_order_invalid_id', __( 'Invalid order ID.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
+
+		do_action( 'woocommerce_before_resend_order_emails', $order, 'customer_invoice' );
+		// Send the customer invoice email.
+		WC()->payment_gateways();
+		WC()->shipping();
+		WC()->mailer()->customer_invoice( $order );
+		// Note the event.
+		$note_id = $order->add_order_note( __( 'Order details manually sent to customer.', 'woocommerce' ), false, true );
+		if ( ! $note_id ) {
+			return new WP_Error( 'woocommerce_api_cannot_create_order_note', __( 'Cannot create order note, please try again.', 'woocommerce' ), array( 'status' => 500 ) );
+		}
+		$note = get_comment( $note_id );
+
+		do_action( 'woocommerce_after_resend_order_email', $order, 'customer_invoice' );
+		$response = $this->prepare_item_for_response( $note, $request );
+		$response = rest_ensure_response( $response );
+		return $response;
+	}
+
+}

--- a/api/class-wc-calypso-bridge-send-invoice-controller.php
+++ b/api/class-wc-calypso-bridge-send-invoice-controller.php
@@ -29,7 +29,7 @@ class WC_Calypso_Bridge_Send_Invoice_Controller extends WC_REST_Controller {
 	 *
 	 * @var string
 	 */
-	protected $rest_base = 'orders/send_invoice';
+	protected $rest_base = 'orders';
 
 	/**
 	 * Post type.
@@ -42,7 +42,8 @@ class WC_Calypso_Bridge_Send_Invoice_Controller extends WC_REST_Controller {
 	 * Register Currency route
 	 */
 	public function register_routes() {
-		register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<id>[\d]+)' , array(
+		# POST wc/v3/orders/<id>/send_invoice
+		register_rest_route( $this->namespace, $this->rest_base . '/(?P<id>[\d]+)/send_invoice' , array(
 			'args' => array(
 				'id' => array(
 					'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),

--- a/api/class-wc-calypso-bridge-send-invoice-controller.php
+++ b/api/class-wc-calypso-bridge-send-invoice-controller.php
@@ -50,7 +50,7 @@ class WC_Calypso_Bridge_Send_Invoice_Controller extends WC_REST_Controller {
 				)
 			),
 			array(
-				'methods'             => WP_REST_Server::READABLE,
+				'methods'             => WP_REST_SERVER::EDITABLE,
 				'callback'            => array( $this, 'send_invoice' ),
 				'permission_callback' => array( $this, 'permissions_check' ),
 			)

--- a/tests/unit-tests/send-invoice-controller.php
+++ b/tests/unit-tests/send-invoice-controller.php
@@ -48,7 +48,7 @@ class Send_Invoice_Controller extends WC_REST_Unit_Test_Case {
     public function test_sending_invoice() {
         wp_set_current_user( $this->user );
 
-        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/orders/send_invoice/' . $this->order_id ) );
+        $response = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/v3/orders/send_invoice/' . $this->order_id ) );
         $note = $response->get_data();
         $this->note_ids[] = $note['id'];
 
@@ -64,7 +64,7 @@ class Send_Invoice_Controller extends WC_REST_Unit_Test_Case {
     public function test_invalid_order_id() {
         wp_set_current_user( $this->user );
 
-        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/orders/send_invoice/1111111' ) );
+        $response = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/v3/orders/send_invoice/1111111' ) );
         $this->assertEquals( 404, $response->get_status() );
         $this->stoppit_and_tidyup();
     }
@@ -73,7 +73,7 @@ class Send_Invoice_Controller extends WC_REST_Unit_Test_Case {
      * Test unauthed requests can not send invoices
      */
     public function test_unauthed_request_fails() {
-        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/orders/send_invoice/'  . $this->order_id ) );
+        $response = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/v3/orders/send_invoice/'  . $this->order_id ) );
         $this->assertEquals( 401, $response->get_status() );
         $this->stoppit_and_tidyup();
     }

--- a/tests/unit-tests/send-invoice-controller.php
+++ b/tests/unit-tests/send-invoice-controller.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Tests for Sending Order Invoices via the REST API.
+ */
+
+class Send_Invoice_Controller extends WC_REST_Unit_Test_Case {
+    /**
+     * Array of note IDs to track.
+     * @var array
+     */
+    protected $note_ids = array();
+
+    /**
+     * An order to hold these notes.
+     * @var int
+     */
+    protected $order_id;
+
+    /**
+     * Setup our test server, endpoints, and user info.
+     */
+    public function setUp() {
+        parent::setUp();
+        $this->endpoint = new WC_Calypso_Bridge_Send_Invoice_Controller();
+        $this->user = $this->factory->user->create( array(
+            'role' => 'administrator',
+        ) );
+
+        $order = WC_Helper_Order::create_order();
+        $this->order_id = $order->get_id();
+    }
+
+    /**
+     * Cleanup.
+     */
+    public function stoppit_and_tidyup() {
+        wp_delete_post( $this->order_id, true );
+        foreach ( $this->note_ids as $note ) {
+            wc_delete_order_note( $note );
+        }
+        $this->note_ids = array();
+    }
+
+    /**
+     * Test sending an invoice on a valid order
+     *
+     */
+    public function test_sending_invoice() {
+        wp_set_current_user( $this->user );
+
+        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/orders/send_invoice/' . $this->order_id ) );
+        $note = $response->get_data();
+        $this->note_ids[] = $note['id'];
+
+        $this->assertEquals( 200, $response->get_status() );
+        $this->assertEquals( $note['note'], 'Order details manually sent to customer.' );
+        $this->assertEquals( $note['customer_note'], false );
+        $this->stoppit_and_tidyup();
+    }
+
+    /**
+     * Test an invalid order ID results in a 404
+     */
+    public function test_invalid_order_id() {
+        wp_set_current_user( $this->user );
+
+        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/orders/send_invoice/1111111' ) );
+        $this->assertEquals( 404, $response->get_status() );
+        $this->stoppit_and_tidyup();
+    }
+
+    /**
+     * Test unauthed requests can not send invoices
+     */
+    public function test_unauthed_request_fails() {
+        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/orders/send_invoice/'  . $this->order_id ) );
+        $this->assertEquals( 401, $response->get_status() );
+        $this->stoppit_and_tidyup();
+    }
+}

--- a/tests/unit-tests/send-invoice-controller.php
+++ b/tests/unit-tests/send-invoice-controller.php
@@ -48,7 +48,7 @@ class Send_Invoice_Controller extends WC_REST_Unit_Test_Case {
     public function test_sending_invoice() {
         wp_set_current_user( $this->user );
 
-        $response = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/v3/orders/send_invoice/' . $this->order_id ) );
+        $response = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/v3/orders/' . $this->order_id . '/send_invoice' ) );
         $note = $response->get_data();
         $this->note_ids[] = $note['id'];
 
@@ -64,7 +64,7 @@ class Send_Invoice_Controller extends WC_REST_Unit_Test_Case {
     public function test_invalid_order_id() {
         wp_set_current_user( $this->user );
 
-        $response = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/v3/orders/send_invoice/1111111' ) );
+        $response = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/v3/orders/1111111/send_invoice' ) );
         $this->assertEquals( 404, $response->get_status() );
         $this->stoppit_and_tidyup();
     }
@@ -73,7 +73,7 @@ class Send_Invoice_Controller extends WC_REST_Unit_Test_Case {
      * Test unauthed requests can not send invoices
      */
     public function test_unauthed_request_fails() {
-        $response = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/v3/orders/send_invoice/'  . $this->order_id ) );
+        $response = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/v3/orders/' . $this->order_id . '/send_invoice' ) );
         $this->assertEquals( 401, $response->get_status() );
         $this->stoppit_and_tidyup();
     }

--- a/wc-calypso-bridge-class.php
+++ b/wc-calypso-bridge-class.php
@@ -78,6 +78,7 @@ class WC_Calypso_Bridge {
 
 		/** API includes */
 		include_once( dirname( __FILE__ ) . '/api/class-wc-calypso-bridge-currencies-controller.php' );
+		include_once( dirname( __FILE__ ) . '/api/class-wc-calypso-bridge-send-invoice-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-calypso-bridge-settings-email-groups-controller.php' );
 		
 		if ( class_exists( 'MailChimp_Woocommerce' ) ) {
@@ -93,6 +94,7 @@ class WC_Calypso_Bridge {
 	public function register_routes() {
 		$controllers = array(
 			'WC_Calypso_Bridge_Currencies_Controller',
+			'WC_Calypso_Bridge_Send_Invoice_Controller',
 			'WC_Calypso_Bridge_Settings_Email_Groups_Controller',
 		);
 


### PR DESCRIPTION
This branch introduces a new endpoint for https://github.com/Automattic/wp-calypso/issues/15679 - which will allow triggering an order invoice email to be send via the API.

__Background__
I'm not 💯 % sold on the path name I have used in this branch, so please feel free to offer suggestions. Additionally, what to return as a response in this action was kind of odd to figure out. I opted to return the note that is created when this action is taken in wp-admin - since that is in-fact an object created by the request... but if so, should this be a `POST`!?

__To Test__
Good news is, the functionality works great in my testing - you too can check it out by:

- running `phpunit` to run the new tests for this endpoint
- I setup an email logging plugin on my test site, and verified the order invoice email was indeed sent when I requested the url via Postman via GET `http://domain/index.php?rest_route=/wc/v3/orders/send_invoice/ORDERID`