### PR TITLE
Prevent referrers getting set during the checkout process 

### DIFF
--- a/inc/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
+++ b/inc/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
@@ -55,6 +55,10 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	 * Make _wca available to queue events
 	 */
 	public function wp_head_top() {
+		if ( is_cart() || is_checkout() || is_checkout_pay_page() || is_order_received_page() || is_add_payment_method_page() ) {
+			$prevent_referrer_code = "<script>window._wca_prevent_referrer = true;</script>";
+			echo "$prevent_referrer_code\r\n";
+		}
 		$wca_code = "<script>window._wca = window._wca || [];</script>";
 		echo "$wca_code\r\n";
 	}

--- a/inc/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
+++ b/inc/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
@@ -55,11 +55,10 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	 * Make _wca available to queue events
 	 */
 	public function wp_head_top() {
-		if ( is_cart() || is_checkout() || is_checkout_pay_page() || is_order_received_page() || is_add_payment_method_page() ) {
-			$prevent_referrer_code = "<script>window._wca_prevent_referrer = true;</script>";
-			echo "$prevent_referrer_code\r\n";
-		}
 		$wca_code = "<script>window._wca = window._wca || [];</script>";
+		if ( is_cart() || is_checkout() || is_checkout_pay_page() || is_order_received_page() || is_add_payment_method_page() ) {
+			$wca_code .= "\r\n<script>window._wca_prevent_referrer = true;</script>";
+		}
 		echo "$wca_code\r\n";
 	}
 


### PR DESCRIPTION
To ensure payment gateways aren't set as referrers. This corresponds to a proposed code fix in Jetpack in the parallel branch -  https://github.com/Automattic/jetpack/pull/8296/commits/f91e76483119c398d711821ac93eeab262284f03

This will require an update to `s.js` to skip setting the referrer.