### PR TITLE
Only Load WooCommerce Analytics on old JP Installs

### DIFF
--- a/wc-calypso-bridge-class.php
+++ b/wc-calypso-bridge-class.php
@@ -89,7 +89,7 @@ class WC_Calypso_Bridge {
 		 * Store Stats Testing. woocommerce-analytics will eventually land in Jetpack.
 		 * See https://github.com/Automattic/jetpack/pull/8296 for more details
 		 */
-		if ( class_exists( 'Jetpack' ) && ! class_exists( 'Jetpack_WooCommerce_Analytics' ) ) {
+		if ( class_exists( 'Jetpack' ) && version_compare( JETPACK__VERSION, '5.8', '<=' ) && ! class_exists( 'Jetpack_WooCommerce_Analytics' ) ) {
 			include_once( dirname( __FILE__ ) . '/inc/woocommerce-analytics/wp-woocommerce-analytics.php' );
 		}
 	}


### PR DESCRIPTION
With `Jetpack_WooCommerce_Analytics` slated for release as part of Jetpack v5.9 - I want to ensure we don't load the "old" version of the WC Analytics package here in Calypso bridge, if a site has been updated to JP 5.9.

This branch just adds in a version check for `JETPACK__VERSION` and if it is 5.9 or greater, it will not load WC analytics.

__To Test__
- Load this plugin on a test site running Jetpack 5.8
- Verify WCA is loaded by visiting a shop page ( in an incognito window ) and verifying that `_wca` is defined by typing it in the console.
- Then update the test site to JP 5.9 ( I believe this is `master` right now on the JP repo )
- Verify that WCA is still present. I added some logging statements to the `if` clause myself while testing, but verifying it works in both JP versions is really all that is needed.