### PR TITLE
Add created_via to products and jetpack sync for products

### DIFF
--- a/inc/wc-calypso-bridge-jetpack-sync.php
+++ b/inc/wc-calypso-bridge-jetpack-sync.php
@@ -17,6 +17,7 @@ function wc_calypso_bridge_add_post_meta_whitelist( $list ) {
 		'_billing_email',
 		'_billing_first_name',
 		'_billing_last_name',
+		'_created_via',
 	);
 	return array_merge( $list, $additional_meta );
 }

--- a/inc/wc-calypso-bridge-products.php
+++ b/inc/wc-calypso-bridge-products.php
@@ -29,6 +29,7 @@ function wc_calypso_bridge_products_get_context() {
 
 	$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '';
 	$known_fragments = array(
+		'&_via_calypso'           => 'calypso',
 		'/wp-json/wc/v2'          => 'rest-api-v2',
 		'/?rest_route=%2Fwc%2Fv2' => 'rest-api-v2-rest-route',
 		'/wp-json/wc/v3'          => 'rest-api-v3',
@@ -59,4 +60,4 @@ function wc_calypso_bridge_products_wp_insert_post( $post_ID, $post, $update ) {
 	update_post_meta( $post_ID, '_created_via', $created_via );
 }
 
-add_action( 'wp_insert_post', 'wc_calypso_bridge_products_wp_insert_post', 10, 4 );
+add_action( 'wp_insert_post', 'wc_calypso_bridge_products_wp_insert_post', 10, 3 );

--- a/inc/wc-calypso-bridge-products.php
+++ b/inc/wc-calypso-bridge-products.php
@@ -28,7 +28,7 @@ function wc_calypso_bridge_products_get_context() {
 	}
 
 	$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '';
-	$triggers = array(
+	$known_fragments = array(
 		'/wp-json/wc/v2'          => 'rest-api-v2',
 		'/?rest_route=%2Fwc%2Fv2' => 'rest-api-v2-rest-route',
 		'/wp-json/wc/v3'          => 'rest-api-v3',
@@ -36,8 +36,8 @@ function wc_calypso_bridge_products_get_context() {
 		'/post-new.php'           => 'post-new',
 	);
 
-	foreach ( $triggers as $fragment => $context ) {
-		if ( false !== strpos( $_SERVER[ 'REQUEST_URI' ], $fragment ) ) {
+	foreach ( $known_fragments as $known_fragment => $context ) {
+		if ( false !== strpos( $request_uri, $fragment ) ) {
 			return $context;
 		}
 	}

--- a/inc/wc-calypso-bridge-products.php
+++ b/inc/wc-calypso-bridge-products.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Adds additional meta to products for the Store on .com experience.
+ * See also wc-calypso-bridge-jetpack-sync.php
+ *
+ * @since 0.1.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+function wc_calypso_bridge_products_get_context() {
+	if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+		$referrer = isset( $_SERVER['HTTP_REFERER'] ) ? $_SERVER['HTTP_REFERER'] : '';
+		$known_referrers = array(
+			'page=product_importer' => 'ajax-product-importer',
+			'/post-new.php'         => 'ajax-post-new',
+		);
+
+		foreach ( $known_referrers as $known_referrer => $context ) {
+			if ( false !== strpos( $referrer, $known_referrer ) ) {
+				return $context;
+			}
+		}
+
+		return 'ajax-unknown';
+	}
+
+	$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '';
+	$triggers = array(
+		'/wp-json/wc/v2'          => 'rest-api-v2',
+		'/?rest_route=%2Fwc%2Fv2' => 'rest-api-v2-rest-route',
+		'/wp-json/wc/v3'          => 'rest-api-v3',
+		'/?rest_route=%2Fwc%2Fv3' => 'rest-api-v3-rest-route',
+		'/post-new.php'           => 'post-new',
+	);
+
+	foreach ( $triggers as $fragment => $context ) {
+		if ( false !== strpos( $_SERVER[ 'REQUEST_URI' ], $fragment ) ) {
+			return $context;
+		}
+	}
+
+	return 'unknown';
+}
+
+function wc_calypso_bridge_products_wp_insert_post( $post_ID, $post, $update ) {
+	if ( $update ) {
+		return;
+	}
+
+	$product_post_types = array( 'product', 'product_variation' );
+	if ( ! in_array( $post->post_type, $product_post_types ) ) {
+		return;
+	}
+
+	$created_via = wc_calypso_bridge_products_get_context();
+	update_post_meta( $post_ID, '_created_via', $created_via );
+}
+
+add_action( 'wp_insert_post', 'wc_calypso_bridge_products_wp_insert_post', 10, 4 );

--- a/inc/wc-calypso-bridge-products.php
+++ b/inc/wc-calypso-bridge-products.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 function wc_calypso_bridge_products_get_context() {
 	if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
-		$referrer = isset( $_SERVER['HTTP_REFERER'] ) ? $_SERVER['HTTP_REFERER'] : '';
+		$referrer        = isset( $_SERVER['HTTP_REFERER'] ) ? $_SERVER['HTTP_REFERER'] : '';
 		$known_referrers = array(
 			'page=product_importer' => 'ajax-product-importer',
 			'/post-new.php'         => 'ajax-post-new',
@@ -27,7 +27,7 @@ function wc_calypso_bridge_products_get_context() {
 		return 'ajax-unknown';
 	}
 
-	$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '';
+	$request_uri     = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '';
 	$known_fragments = array(
 		'&_via_calypso'           => 'calypso',
 		'/wp-json/wc/v2'          => 'rest-api-v2',

--- a/inc/wc-calypso-bridge-products.php
+++ b/inc/wc-calypso-bridge-products.php
@@ -37,7 +37,7 @@ function wc_calypso_bridge_products_get_context() {
 	);
 
 	foreach ( $known_fragments as $known_fragment => $context ) {
-		if ( false !== strpos( $request_uri, $fragment ) ) {
+		if ( false !== strpos( $request_uri, $known_fragment ) ) {
 			return $context;
 		}
 	}

--- a/wc-calypso-bridge-class.php
+++ b/wc-calypso-bridge-class.php
@@ -75,7 +75,7 @@ class WC_Calypso_Bridge {
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-mailchimp-no-redirect.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-masterbar-menu.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-paypal-defaults.php' );
-		include_ince( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-products.php' );
+		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-products.php' );
 
 		/** API includes */
 		include_once( dirname( __FILE__ ) . '/api/class-wc-calypso-bridge-send-invoice-controller.php' );

--- a/wc-calypso-bridge-class.php
+++ b/wc-calypso-bridge-class.php
@@ -75,6 +75,7 @@ class WC_Calypso_Bridge {
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-mailchimp-no-redirect.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-masterbar-menu.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-paypal-defaults.php' );
+		include_ince( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-products.php' );
 
 		/** API includes */
 		include_once( dirname( __FILE__ ) . '/api/class-wc-calypso-bridge-send-invoice-controller.php' );


### PR DESCRIPTION
Fixes #31 

Makes it possible to understand the origin of products sync-ed to Jetpack (importer, wp-admin, REST API v3, etc) by adding and syncing that post meta to WordPress.com

To test: See D10144