### PR TITLE
MailChimp: Truncate tables on deactivation.

### DIFF
--- a/inc/wc-calypso-bridge-mailchimp-deactivate-hook.php
+++ b/inc/wc-calypso-bridge-mailchimp-deactivate-hook.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Clear out MailChimp tables on deactivation
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+register_deactivation_hook( 'mailchimp-for-woocommerce/mailchimp-woocommerce.php', 'wc_calypso_bridge_clear_mailchimp_tables' );
+
+function wc_calypso_bridge_clear_mailchimp_tables() {
+	global $wpdb;
+	$log = new WC_Logger();
+
+	$mailchimp_tables = array(
+		"{$wpdb->prefix}queue",
+		"{$wpdb->prefix}failed_jobs",
+		"{$wpdb->prefix}mailchimp_carts",
+	);
+
+	foreach( $mailchimp_tables as $table ) {
+		$sql = "TRUNCATE TABLE `$table`";
+
+		if ( $wpdb->query( $sql ) ) {
+			$log->add( 'mailchimp-for-woocommerce', "Plugin Deactivated: success clearing `$table` table." );
+		} else {
+			$log->add( 'mailchimp-for-woocommerce', "Plugin Deactivated: FAILURE clearing `$table` table." );
+		}
+	}
+}

--- a/inc/wc-calypso-bridge-mailchimp-deactivate-hook.php
+++ b/inc/wc-calypso-bridge-mailchimp-deactivate-hook.php
@@ -11,7 +11,11 @@ register_deactivation_hook( 'mailchimp-for-woocommerce/mailchimp-woocommerce.php
 
 function wc_calypso_bridge_clear_mailchimp_tables() {
 	global $wpdb;
-	$log = new WC_Logger();
+	$logger = false;
+
+	if ( class_exists( 'WC_Logger' ) ) {
+		$logger = new WC_Logger();
+	}
 
 	$mailchimp_tables = array(
 		"{$wpdb->prefix}queue",
@@ -19,13 +23,17 @@ function wc_calypso_bridge_clear_mailchimp_tables() {
 		"{$wpdb->prefix}mailchimp_carts",
 	);
 
-	foreach( $mailchimp_tables as $table ) {
-		$sql = "TRUNCATE TABLE `$table`";
+	foreach( (array) $mailchimp_tables as $table ) {
+		$sql = $wpdb->prepare( "TRUNCATE TABLE `$table`" );
 
 		if ( $wpdb->query( $sql ) ) {
-			$log->add( 'mailchimp-for-woocommerce', "Plugin Deactivated: success clearing `$table` table." );
+			$log_message = "Plugin Deactivated: success clearing `$table` table.";
 		} else {
-			$log->add( 'mailchimp-for-woocommerce', "Plugin Deactivated: FAILURE clearing `$table` table." );
+			$log_message = "Plugin Deactivated: FAILURE clearing `$table` table.";
+		}
+
+		if ( $logger ) {
+			$logger->add( 'mailchimp-for-woocommerce', $log_message );
 		}
 	}
 }

--- a/wc-calypso-bridge-class.php
+++ b/wc-calypso-bridge-class.php
@@ -71,6 +71,7 @@ class WC_Calypso_Bridge {
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-hide-alerts.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-jetpack-hotfixes.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-jetpack-sync.php' );
+		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-mailchimp-deactivate-hook.php' );		
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-mailchimp-no-redirect.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-masterbar-menu.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-paypal-defaults.php' );


### PR DESCRIPTION
This branch is part of the cleanup project for the `mailchimp-for-woocommerce` plugin ( background p90Yrv-CD-p2 ). In lieu of making an endpoint to clear out the MC queue tables when we remove the plugins - I opted to hook into the deactivation process here.

FWIW I spoke with the developers today, and they are going to add similar logic to clean up the mysql tables ( possibly DELETE'ing them ) upon deactivation. I still feel a bit more comfortable with the `TRUNCATE` here, just in case for some odd reason a site has a plugin/logic that depends on these tables. Please tell me if I'm being too paranoid here 😟

__To Test__
- Install the `mailchimp-for-woocommerce` plugin on a test site if it isn't already present
- deactivate the plugin, verify nothing explodes
- View the logs under WooCommerce > Status to verify the log entries for truncating all 3 tables are SUCCESS:

<img width="1199" alt="deactivate" src="https://user-images.githubusercontent.com/22080/38342737-00cb0028-3835-11e8-8848-3e881da12d39.png">
