### PR TITLE
Store: Add `woocommerce_email_footer_text` to the `settings_email_groups` response

### DIFF
--- a/api/class-wc-calypso-bridge-settings-email-groups-controller.php
+++ b/api/class-wc-calypso-bridge-settings-email-groups-controller.php
@@ -53,6 +53,7 @@ class WC_Calypso_Bridge_Settings_Email_Groups_Controller extends WC_REST_Setting
 		$items = [
 			[ 'group_id' => 'email',                           'id' => 'woocommerce_email_from_name' ],
 			[ 'group_id' => 'email',                           'id' => 'woocommerce_email_from_address' ],
+			[ 'group_id' => 'email',                           'id' => 'woocommerce_email_footer_text' ],
 			[ 'group_id' => 'email_new_order',                 'id' => 'enabled' ],
 			[ 'group_id' => 'email_new_order',                 'id' => 'recipient' ],
 			[ 'group_id' => 'email_cancelled_order',           'id' => 'enabled' ],

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -112,11 +112,6 @@ class WC_Calypso_Bridge_Unit_Tests_Bootstrap {
 	 * If needed, these can also be shipped with the dev plugin and a local copy can be called.
 	 */
 	public function includes() {
-
-		// factories
-		require_once( $this->wc_tests_dir . '/framework/factories/class-wc-unit-test-factory-for-webhook.php' );
-		require_once( $this->wc_tests_dir . '/framework/factories/class-wc-unit-test-factory-for-webhook-delivery.php' );
-
 		// framework
 		require_once( $this->wc_tests_dir . '/framework/class-wc-unit-test-factory.php' );
 		require_once( $this->wc_tests_dir  . '/framework/class-wc-mock-session-handler.php' );

--- a/tests/unit-tests/email-groups-controller.php
+++ b/tests/unit-tests/email-groups-controller.php
@@ -44,66 +44,72 @@ class Email_Groups_Controller extends WC_REST_Unit_Test_Case {
 				'default' => 'admin@example.org',
 			),
 			2 => array(
-				'id' => 'enabled',
-				'value' => 'yes',
-				'group_id' => 'email_new_order',
-				'default' => 'yes'
+				'id' => 'woocommerce_email_footer_text',
+				'value' => '{site_title}',
+				'group_id' => 'email',
+				'default' => '{site_title}',
 			),
 			3 => array(
+				'id' => 'enabled',
+				'value' => 'yes',
+				'group_id' => 'email_new_order',
+				'default' => 'yes'
+			),
+			4 => array(
 				'id' => 'recipient',
 				'value' => '',
 				'group_id' => 'email_new_order',
 				'default' => '',
 			),
-			4 => array(
+			5 => array(
 				'id' => 'enabled',
 				'value' => 'yes',
 				'group_id' => 'email_cancelled_order',
 				'default' => 'yes'
 			),
-			5 => array(
+			6 => array(
 				'id' => 'recipient',
 				'value' => '',
 				'group_id' => 'email_cancelled_order',
 				'default' => '',
 			),
-			6 => array(
+			7 => array(
 				'id' => 'enabled',
 				'value' => 'yes',
 				'group_id' => 'email_failed_order',
 				'default' => 'yes',
 			),
-			7 => array(
+			8 => array(
 				'id' => 'recipient',
 				'value' => '',
 				'group_id' => 'email_failed_order',
 				'default' => '',
 			),
-			8 => array(
+			9 => array(
 				'id' => 'enabled',
 				'value' => 'yes',
 				'group_id' => 'email_customer_on_hold_order',
 				'default' => 'yes',
 			),
-			9 => array(
+			10 => array(
 				'id' => 'enabled',
 				'value' => 'yes',
 				'group_id' => 'email_customer_processing_order',
 				'default' => 'yes',
 			),
-			10 => array(
+			11 => array(
 				'id' => 'enabled',
 				'value' => 'yes',
 				'group_id' => 'email_customer_completed_order',
 				'default' => 'yes',
 			),
-			11 => array(
+			12 => array(
 				'id' => 'enabled',
 				'value' => 'yes',
 				'group_id' => 'email_customer_refunded_order',
 				'default' => 'yes',
 			),
-			12 => array(
+			13 => array(
 				'id' => 'enabled',
 				'value' => 'yes',
 				'group_id' => 'email_customer_new_account',


### PR DESCRIPTION
This PR adds `woocommerce_email_footer_text` to the `/wc/v3/settings_email_groups` endpoint (used by email settings in Calypso).

It also fixes tests by removing the require's for webhook factories (which are no longer in core).

To Test:
* Run `phpunit` and make sure all tests pass.
* Use something like postman to make a request to `/wc/v3/settings_email_groups` and make sure `woocommerce_email_footer_text` is present in the response.