### PR TITLE
Fix broken customizer steps.

### DIFF
--- a/assets/js/admin/customizer.js
+++ b/assets/js/admin/customizer.js
@@ -163,9 +163,6 @@
 			switch ( step.altStep.action ) {
 				case 'expandThemes':
 					var nextStep, themePanel;
-					themePanel = api.section.instance( 'themes' );
-					themePanel.expand();
-					
 					nextStep = step.altStep;
 					delete( nextStep.buttonText );
 					self._renderStep( nextStep );

--- a/inc/class-customizer-guided-tour.php
+++ b/inc/class-customizer-guided-tour.php
@@ -143,8 +143,8 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 				'altStep'     => array(
 					'buttonText'  => __( 'I\'ll try Storefront!', 'wc_calypso_bridge' ),
 					'action'      => 'expandThemes',
-					'message'     => __( 'Click the thumbnail to get started with Storefront', 'wc_calypso_bridge' ),
-					'section'     => '#customize-control-theme_storefront .theme-screenshot',
+					'message'     => __( 'Click the change button and select Storefront to get started.', 'wc_calypso_bridge' ),
+					'section'     => '#accordion-section-themes',
 					'stat'        => '1-click-try-sf',
 				),
 			);
@@ -180,9 +180,9 @@ if ( ! class_exists( 'Customizer_NUX_Guided_Tour' ) ) :
 
 			$steps[] = array(
 				'message'      => __( '<p>Choose a menu to add shop pages to.</p>', 'wc_calypso_bridge' ),
-				'section'      => '#sub-accordion-panel-nav_menus',
+				'section'      => '#accordion-section-menu_locations .accordion-section-title',
 				'panel'        => 'nav_menus',
-				'panelSection' => '.control-section-nav_menu',
+				'panelSection' => '#accordion-section-menu_locations .accordion-section-title',
 				'action'       => 'updateMenus',
 				'showSkip'     => ( bool ) true,
 				'stat'         => '4-add-menu',


### PR DESCRIPTION
This branch fixes https://github.com/Automattic/wp-calypso/issues/24663

It appears there were some changes to nav structure in the Customizer that we were keying off of to create the guided tour. Specifically the panel that used to show Theme thumbnails no longer exists, and is now a full screen browser:

<img width="1435" alt="theme-browser" src="https://user-images.githubusercontent.com/22080/40336340-e4fcaf3c-5d1d-11e8-8cdc-178e3bbf50b8.png">

In lieu of exploring any new API this theme browser provides, the "Try Storefront" link now shows this prompt to the user:

<img width="772" alt="try-storefront" src="https://user-images.githubusercontent.com/22080/40336373-0dcfa464-5d1e-11e8-8778-3db12b23bdd4.png">

Menus also changed up a bit, so I modified the selectors so they will work now.

Honestly a part of me thought just about disabling the tour altogether since I imagine this will be a steady game of whack-a-mole as new .org releases come out.

It seems the Storefront guided tour is offline too - at least I wasn't able to pull it up with the old URL param.

__To Test__
- Visit http://YOURDOMAIN/wp-admin/customize.php?store-wpcom-nux=true# on a site that has storefront installed but a different theme activated
- Go through the tour steps and validate they work okay

