### PR TITLE
Add page registration system and basic menu handling

### DIFF
--- a/includes/connect/core.php
+++ b/includes/connect/core.php
@@ -1,0 +1,135 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'edit-shop_coupon',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=shop_coupon',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'add-shop_coupon',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=shop_coupon',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'shop_coupon',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=shop_coupon',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'edit-shop_order',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=shop_order',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'add-shop_order',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=shop_order',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'shop_order',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=shop_order',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'edit-product',
+	'menu'      => 'edit.php?post_type=product',
+	'submenu'   => 'edit.php?post_type=product',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'add-product',
+	'menu'      => 'edit.php?post_type=product',
+	'submenu'   => 'post-new.php?post_type=product',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'product',
+	'menu'      => 'edit.php?post_type=product',
+	'submenu'   => 'edit.php?post_type=product',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-reports-orders',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-reports-customers',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-reports-stock',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-settings-general',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-settings-products',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-settings-shipping',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-settings-checkout',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-settings-account',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-settings-email',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-settings-advanced',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-status-status',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-status-tools',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-status-logs',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-status-action-scheduler',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-addons',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'product_page_product_attributes',
+	'menu'      => 'edit.php?post_type=product',
+	'submenu'   => 'edit-tags.php?taxonomy=product_cat&post_type=product',
+) );

--- a/includes/connect/mailchimp-for-woocommerce.php
+++ b/includes/connect/mailchimp-for-woocommerce.php
@@ -1,0 +1,5 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'toplevel_page_mailchimp-woocommerce',
+	'menu'      => 'mailchimp-woocommerce',
+) );

--- a/includes/menus.php
+++ b/includes/menus.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * WC_Calypso_Bridge_Menus.
+ * 
+ * Removes WooCommerce plugins/extensions from the main plugin management interface and puts them under a new 'Store' item.
+ *
+ * wc_calypso_bridge_connect_page, is_wc_calypso_bridge_page, wc_calypso_bridge_get_current_screen_id().
+ * 
+ */
+class WC_Calypso_Bridge_Menus {
+
+	static $instance = false;
+
+	public static function getInstance() {
+		if ( !self::$instance ) {
+			self::$instance = new self;
+		}
+		return self::$instance;
+	}
+
+	private function __construct() {
+		add_action( 'current_screen', array( $this, 'setup_menu_hooks' ), 20 );
+    }
+
+	/**
+	 * Hooks into WordPress to overtake the menu system on WooCommerce pages.
+	 */
+	public function setup_menu_hooks() {
+		// TODO, Figure out correct loading conditions. For now we will use the same user meta as calypsoify.
+		if ( 1 != (int) get_user_meta( get_current_user_id(), 'calypsoify', true ) ) {
+			return;
+		}
+
+		// TODO If any extensions add new pages to wp-admin's settings section, we will want to copy those over,
+		// just like Calypsoify does in `add_plugin_menus`.
+		$late_priority = PHP_INT_MAX;
+		if ( is_wc_calypso_bridge_page() ) {
+			add_action( 'in_admin_header', array( $this, 'insert_sidebar_html' ) );
+			remove_action( 'in_admin_header', array( Jetpack_Calypsoify::getInstance(), 'insert_sidebar_html' ) );
+
+			add_action( 'admin_head', array( $this, 'woocommerce_menu_handler' ), $late_priority );
+		} else {
+			add_action( 'admin_head', array( $this, 'calypsoify_menu_handler' ), $late_priority );
+		}
+	}
+
+	/**
+	 * Creates a top level "WooCommerce" Calypso item, so that users can easily navigate back to the real Calypso.
+	 *
+	 * TODO: Final naming on this (Store vs eCommerce vs WooCommerce)
+	 * TODO: id="calypso-woocommerce" instead, once we start loading some CSS.
+	 */
+	public function insert_sidebar_html() { ?>
+		<a href="<?php echo esc_url( 'https://wordpress.com/stats/day/' . Jetpack::build_raw_urls( home_url() ) ); ?>" id="calypso-sidebar-header">
+			<svg class="gridicon gridicons-chevron-left" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M14 20l-8-8 8-8 1.414 1.414L8.828 12l6.586 6.586"></path></g></svg>
+			<ul>
+			<li id="calypso-sitename"><?php bloginfo( 'name' ); ?></li>
+			<li id="calypso-plugins"><?php esc_html_e( 'WooCommerce' ); ?></li>
+			</ul>
+		</a>
+		<?php
+	}
+
+	/**
+	 * Updates the menu handling on WooCommerce pages to only show WooCommerce navigation.
+	 */
+	public function woocommerce_menu_handler() {
+		global $menu, $submenu;
+
+		$wc_menus = wc_calypso_bridge_menu_slugs();
+
+		foreach ( $menu as $menu_key => $menu_item ) {
+			if ( ! in_array( $menu_item[2], $wc_menus ) ) {
+				unset( $menu[ $menu_key ] );
+			}
+		}
+		
+	}
+
+	/**
+	 * Updates the menu handling on Calypsoified pages to only show plugin navigation.
+	 */
+	public function calypsoify_menu_handler() {
+		global $menu, $submenu;
+
+		$wc_menus = wc_calypso_bridge_menu_slugs();
+
+		foreach ( $menu as $menu_key => $menu_item ) {
+			if ( in_array( $menu_item[2], $wc_menus ) ) {
+				unset( $menu[ $menu_key ] );
+			}
+		}
+	}
+}
+
+$WC_Calypso_Bridge_Menus = WC_Calypso_Bridge_Menus::getInstance();

--- a/includes/menus.php
+++ b/includes/menus.php
@@ -19,8 +19,11 @@ class WC_Calypso_Bridge_Menus {
 	}
 
 	private function __construct() {
-		add_action( 'current_screen', array( $this, 'setup_menu_hooks' ), 20 );
-    }
+		add_action( 'current_screen', array( $this, 'setup_menu_hooks' ) );
+	}
+
+	// TODO If any extensions add new pages to wp-admin's settings section, we will want to copy those over,
+	// just like Calypsoify does in `add_plugin_menus`.
 
 	/**
 	 * Hooks into WordPress to overtake the menu system on WooCommerce pages.
@@ -31,16 +34,15 @@ class WC_Calypso_Bridge_Menus {
 			return;
 		}
 
-		// TODO If any extensions add new pages to wp-admin's settings section, we will want to copy those over,
-		// just like Calypsoify does in `add_plugin_menus`.
-		$late_priority = PHP_INT_MAX;
+		//  We want the menu handler hooks to run late, so that other plugins hooking in here can make changes first.
+		$late_priority = 1000;
 		if ( is_wc_calypso_bridge_page() ) {
 			add_action( 'in_admin_header', array( $this, 'insert_sidebar_html' ) );
 			remove_action( 'in_admin_header', array( Jetpack_Calypsoify::getInstance(), 'insert_sidebar_html' ) );
 
-			add_action( 'admin_head', array( $this, 'woocommerce_menu_handler' ), $late_priority );
+			add_action( 'admin_head', array( $this, 'woocommerce_menu_handler' ) );
 		} else {
-			add_action( 'admin_head', array( $this, 'calypsoify_menu_handler' ), $late_priority );
+			add_action( 'admin_head', array( $this, 'calypsoify_menu_handler' ) );
 		}
 	}
 

--- a/includes/page-controller.php
+++ b/includes/page-controller.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Returns the current screen ID.
+ * This is different from WP's get_current_screen, in that it attaches an action,
+ * so certain pages like 'add new' pages can have different screen ids & handling.
+ * It also catches some more unique dynamic pages like taxonomy/attribute management.
+ *
+ * Format: {$current_screen->action}-{$current_screen->id}-$tab,
+ * {$current_screen->action}-{$current_screen->id} if no tab is present,
+ * or just {$current_screen->id} if no action or tab is present.
+ *
+ * @return string Current screen ID.
+ */
+function wc_calypso_bridge_get_current_screen_id() {
+	$current_screen = get_current_screen();
+
+	if ( ! $current_screen ) {
+		return false;
+	}
+	$current_screen_id = $current_screen->action ? $current_screen->action . '-' . $current_screen->id : $current_screen->id;
+	if ( ! empty( $_GET['taxonomy' ] ) && ! empty( $_GET['post_type'] ) && 'product' === $_GET['post_type'] ) {
+		$current_screen_id = 'product_page_product_attributes';
+	}
+	// Default tabs
+	$pages_with_tabs = apply_filters( 'wc_calypso_bridge_pages_with-tabs', array(
+		'wc-reports'  => 'orders',
+		'wc-settings' => 'general',
+		'wc-status'   => 'status',
+	) );
+	if ( ! empty( $_GET['page' ] ) ) {
+		if ( in_array( $_GET['page'], array_keys( $pages_with_tabs ) ) ) {
+			if ( ! empty( $_GET['tab'] ) ) {
+				$tab = $_GET['tab'];
+			} else {
+				$tab = $pages_with_tabs[ $_GET['page'] ];
+			}
+			$current_screen_id = $current_screen_id . '-' . $tab;
+		}
+	}
+	return $current_screen_id;
+}
+
+/**
+ * Connects a wp-admin page to a Calypso WooCommerce page.
+ * The page will no longer be shown in the Calypsoified plugins section and will instead
+ * show up under Store/WooCommerce
+ * 
+ * They will also get Calypsoified styles.
+ *
+ * @param array $options {
+ *	 Array describing the page.
+ *
+ *   @type string      menu         wp-admin menu id/path.
+ *   @type string      submenu      wp-admin submenu id/path.
+ *   @type string      screen_id    WooCommerce screen ID (`wc_calypso_bridge_get_current_screen_id()`). Used for correctly identifying which pages are WooCommerce pages.
+ * }
+ */
+function wc_calypso_bridge_connect_page( $options ) {
+	$defaults = array(
+		'menu' => '',
+	);
+	$options = wp_parse_args( $options, $defaults );
+
+	$WC_Admin_Page_Controller = WC_Calypso_Bridge_Page_Controller::getInstance();
+
+	if ( ! empty( $options['menu'] ) ) {
+		$WC_Admin_Page_Controller->register_menu( $options );
+	}
+
+	$WC_Admin_Page_Controller->register_page( $options );
+}
+
+/**
+ * Returns if we are on a WooCOmmerce related admin page.
+ *
+ * @return bool True if this is a WooCommerce admin page. False otherwise.
+ */
+function is_wc_calypso_bridge_page() {
+	$controller         = WC_Calypso_Bridge_Page_Controller::getInstance();
+	$pages              = $controller->get_registered_pages();
+	$screen_id          = wc_calypso_bridge_get_current_screen_id();
+	$is_registered_page = false;
+ 	foreach ( $pages as $page ) {
+		if ( $screen_id === $page['screen_id' ] ) {
+			$is_registered_page = true;
+			break;
+		}
+	}
+ 	return $is_registered_page;
+}
+
+/**
+ * Returns an array of wp-admin menu slugs that are registered as woocommerce menu items.
+ *
+ * @return bool True if this is a WooCommerce admin page. False otherwise.
+ */
+function wc_calypso_bridge_menu_slugs() {
+	$controller       = WC_Calypso_Bridge_Page_Controller::getInstance();
+	$registered_menus = $controller->get_registered_menus();
+
+	$wc_menus = array();
+	foreach ( $registered_menus as $registered_menu ) {
+		if ( ! empty( $registered_menu['menu'] ) ) {
+			$wc_menus[] = $registered_menu['menu'];
+		}
+	}
+
+	return $wc_menus;
+}
+
+/**
+ * WC_Calypso_Bridge_Page_Controller.
+ * 
+ * Manages all of the admin pages that make up WooCommerce + WooCommerce Extensions
+ * This includes registering support  and menu handlig.
+ * Generally, the class is not used directly. The following helper functions can be used instead:
+ *
+ * wc_calypso_bridge_connect_page, is_wc_calypso_bridge_page, wc_calypso_bridge_get_current_screen_id().
+ * 
+ */
+class WC_Calypso_Bridge_Page_Controller {
+	static $instance = false;
+
+	/**
+	 * Menu items.
+	 */
+	private $menus = array();
+
+	/**
+	 * Registered pages
+	 * Contains information (breadcrumbs, menu info) about JS powered pages and classic WooCommerce pages.
+	 */
+	private $pages = array();
+		
+	/**
+	 * We want a single instance of this class so we can accurately track registered menus and pages.
+	 */
+	public static function getInstance() {
+		if ( !self::$instance ) {
+			self::$instance = new self;
+		}
+		return self::$instance;
+	}
+ 
+ 	/**
+	 * Registers a menu item.
+	 * @param array $options. Array describing the menu. See wc_calypso_bridge_connect_page.
+	 */
+	public function register_menu( $options ) {
+		global $menu, $submenu;
+		$this->menus[] = $options;
+		$this->id_mapping_to_path[ $options['id' ] ] = $options['path'];
+	}
+	/**
+	 * Registers a page.
+	 *
+	 * @param array $options. Array describing the page. See wc_calypso_bridge_connect_page.
+	 */
+	public function register_page( $options ) {
+		$this->pages[] = $options;
+	}
+	/**
+	 * Returns an array of registered WooCommerce pages.
+	 *
+	 * @return array Array of registered pages.
+	 */
+	public function get_registered_pages() {
+		return $this->pages;
+	}
+	/**
+	 * Returns an array of registered WooCommerce menus.
+	 *
+	 * @return array Array of registered menus.
+	 */
+	public function get_registered_menus() {
+		return $this->menus;
+	}
+	/**
+	 * Returns an array of path to ID maps.
+	 *
+	 * @return array Array paths to ids.
+	 */
+	public function get_path_to_id_mapping() {
+		return array_flip( $this->id_mapping_to_path );
+	}
+}
+
+$WC_Calypso_Bridge_Page_Controller = WC_Calypso_Bridge_Page_Controller::getInstance();

--- a/includes/page-controller.php
+++ b/includes/page-controller.php
@@ -71,7 +71,7 @@ function wc_calypso_bridge_connect_page( $options ) {
 }
 
 /**
- * Returns if we are on a WooCOmmerce related admin page.
+ * Returns if we are on a WooCommerce related admin page.
  *
  * @return bool True if this is a WooCommerce admin page. False otherwise.
  */

--- a/wc-calypso-bridge-class.php
+++ b/wc-calypso-bridge-class.php
@@ -18,8 +18,21 @@ class WC_Calypso_Bridge {
 	 * Constructor.
 	 */
 	public function __construct() {
-		//add_action( 'woocommerce_init', array( $this, 'init' ), 20 );
-    }
+		$this->includes();
+	}
+
+	/**
+	 * Loads required functionality, classes, and API endpoints.
+	 */
+	private function includes() {
+		include_once( dirname( __FILE__ ) . '/includes/page-controller.php' );
+		include_once( dirname( __FILE__ ) . '/includes/menus.php' );
+
+		$connect_files = glob( dirname( __FILE__ ) . '/includes/connect/*.php' );
+		foreach ( $connect_files as $connect_file ) {
+			include_once( $connect_file );
+		}
+	}
 
 	/**
 	 * Class instance.


### PR DESCRIPTION
Per p90Yrv-OY-p2, this PR adds a page registration system similar to the one we might end up using in the wc-admin project. It allows for easily connecting a screen to 'WooCommerce' so the correct pages/menu items can be determined. 

Right now, these definitions are prefixed with `wc_calypso_bridge_`. Luckily, they follow the format I am proposing for wc-admin, so we should be able to take any definitions we write for this project and rename them to work with wc-admin.

This PR registers all core pages, and the Mailchimp extension to show how this works for extensions.

To Test:
* Install the MailChimp plugin (https://woocommerce.com/products/mailchimp-for-woocommerce/)
* Setup Jetpack Calypsoify (https://github.com/Automattic/jetpack/pull/10200)
* Visit `/wp-admin/plugins.php?calypsoify=1` to activate Calypsoify.
* Verify that the plugins management page does not show WooCommerce or MailChimp.
* Go to `/wp-admin/edit.php?post_type=shop_order` and verify that you only see `WooCommerce`, `Products`, and `MailChimp` as menu items. Verify you see "< WooCommerce" instead of "< Plugins" on these pages.
* Click around a few pages and verify the navigation for WC stays consistent.

<img width="638" alt="screen shot 2018-10-16 at 11 53 16 am" src="https://user-images.githubusercontent.com/689165/47031212-6c995b00-d13d-11e8-94d9-5fdbe34a418e.png">

<img width="1077" alt="screen shot 2018-10-16 at 11 53 22 am" src="https://user-images.githubusercontent.com/689165/47031222-70c57880-d13d-11e8-83d3-ab675d09498b.png">
