### PR TITLE
Update Jetpack Sync for currency info + new comment filter

### DIFF
--- a/inc/wc-calypso-bridge-jetpack-sync.php
+++ b/inc/wc-calypso-bridge-jetpack-sync.php
@@ -19,24 +19,25 @@ function wc_calypso_bridge_add_post_meta_whitelist( $list ) {
 	return array_merge( $list, $additional_meta );
 }
 
-add_filter( 'jetpack_sync_post_meta_whitelist', 'wc_calypso_bridge_add_post_meta_whitelist', 10 );
+add_filter( 'jetpack_sync_post_meta_whitelist', 'wc_calypso_bridge_add_post_meta_whitelist' );
 
-// There is no Jetpack sync filter for the comment meta whitelist like there is for postmeta
-// We can still hook into the return value of the option where the whitelist is stored.
-// @TODO We can update this when https://github.com/Automattic/jetpack/issues/8170 is resolved.
+function wc_calypso_bridge_add_options_whitelist( $list ) {
+	$additional_options = array(
+		'woocommerce_currency_pos',
+		'woocommerce_price_thousand_sep',
+		'woocommerce_price_decimal_sep',
+		'woocommerce_price_num_decimals',
+	);
+	return array_merge( $list, $additional_options );
+}
+
+add_filter( 'jetpack_sync_options_whitelist', 'wc_calypso_bridge_add_options_whitelist' );
+
 function wc_calypso_bridge_add_comment_meta_whitelist( $list ) {
-	if ( false === $list ) {
-		return false;
-	}
-
-	if ( ! is_array( $list ) ) {
-		return $list;
-	}
-
 	$additional_meta = array(
 		'rating',
 	);
 	return array_merge( $list, $additional_meta );
 }
 
-add_filter( 'option_jetpack_sync_settings_comment_meta_whitelist', 'wc_calypso_bridge_add_comment_meta_whitelist', 10 );
+add_filter( 'jetpack_sync_comment_meta_whitelist', 'wc_calypso_bridge_add_comment_meta_whitelist' );


### PR DESCRIPTION
@timmyc Earlier in the week I suggested updating the order notification to use a synced version of the currency position/etc.

This PR adds those options to the sync whitelist on the Jetpack side -- figured we would want to get that in if we are doing a release for the store endpoints.

We should be able to update your patch and use these on the .com side (We might still need to use `left/,/./2` as defaults for sites that haven't re-synced options yet).

It also updates the comment meta call to use the Jetpack filter added in 2.7 / December.

To Test:
* Point your Jetpack blog API base to your mapped WP.com blog ([see this gist](https://gist.github.com/justinshreve/48ad53e075884195a8f5f87f620ea368))
* Sandbox public-api.wordpress.com
* Post a product review as a logged out user and make sure you can see the rating in your notification
* Edit your local copy of `class.jetpack-sync-module-options.php` and add the following debug to `whitelist_options` -- right before `return $args`:
```
		$_test_wc_options = array( 'woocommerce_currency_pos', 'woocommerce_price_num_decimals', 'woocommerce_price_thousand_sep', 'woocommerce_price_decimal_sep' );
		if ( in_array( $args[0], $_test_wc_options ) ) {
			error_log( print_r( $args,1 ) );
		}
```
* Update one of these options via WooCommerce > Settings (They only sync on setting change or queued sync which happens on a delay), and confirm you see the white listed option pass all checks.