### PR TITLE
Remove reference to a missing schema element.

### DIFF
--- a/api/class-wc-calypso-bridge-mailchimp-settings-controller.php
+++ b/api/class-wc-calypso-bridge-mailchimp-settings-controller.php
@@ -62,7 +62,6 @@ class WC_Calypso_Bridge_MailChimp_Settings_Controller extends WC_REST_Controller
 				'callback'            => array( $this, 'update_store_info' ),
 				'permission_callback' => array( $this, 'permissions_check' ),
 			),
-		'schema' => array( $this, 'get_store_info_schema' ),
 		) );
 		register_rest_route( $this->namespace, '/' . $this->rest_base . '/campaign_defaults', array(
 			array(


### PR DESCRIPTION
### Infromation
This PR removes reference to a missing schema providing function. 
I was cleaning up the schema usage some time ago ( https://github.com/woocommerce/wc-api-dev/pull/56/commits/9b2097f4e353fe108859a09f72bbe0b1717a2cc8 ) but I have missed one occurrence. 