### PR TITLE
Release 0.1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ Ideally all API functionality will eventually be contained within `wc-api-dev` (
 ### Running the Test Suite
 
 From a test install of WordPress with `wc-api-dev` and `woocommerce` present, run `phpunit` from the root of this plugin directory.
+
+ Code coverage reports can be ran with `phpunit --coverage-html /tmp/coverage`.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "automattic/wc-calypso-bridge",
-	"version": "v0.1.8",
+	"version": "v0.1.9",
 	"autoload": {
 		"files": [
 			"wc-calypso-bridge.php"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,7 +14,4 @@
 			<directory suffix=".php">./tests/unit-tests</directory>
 		</testsuite>
 	</testsuites>
-	<logging>
-		<log type="coverage-html" target="./tmp/coverage" charset="UTF-8" />
-	</logging>
 </phpunit>

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce
 Requires at least: 4.6
 Tested up to: 4.8
-Stable tag: 0.1.8
+Stable tag: 0.1.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ This section describes how to install the plugin and get it working.
 1. Activate the plugin through the 'Plugins' screen in WordPress
 
 == Changelog ==
+
+= 0.1.9 =
+* Added the `woocommerce_email_footer_text` setting to batch email settings endpoint.
 
 = 0.1.8 =
 * Ensure WooCommerce Analytics does not get loaded when Jetpack v5.9 is shipped/installed

--- a/wc-calypso-bridge-class.php
+++ b/wc-calypso-bridge-class.php
@@ -7,7 +7,7 @@ class WC_Calypso_Bridge {
 	/**
 	 * Current version of the plugin.
 	 */
-	const CURRENT_VERSION = '0.1.8';
+	const CURRENT_VERSION = '0.1.9';
 
 	/**
 	 * Minimum woocommerce version needed to run this plugin.

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 0.1.8
+ * Version: 0.1.9
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4


### PR DESCRIPTION
This PR bumps the version to `0.1.9` and removes the code coverage line from PHPUnit (to speed up normal runs of the tests).

I'll be prepping a wpcomsh release this week with my changes in `wc-api-dev` as well.