### PR TITLE
Register support for extensions (batch 1)

### DIFF
--- a/includes/connect/core.php
+++ b/includes/connect/core.php
@@ -138,3 +138,13 @@ wc_calypso_bridge_connect_page( array(
 	'screen_id' => 'woocommerce_page_wc-settings-integration',
 	'menu'      => 'woocommerce',
 ) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-reports-taxes',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-settings-tax',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/connect/woocommerce-bookings.php
+++ b/includes/connect/woocommerce-bookings.php
@@ -1,0 +1,50 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'edit-wc_booking',
+	'menu'      => 'edit.php?post_type=wc_booking',
+	'submenu'   => 'edit.php?post_type=wc_booking',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'wc_booking_page_create_booking',
+	'menu'      => 'edit.php?post_type=wc_booking',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'edit-bookable_resource',
+	'menu'      => 'edit.php?post_type=wc_booking',
+	'submenu'   => 'edit.php?post_type=bookable_resource',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'add-bookable_resource',
+	'menu'      => 'edit.php?post_type=wc_booking',
+	'submenu'   => 'edit.php?post_type=bookable_resource',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'bookable_resource',
+	'menu'      => 'edit.php?post_type=wc_booking',
+	'submenu'   => 'edit.php?post_type=bookable_resource',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'wc_booking_page_booking_calendar',
+	'menu'      => 'edit.php?post_type=wc_booking',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'wc_booking_page_booking_notification',
+	'menu'      => 'edit.php?post_type=wc_booking',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'wc_booking_page_wc_bookings_global_availability',
+	'menu'      => 'edit.php?post_type=wc_booking',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'wc_booking',
+	'menu'      => 'edit.php?post_type=wc_booking',
+	'submenu'   => 'edit.php?post_type=wc_booking',
+) );

--- a/includes/connect/woocommerce-checkout-field-editor.php
+++ b/includes/connect/woocommerce-checkout-field-editor.php
@@ -1,0 +1,5 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_checkout_field_editor',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/connect/woocommerce-conditional-shipping-and-payments.php
+++ b/includes/connect/woocommerce-conditional-shipping-and-payments.php
@@ -1,0 +1,5 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-settings-restrictions',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/connect/woocommerce-customer-order-csv-export.php
+++ b/includes/connect/woocommerce-customer-order-csv-export.php
@@ -1,0 +1,5 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc_customer_order_csv_export',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/connect/woocommerce-deposits.php
+++ b/includes/connect/woocommerce-deposits.php
@@ -1,0 +1,5 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'product_page_deposit_payment_plans',
+	'menu'      => 'edit.php?post_type=product',
+) );

--- a/includes/connect/woocommerce-dynamic-pricing.php
+++ b/includes/connect/woocommerce-dynamic-pricing.php
@@ -1,0 +1,5 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc_dynamic_pricing',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/connect/woocommerce-follow-up-emails.php
+++ b/includes/connect/woocommerce-follow-up-emails.php
@@ -1,0 +1,56 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'toplevel_page_followup-emails',
+	'menu'      => 'followup-emails',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'edit-follow_up_email_campaign',
+	'menu'      => 'followup-emails',
+	'submenu'   => 'fue_campaigns',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'add-follow_up_email',
+	'menu'      => 'followup-emails',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'follow_up_email',
+	'menu'      => 'followup-emails',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'follow-up_page_followup-emails-reports',
+	'menu'      => 'followup-emails',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'follow-up_page_followup-emails-reports-customers',
+	'menu'      => 'followup-emails',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'follow-up_page_followup-emails-coupons',
+	'menu'      => 'followup-emails',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'follow-up_page_followup-emails-queue',
+	'menu'      => 'followup-emails',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'follow-up_page_followup-emails-subscribers',
+	'menu'      => 'followup-emails',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'follow-up_page_followup-emails-templates',
+	'menu'      => 'followup-emails',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'follow-up_page_followup-emails-settings',
+	'menu'      => 'followup-emails',
+) );

--- a/includes/connect/woocommerce-memberships.php
+++ b/includes/connect/woocommerce-memberships.php
@@ -1,0 +1,47 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'wc_membership_plan',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=wc_membership_plan',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'admin_page_wc_memberships_import_export',
+	'menu'      => '',
+	'submenu'   => 'edit.php?post_type=wc_user_membership',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'edit-wc_membership_plan',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=wc_membership_plan',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'add-wc_membership_plan',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=wc_membership_plan',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'edit-wc_user_membership',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=wc_user_membership',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'add-wc_user_membership',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=wc_user_membership',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'wc_user_membership',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=wc_user_membership',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-settings-memberships',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/connect/woocommerce-pip.php
+++ b/includes/connect/woocommerce-pip.php
@@ -1,0 +1,5 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-settings-pip',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/connect/woocommerce-product-feeds.php
+++ b/includes/connect/woocommerce-product-feeds.php
@@ -1,0 +1,5 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-settings-gpf',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/connect/woocommerce-services.php
+++ b/includes/connect/woocommerce-services.php
@@ -3,3 +3,8 @@ wc_calypso_bridge_connect_page( array(
 	'screen_id' => 'woocommerce_page_wc-status-connect',
 	'menu'      => 'woocommerce',
 ) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-reports-wcs_labels',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/connect/woocommerce-smart-coupons.php
+++ b/includes/connect/woocommerce-smart-coupons.php
@@ -1,0 +1,15 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_sc-about',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-settings-wc-smart-coupons',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-smart-coupons',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/connect/woocommerce-subscriptions.php
+++ b/includes/connect/woocommerce-subscriptions.php
@@ -1,0 +1,28 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'edit-shop_subscription',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=shop_subscription',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-settings-subscriptions',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'add-shop_subscription',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=shop_subscription',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'shop_subscription',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=shop_subscription',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-reports-subscriptions',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/connect/woocommerce-zapier.php
+++ b/includes/connect/woocommerce-zapier.php
@@ -1,0 +1,18 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'edit-wc_zapier_feed',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=wc_zapier_feed',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'add-wc_zapier_feed',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=wc_zapier_feed',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'wc_zapier_feed',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=wc_zapier_feed',
+) );


### PR DESCRIPTION
This PR adds extension support for 25 more extensions. See #63. See p90Yrv-Po-p2.

Extensions Tested:
- google-product-feed
- authorize-net-aim
- dynamic-pricing
- subscriptions
- deposits
- conditional-shipping-and-payments
- product-bundles
- checkout-field-editor
- follow-up-emails
- paypal-pro
- zapier
- smart-coupons
- composite-products
- gravity-forms-add-ons
- print-invoices-packing-lists
- shipment-tracking
- shipstation-integration
- table-rate-shipping
- fedex-shipping-module
- pay-with-amazon
- authorize-net-cim
- avatax
- bookings
- memberships
- ordercustomer-csv-export

<img width="294" alt="screen shot 2018-10-19 at 1 28 19 pm" src="https://user-images.githubusercontent.com/689165/47234163-e7af7b00-d3a2-11e8-921d-d0c16f256361.png">

To Test:

* Install some (or all) of these extensions and verify they show up in the right section.