### PR TITLE
Add `/data/counts` and `/products/reviews' endpoints

### DIFF
--- a/api/class-wc-calypso-bridge-data-counts-controller.php
+++ b/api/class-wc-calypso-bridge-data-counts-controller.php
@@ -1,0 +1,316 @@
+<?php
+/**
+ * REST API Data object counts controller.
+ *
+ * Handles requests to the /data/counts endpoint.
+ *
+ * @author   Automattic
+ * @category API
+ * @package  WooCommerce/API
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * REST API Data Counts controller class.
+ *
+ * @package WooCommerce/API
+ */
+class WC_Calypso_Bridge_Data_Counts_Controller extends WC_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'data/counts';
+
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_items' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+			),
+			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
+	}
+
+	/**
+	 * Check whether a given request has permission to read site data.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		return true;
+	}
+
+	/**
+	 * Return the list of order counts.
+	 *
+	 * @return array list of counts for all order statuses
+	 */
+	public function get_order_counts() {
+		$statuses = array_keys( wc_get_order_statuses() );
+		// Pre-fill the array with all statuses at zero
+		$counts = array_combine( $statuses, array_fill( 0, count( $statuses ), 0 ) );
+		foreach ( wc_get_order_types( 'order-count' ) as $type ) {
+			$counts_for_type = (array) wp_count_posts( $type );
+			foreach ( $statuses as $status ) {
+				$counts[ $status ] += $counts_for_type[ $status ] ? $counts_for_type[ $status ] : 0;
+			}
+		}
+		return $counts;
+	}
+
+	/**
+	 * Return the list of product counts.
+	 *
+	 * @return array list of counts for all product statuses
+	 */
+	public function get_product_counts() {
+		global $wpdb;
+		$count = wp_cache_get( 'wc-counts-products' );
+		if ( false !== $count ) {
+			return $count;
+		}
+
+		$counts = array();
+		$counts['all'] = (int) $wpdb->get_var(
+			"SELECT COUNT( DISTINCT posts.ID )
+				FROM {$wpdb->posts} as posts
+				WHERE 1=1
+				AND posts.post_type IN ( 'product', 'product_variation' )
+				AND posts.post_status = 'publish'"
+		);
+
+		$low_stock_amount = get_option( 'woocommerce_notify_low_stock_amount' );
+		$no_stock_amount = get_option( 'woocommerce_notify_no_stock_amount' );
+
+		$counts['out-of-stock'] = (int) $wpdb->get_var(
+			"SELECT COUNT( DISTINCT posts.ID )
+				FROM {$wpdb->posts} as posts
+				INNER JOIN {$wpdb->postmeta} AS postmeta ON posts.ID = postmeta.post_id
+				INNER JOIN {$wpdb->postmeta} AS postmeta2 ON posts.ID = postmeta2.post_id
+				WHERE 1=1
+				AND posts.post_type IN ( 'product', 'product_variation' )
+				AND posts.post_status = 'publish'
+				AND postmeta2.meta_key = '_manage_stock' AND postmeta2.meta_value = 'yes'
+				AND postmeta.meta_key = '_stock' AND CAST(postmeta.meta_value AS SIGNED) <= '{$no_stock_amount}'"
+		);
+
+		$counts['low-inventory'] = (int) $wpdb->get_var(
+			"SELECT COUNT( DISTINCT posts.ID )
+				FROM {$wpdb->posts} as posts
+				INNER JOIN {$wpdb->postmeta} AS postmeta ON posts.ID = postmeta.post_id
+				INNER JOIN {$wpdb->postmeta} AS postmeta2 ON posts.ID = postmeta2.post_id
+				WHERE 1=1
+				AND posts.post_type IN ( 'product', 'product_variation' )
+				AND posts.post_status = 'publish'
+				AND postmeta2.meta_key = '_manage_stock' AND postmeta2.meta_value = 'yes'
+				AND postmeta.meta_key = '_stock' AND CAST(postmeta.meta_value AS SIGNED) <= '{$low_stock_amount}'
+				AND postmeta.meta_key = '_stock' AND CAST(postmeta.meta_value AS SIGNED) > '{$no_stock_amount}'"
+		);
+
+		wp_cache_set( 'wc-counts-products', $counts );
+		return $counts;
+	}
+
+	/**
+	 * Return the list of review counts.
+	 *
+	 * @return array list of counts for all review statuses
+	 */
+	public function get_review_counts() {
+		global $wpdb;
+		$count = wp_cache_get( 'wc-counts-reviews' );
+		if ( false !== $count ) {
+			return $count;
+		}
+
+		$sql = "SELECT comment_approved, COUNT( * ) AS total
+			FROM {$wpdb->comments}
+			JOIN {$wpdb->posts} ON {$wpdb->posts}.ID = {$wpdb->comments}.comment_post_ID
+			WHERE {$wpdb->posts}.post_type IN ('product')
+			GROUP BY comment_approved";
+
+		$totals = (array) $wpdb->get_results( $sql, ARRAY_A );
+
+		$comment_count = array(
+			'approved'            => 0,
+			'awaiting_moderation' => 0,
+			'spam'                => 0,
+			'trash'               => 0,
+			'post-trashed'        => 0,
+			'total_comments'      => 0,
+			'all'                 => 0,
+		);
+
+		foreach ( $totals as $row ) {
+			switch ( $row['comment_approved'] ) {
+				case 'trash':
+					$comment_count['trash'] = (int) $row['total'];
+					break;
+				case 'post-trashed':
+					$comment_count['post-trashed'] = (int) $row['total'];
+					break;
+				case 'spam':
+					$comment_count['spam'] = (int) $row['total'];
+					$comment_count['total_comments'] += $row['total'];
+					break;
+				case '1':
+					$comment_count['approved'] = (int) $row['total'];
+					$comment_count['total_comments'] += $row['total'];
+					$comment_count['all'] += $row['total'];
+					break;
+				case '0':
+					$comment_count['awaiting_moderation'] = (int) $row['total'];
+					$comment_count['total_comments'] += $row['total'];
+					$comment_count['all'] += $row['total'];
+					break;
+				default:
+					break;
+			}
+		}
+
+		wp_cache_set( 'wc-counts-reviews', $comment_count );
+		return $comment_count;
+	}
+
+	/**
+	 * Return the list of counts per object.
+	 *
+	 * @param  WP_REST_Request $request
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$data = array(
+			'orders'   => $this->get_order_counts(),
+			'products' => $this->get_product_counts(),
+			'reviews'  => $this->get_review_counts(),
+		);
+
+		return $this->prepare_item_for_response( $data, $request );
+	}
+
+	/**
+	 * Prepare the data object for response.
+	 *
+	 * @param object $item Data object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response $response Response data.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$data     = $this->add_additional_fields_to_object( $item, $request );
+		$data     = $this->filter_response_by_context( $data, 'view' );
+		$response = rest_ensure_response( $data );
+
+		$response->add_links( $this->prepare_links( $item ) );
+
+		/**
+		 * Filter counts returned from the API.
+		 *
+		 * @param WP_REST_Response $response The response object.
+		 * @param array            $item     Object count data.
+		 * @param WP_REST_Request  $request  Request used to generate the response.
+		 */
+		return apply_filters( 'woocommerce_rest_prepare_data_counts', $response, $item, $request );
+	}
+
+	/**
+	 * Prepare links for the request.
+	 *
+	 * @param object $item Data object.
+	 * @return array Links for the given count collection.
+	 */
+	protected function prepare_links( $item ) {
+		$links = array(
+			'self' => array(
+				'href' => rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ),
+			),
+		);
+
+		return $links;
+	}
+
+	/**
+	 * Get the counts schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema' => 'http://json-schema.org/draft-04/schema#',
+			'title'   => 'data_counts',
+			'type'       => 'object',
+			'properties' => array(
+				'orders' => array(
+					'type'        => 'object',
+					'description' => __( 'Collection of order totals by order status.', 'woocommerce' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'products' => array(
+					'type'        => 'object',
+					'description' => __( 'Collection of product totals by stock status.', 'woocommerce' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'reviews' => array(
+					'type'        => 'object',
+					'description' => __( 'Collection of review totals by comment status.', 'woocommerce' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+}
+
+/**
+ * Clear the products count cache when products are added or updated, or when
+ * the no/low stock options are changed.
+ */
+function woocommerce_clear_product_count_cache( $id ) {
+	wp_cache_delete( 'wc-counts-products' );
+}
+add_action( 'woocommerce_update_product', 'woocommerce_clear_product_count_cache' );
+add_action( 'woocommerce_new_product', 'woocommerce_clear_product_count_cache' );
+add_action( 'update_option_woocommerce_notify_low_stock_amount', 'woocommerce_clear_product_count_cache' );
+add_action( 'update_option_woocommerce_notify_no_stock_amount', 'woocommerce_clear_product_count_cache' );
+
+/**
+ * Clear the reviews count cache when comments are added, deleted, or moderated,
+ * only applies to comments on products.
+ */
+function woocommerce_clear_review_count_cache( $comment_id ) {
+	$comment = get_comment( $comment_id );
+	$post_id = $comment ? $comment->comment_post_ID : false;
+	if ( ! $post_id || 'product' !== get_post_type( $post_id ) ) {
+		return;
+	}
+	// This is a comment on a product - a review - so clear the review cache
+	wp_cache_delete( 'wc-counts-reviews' );
+}
+add_action( 'delete_comment', 'woocommerce_clear_review_count_cache' );
+add_action( 'wp_insert_comment', 'woocommerce_clear_review_count_cache' );
+add_action( 'wp_set_comment_status', 'woocommerce_clear_review_count_cache' );

--- a/api/class-wc-calypso-bridge-product-reviews-controller.php
+++ b/api/class-wc-calypso-bridge-product-reviews-controller.php
@@ -1,0 +1,385 @@
+<?php
+/**
+ * REST API Product Reviews Controller
+ *
+ * Handles requests to /products/reviews.
+ *
+ * @author   WooThemes
+ * @category API
+ * @package  WooCommerce/APIå
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * REST API Product Reviews Controller Class.
+ *
+ * @package WooCommerce/API
+ */
+class WC_Calypso_Bridge_Product_Reviews_Controller extends WC_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * List route base.
+	 *
+	 * @var string
+	 */
+	protected $list_rest_base = 'products/reviews';
+
+	/**
+	 * Register Routes
+	 *
+	 * Registers a root /products/reviews endpoint that returns all reviews for a site.
+	 */
+	public function register_routes() {
+		//parent::register_routes();
+		register_rest_route( $this->namespace, '/' . $this->list_rest_base, array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_list_items' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				'args'                => $this->get_list_collection_params(),
+			),
+			'schema' => array( $this, 'get_item_schema' ),
+		) );
+	}
+
+	/**
+	 * Check whether a given request has permission to read site data.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		return true;
+	}
+
+	/**
+	 * Get all reviews for a site.
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return array|WP_Error
+	 */
+	public function get_list_items( $request ) {
+		global $wpdb;
+
+		$per_page = intval( $request['per_page'] );
+
+		switch( $request['status'] ) {
+			case 'pending':
+				$status = 'hold';
+				break;
+			case 'approved':
+				$status = 'approve';
+				break;
+			case 'trash':
+				$status = 'trash';
+				break;
+			case 'spam':
+				$status = 'spam';
+				break;
+			default:
+				$status = 'all';
+		}
+
+		$args = array(
+			'post_type'     => 'product',
+			'parent'        => '',
+			'type'          => '',
+			'hierarchical'  => 'threaded',
+			'number'        => $per_page,
+			'offset'        => intval( ( $request['page'] - 1 ) * $per_page ),
+			'status'        => $status,
+			'order'         => $request['order'],
+			'orderby'       => 'date_created',
+			'no_found_rows' => false,
+		);
+
+		if ( ! empty( $request['product']) ) {
+			$args['post_id'] = $request['product'];
+		}
+
+		if ( ! empty( $request['search']) ) {
+			$args['search'] = $request['search'];
+		}
+
+		$reviews_query = new WP_Comment_Query;
+		$reviews       = $reviews_query->query( $args );
+
+		$data = array();
+		foreach ( $reviews as $review_data ) {
+			$review = $this->prepare_item_for_response( $review_data, $request );
+			$review = $this->prepare_response_for_collection( $review );
+			$data[] = $review;
+		}
+
+		$response = rest_ensure_response( $data );
+
+		$response->header( 'X-WP-Total', (int) $reviews_query->found_comments );
+		$response->header( 'X-WP-TotalPages', (int) $reviews_query->max_num_pages );
+
+		return $response;
+	}
+
+	/**
+	 * Prepare links for the request.
+	 *
+	 * @param WP_Comment $review Product review object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return array Links for the given product review.
+	 */
+	protected function prepare_links( $review, $request ) {
+		$links = array(
+			'self' => array(
+				'href' => rest_url( sprintf( '/%s/%s', $this->namespace, 'products/' . $review->comment_post_ID . '/reviews/' . $review->comment_ID ) ),
+			),
+			'collection' => array(
+				'href' => rest_url( sprintf( '/%s/%s', $this->namespace, 'products/' . $review->comment_post_ID . '/reviews' ) ),
+			),
+			'up' => array(
+				'href' => rest_url( sprintf( '/%s/%s', $this->namespace, 'products/' . $review->comment_post_ID ) ),
+			),
+		);
+
+		return $links;
+	}
+
+	/**
+	 * Prepare a single product review output for response.
+	 *
+	 * v3 adds 'product_id' and 'approved'.
+	 *
+	 * @param WP_Comment $review Product review object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response $response Response data.
+	 */
+	public function prepare_item_for_response( $review, $request ) {
+		$product = new WC_Product( $review->comment_post_ID );
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+
+		$images        = wp_get_attachment_image_src( $product->get_image_id(), 'full' );
+		$product_image = is_array( $images ) ? current( $images ) : '';
+
+		switch( $review->comment_approved ) {
+			case '1':
+				$status = 'approved';
+				break;
+			case 'spam':
+				$status = 'spam';
+				break;
+			case 'trash':
+				$status = 'trash';
+				break;
+			case '0':
+			default:
+				$status = 'pending';
+				break;
+		}
+
+		$content = 'view' === $context ? wpautop( $review->comment_content ) : $review->comment_content;
+
+		$data = array(
+			'id'               => (int) $review->comment_ID,
+			'date_created'     => wc_rest_prepare_date_response( $review->comment_date ),
+			'date_created_gmt' => wc_rest_prepare_date_response( $review->comment_date_gmt ),
+			'review'           => $content,
+			'rating'           => (int) get_comment_meta( $review->comment_ID, 'rating', true ),
+			'name'             => $review->comment_author,
+			'email'            => $review->comment_author_email,
+			'avatar_urls'      => rest_get_avatar_urls( $review->comment_author_email ),
+			'verified'         => wc_review_is_from_verified_owner( $review->comment_ID ),
+			'status'           => $status,
+			'product'          => array(
+				'id'    => (int) $review->comment_post_ID,
+				'name'  => $product->get_name(),
+				'image' => $product_image,
+			)
+		);
+
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+
+		$response = rest_ensure_response( $data );
+		$response->add_links( $this->prepare_links( $review, $request ) );
+
+		/**
+		 * Filter product reviews object returned from the REST API.
+		 *
+		 * @param WP_REST_Response $response The response object.
+		 * @param WP_Comment       $review   Product review object used to create response.
+		 * @param WP_REST_Request  $request  Request object.
+		 */
+		return apply_filters( 'woocommerce_rest_prepare_product_review', $response, $review, $request );
+	}
+
+	/**
+	 * Get the query params for collections.
+	 *
+	 * @return array
+	 */
+	public function get_list_collection_params() {
+		$params = array();
+
+		$params['context'] = $this->get_context_param( array( 'default' => 'view' ) );
+
+		$params['status'] = array(
+			'default'           => 'any',
+			'description'       => __( 'Limit result set to reviews with a specific status.', 'woocommerce' ),
+			'type'              => 'stringy',
+			'enum'              => array( 'any', 'pending', 'approved', 'trash', 'spam' ),
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		$params['page'] = array(
+			'description'        => __( 'Current page of the collection.', 'woocommerce' ),
+			'type'               => 'integer',
+			'default'            => 1,
+			'sanitize_callback'  => 'absint',
+			'validate_callback'  => 'rest_validate_request_arg',
+			'minimum'            => 1,
+		);
+
+		$params['per_page'] = array(
+			'description'        => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
+			'type'               => 'integer',
+			'default'            => 10,
+			'minimum'            => 1,
+			'maximum'            => 100,
+			'sanitize_callback'  => 'absint',
+			'validate_callback'  => 'rest_validate_request_arg',
+		);
+
+		$params['order'] = array(
+			'description'        => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
+			'type'               => 'string',
+			'default'            => 'desc',
+			'enum'               => array( 'asc', 'desc' ),
+			'validate_callback'  => 'rest_validate_request_arg',
+		);
+
+		$params['product'] = array(
+			'description'       => __( 'Limit result set to reviews assigned a specific product.', 'woocommerce' ),
+			'type'              => 'integer',
+			'sanitize_callback' => 'absint',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		$params['search'] = array(
+			'description'        => __( 'Limit results to those matching a string.', 'woocommerce' ),
+			'type'               => 'string',
+			'sanitize_callback'  => 'sanitize_text_field',
+			'validate_callback'  => 'rest_validate_request_arg',
+		);
+
+		return $params;
+	}
+
+	/**
+	 * Get the Product Review's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'product_review',
+			'type'       => 'object',
+			'properties' => array(
+				'id' => array(
+					'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'review' => array(
+					'description' => __( 'The content of the review.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'date_created' => array(
+					'description' => __( "The date the review was created, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'date_created_gmt' => array(
+					'description' => __( "The date the review was created, as GMT.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'rating' => array(
+					'description' => __( 'Review rating (0 to 5).', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'name' => array(
+					'description' => __( 'Reviewer name.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'email' => array(
+					'description' => __( 'Reviewer email.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'avatar_urls' => array(
+					'description' => __( "URLs for the reviewer's avatar.", 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'verified' => array(
+					'description' => __( 'Shows if the reviewer bought the product or not.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'status' => array(
+					'description' => __( 'Status of the review', 'woocommerce' ),
+					'type'        => 'string',
+					'enum'        => array( 'pending', 'approved', 'trash', 'spam' ),
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'product' => array(
+					'description' => __( 'Basic information on the product that the review is for.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+					'properties' => array(
+						'id' => array(
+							'description' => __( 'ID of the product.', 'woocommerce' ),
+							'type'        => 'integer',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'name' => array(
+							'description' => __( 'Name of the product.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'image' => array(
+							'description' => __( 'Featured image for the product.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+					),
+				),
+			),
+		);
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+}

--- a/api/class-wc-calypso-bridge-product-reviews-controller.php
+++ b/api/class-wc-calypso-bridge-product-reviews-controller.php
@@ -179,6 +179,7 @@ class WC_Calypso_Bridge_Product_Reviews_Controller extends WC_REST_Controller {
 			case 'spam':
 				$status = 'spam';
 				break;
+			case 'post-trashed':
 			case 'trash':
 				$status = 'trash';
 				break;

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "automattic/wc-calypso-bridge",
-	"version": "v0.2.1",
+	"version": "v0.2.2",
 	"autoload": {
 		"files": [
 			"wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 0.2.1
+Stable tag: 0.2.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,10 @@ This section describes how to install the plugin and get it working.
 1. Activate the plugin through the 'Plugins' screen in WordPress
 
 == Changelog ==
+
+= 0.2.2 =
+* `data/counts` endpoint added (moved from wc-api-dev)
+* `products/reviews` endpoint added (moved from wc-api-dev)
 
 = 0.2.1 =
 * Fixed customizer tour

--- a/readme.txt
+++ b/readme.txt
@@ -25,6 +25,7 @@ This section describes how to install the plugin and get it working.
 = 0.2.2 =
 * `data/counts` endpoint added (moved from wc-api-dev)
 * `products/reviews` endpoint added (moved from wc-api-dev)
+* Sync currency info and update comment sync filter
 
 = 0.2.1 =
 * Fixed customizer tour

--- a/wc-calypso-bridge-class.php
+++ b/wc-calypso-bridge-class.php
@@ -7,7 +7,7 @@ class WC_Calypso_Bridge {
 	/**
 	 * Current version of the plugin.
 	 */
-	const CURRENT_VERSION = '0.2.1';
+	const CURRENT_VERSION = '0.2.2';
 
 	/**
 	 * Minimum woocommerce version needed to run this plugin.
@@ -81,6 +81,8 @@ class WC_Calypso_Bridge {
 		/** API includes */
 		include_once( dirname( __FILE__ ) . '/api/class-wc-calypso-bridge-send-invoice-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-calypso-bridge-settings-email-groups-controller.php' );
+		include_once( dirname( __FILE__ ) . '/api/class-wc-calypso-bridge-data-counts-controller.php' );
+		include_once( dirname( __FILE__ ) . '/api/class-wc-calypso-bridge-product-reviews-controller.php' );
 
 		if ( class_exists( 'MailChimp_Woocommerce' ) ) {
 			include_once( dirname( __FILE__ ) . '/api/class-wc-calypso-bridge-mailchimp-settings-controller.php' );
@@ -97,6 +99,8 @@ class WC_Calypso_Bridge {
 		$controllers = array(
 			'WC_Calypso_Bridge_Send_Invoice_Controller',
 			'WC_Calypso_Bridge_Settings_Email_Groups_Controller',
+			'WC_Calypso_Bridge_Data_Counts_Controller',
+			'WC_Calypso_Bridge_Product_Reviews_Controller',
 		);
 
 		if ( class_exists( 'MailChimp_Woocommerce' ) ) {

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 0.2.1
+ * Version: 0.2.2
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4


### PR DESCRIPTION
Partially fixes #49.

This PR adds the `/data/counts` and `/products/reviews` endpoints removed from `wc-api-dev`. They are still in use on Store on WP.com, so we need to keep them around.

This PR also bumps the version number.

To Test:
* Make sure you have at least one product review.
* Apply https://github.com/woocommerce/wc-api-dev/pull/112 and this branch.
* Upload [this helper plugin gist](https://gist.github.com/justinshreve/3c6494bdb7cd5e32da94c2379b6a65c8) as `debug-store-path-logging.php` and enable the plugin. 
* Using Postman, make a request to `/wc/v3/data/counts` and make sure you get a valid response back.
* View your debug log (either your PHP error log or the wpcom-store log under `WooCommerce > Status > Logs` which is useful on AT sites) and verify you see a line like `DEBUG /wp-json/wc/v3/data/counts executing from /path/to/wc-calypso-bridge/api/class-wc-calypso-bridge-data-counts-controller.php`.
* Using Postman, make a request to `/wc/v3/products/reviews` and make sure you get a valid response back.
* View your debug log and verify you see a line like `DEBUG /wp-json/wc/v3/products/reviews executing from /path/to/wc-calypso-bridge/api/class-wc-calypso-bridge-product-reviews-controller.php`.
* Using Postman, make a request to `/wc/v3/products/$product_id/reviews` and make sure you get a valid response back.
* View your debug log and verify you see a line like `DEBUG /wp-json/wc/v3/products/$product_id/reviews executing from /path/to/woocommerce/includes/api/class-wc-rest-product-reviews-controller.php`. **Note** that the plugin here is `woocommerce` instead of `wc-calypso-bridge`.
* Spot check these branches on Calypso: Make sure reviews load, and the counts in the sidebar load.
* Remove `debug-store-path-logging.php`.




