### PR TITLE
Store: Remove name & email address from list of synced meta

### DIFF
--- a/inc/wc-calypso-bridge-jetpack-sync.php
+++ b/inc/wc-calypso-bridge-jetpack-sync.php
@@ -14,9 +14,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 function wc_calypso_bridge_add_post_meta_whitelist( $list ) {
 	$additional_meta = array(
-		'_billing_email',
-		'_billing_first_name',
-		'_billing_last_name',
 		'_created_via',
 	);
 	return array_merge( $list, $additional_meta );


### PR DESCRIPTION
As a follow-up to https://github.com/Automattic/jetpack/pull/9058 this stop syncing a few fields that were being passed via Jetpack sync.
See the thread at p90Yrv-Cl-p2.

You can optionally test creating an order and making sure the order notification comes through.
It looks like the server side list might still need updated.