### PR TITLE
Disable publicize on API Product Create

### DIFF
--- a/inc/wc-calypso-bridge-disable-publicize.php
+++ b/inc/wc-calypso-bridge-disable-publicize.php
@@ -31,8 +31,8 @@ function wc_calypso_bridge_maybe_disable_publicize( $submit_post, $post_id, $ser
 			$should_disable_publicize = true;
 			break;
 		}
-	}
-
+    }
+    
     $post_type = get_post_type( $post_id );
 
 	// If not a product, or not a REST API request, return.

--- a/inc/wc-calypso-bridge-disable-publicize.php
+++ b/inc/wc-calypso-bridge-disable-publicize.php
@@ -23,12 +23,12 @@ add_action( 'publicize_save_meta', 'wc_calypso_bridge_maybe_disable_publicize', 
  */
 function wc_calypso_bridge_maybe_disable_publicize( $submit_post, $post_id, $service_name, $connection ) {
     $trigger_strings = array( '/wp-json/wc/v', '/?rest_route=%2Fwc%2Fv' );
-    $should_disable_publicize = false;
+    $is_rest_api_request = false;
 
     // Only run this logic on REST API requests
     foreach( $trigger_strings as $trigger_string ) {
         if ( false !== strpos( $_SERVER[ 'REQUEST_URI' ], $trigger_string ) ) {
-            $should_disable_publicize = true;
+            $is_rest_api_request = true;
             break;
         }
     }
@@ -36,13 +36,13 @@ function wc_calypso_bridge_maybe_disable_publicize( $submit_post, $post_id, $ser
     $post_type = get_post_type( $post_id );
 
     // If not a product, or not a REST API request, return.
-    if ( 'product' != $post_type || ! $should_disable_publicize ) {
+    if ( 'product' != $post_type || ! $is_rest_api_request ) {
         return;
     }
 
     // Since this is a product, and we are in an API request, disable publicize.
     if ( ! empty( $connection->unique_id ) ) {
-	    $unique_id = $connection->unique_id;
+        $unique_id = $connection->unique_id;
     } else if ( ! empty( $connection['connection_data']['token_id'] ) ) {
         $unique_id = $connection['connection_data']['token_id'];
     }

--- a/inc/wc-calypso-bridge-disable-publicize.php
+++ b/inc/wc-calypso-bridge-disable-publicize.php
@@ -22,21 +22,21 @@ add_action( 'publicize_save_meta', 'wc_calypso_bridge_maybe_disable_publicize', 
  * @param array $connection Array of connection details.
  */
 function wc_calypso_bridge_maybe_disable_publicize( $submit_post, $post_id, $service_name, $connection ) {
-	$trigger_strings = array( '/wp-json/wc/v', '/?rest_route=%2Fwc%2Fv' );
-	$should_disable_publicize = false;
+    $trigger_strings = array( '/wp-json/wc/v', '/?rest_route=%2Fwc%2Fv' );
+    $should_disable_publicize = false;
 
-	// Only run this logic on REST API requests
-	foreach( $trigger_strings as $trigger_string ) {
-		if ( false !== strpos( $_SERVER[ 'REQUEST_URI' ], $trigger_string ) ) {
-			$should_disable_publicize = true;
-			break;
-		}
+    // Only run this logic on REST API requests
+    foreach( $trigger_strings as $trigger_string ) {
+        if ( false !== strpos( $_SERVER[ 'REQUEST_URI' ], $trigger_string ) ) {
+            $should_disable_publicize = true;
+            break;
+        }
     }
     
     $post_type = get_post_type( $post_id );
 
-	// If not a product, or not a REST API request, return.
-	if ( 'product' != $post_type || ! $should_disable_publicize ) {
+    // If not a product, or not a REST API request, return.
+    if ( 'product' != $post_type || ! $should_disable_publicize ) {
         return;
     }
 

--- a/inc/wc-calypso-bridge-disable-publicize.php
+++ b/inc/wc-calypso-bridge-disable-publicize.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Disables publicize on API-created Products
+ *
+ * @since 0.2.3
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_action( 'publicize_save_meta', 'wc_calypso_bridge_maybe_disable_publicize', 10, 4 );
+
+/**
+ * Possibly Update post meta to disable publicize on Products
+ *
+ * @since 0.2.3
+ *
+ * @param bool $submit_post Should the post be publicized.
+ * @param int $post->ID Post ID.
+ * @param string $service_name Service name.
+ * @param array $connection Array of connection details.
+ */
+function wc_calypso_bridge_maybe_disable_publicize( $submit_post, $post_id, $service_name, $connection ) {
+	$trigger_strings = array( '/wp-json/wc/v', '/?rest_route=%2Fwc%2Fv' );
+	$should_disable_publicize = false;
+
+	// Only run this logic on REST API requests
+	foreach( $trigger_strings as $trigger_string ) {
+		if ( false !== strpos( $_SERVER[ 'REQUEST_URI' ], $trigger_string ) ) {
+			$should_disable_publicize = true;
+			break;
+		}
+	}
+
+    $post_type = get_post_type( $post_id );
+
+	// If not a product, or not a REST API request, return.
+	if ( 'product' != $post_type || ! $should_disable_publicize ) {
+        return;
+    }
+
+    // Since this is a product, and we are in an API request, disable publicize.
+    if ( ! empty( $connection->unique_id ) ) {
+	    $unique_id = $connection->unique_id;
+    } else if ( ! empty( $connection['connection_data']['token_id'] ) ) {
+        $unique_id = $connection['connection_data']['token_id'];
+    }
+
+    update_post_meta( $post_id, '_wpas_skip_' . $unique_id, 1 );
+}

--- a/wc-calypso-bridge-class.php
+++ b/wc-calypso-bridge-class.php
@@ -66,6 +66,7 @@ class WC_Calypso_Bridge {
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-add-bacs-accounts.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-allowed-redirect-hosts.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-cheque-defaults.php' );
+		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-disable-publicize.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-email-order-url.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-enable-auto-update-db.php' );
 		include_once( dirname( __FILE__ ) . '/inc/wc-calypso-bridge-hide-alerts.php' );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/19457

When creating a new product via Store on WordPress.com - any active publicize connections will publish the new product creation. Since we have no user interface in Store to select which connections to publicize too, this can come as quite a surprise that products are showing up on all configured publicize services.

To best test this PR, it might be nice to replicate the problem first:

__To Verify Bug__
- Setup a publicize connection on a Store ( i use a fake page on Facebook for testing )
- Create a product via Store on WPCOM
- Check the publicize service and see that your new product was published

__To Test The Fix__
- Install this branch on the same test site
- Also having `Post Meta Inspector` plugin installed is handy
- Take the same steps above, and verify the new product is not publicized
- Also inspect the post meta on the new product, and verify you see an entry like:

![meta-skip](https://user-images.githubusercontent.com/22080/41003116-b7703288-68ca-11e8-8b1b-27dba2badeab.png)

__Verify Publicize Still Works on non-API Products__
- Then create a product using wp-admin
- Make sure the publicize service is checked in the sidebar of the editor
- Verify the item is still publicized as expected after the product is published