### PR TITLE
Register support for extensions (batch 2)

### DIFF
--- a/includes/connect/woocommerce-avatax.php
+++ b/includes/connect/woocommerce-avatax.php
@@ -1,0 +1,5 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-settings-avatax-landed-cost',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/connect/woocommerce-catalog-visibility-options.php
+++ b/includes/connect/woocommerce-catalog-visibility-options.php
@@ -1,0 +1,5 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-settings-visibility_options',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/connect/woocommerce-checkout-add-ons.php
+++ b/includes/connect/woocommerce-checkout-add-ons.php
@@ -1,0 +1,5 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc_checkout_add_ons',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/connect/woocommerce-cost-of-goods.php
+++ b/includes/connect/woocommerce-cost-of-goods.php
@@ -1,0 +1,5 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-reports-profit',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/connect/woocommerce-customer-order-csv-import.php
+++ b/includes/connect/woocommerce-customer-order-csv-import.php
@@ -1,0 +1,21 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_csv_import_suite',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'importer_woocommerce_coupon_csv',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'importer_woocommerce_customer_csv',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'importer_woocommerce_order_csv',
+	'menu'      => 'tools.php',
+	'submenu'   => 'import.php',
+) );

--- a/includes/connect/woocommerce-name-your-price.php
+++ b/includes/connect/woocommerce-name-your-price.php
@@ -1,0 +1,5 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-settings-nyp',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/connect/woocommerce-order-status-manager.php
+++ b/includes/connect/woocommerce-order-status-manager.php
@@ -1,0 +1,36 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'edit-wc_order_status',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'wc-settings',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'wc_order_status',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'wc-settings',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'edit-wc_order_email',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'wc-settings',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'add-wc_order_status',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'wc-settings',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'add-wc_order_email',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'wc-settings',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'wc_order_email',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'wc-settings',
+) );

--- a/includes/connect/woocommerce-points-and-rewards.php
+++ b/includes/connect/woocommerce-points-and-rewards.php
@@ -1,0 +1,5 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_woocommerce-points-and-rewards',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/connect/woocommerce-pre-orders.php
+++ b/includes/connect/woocommerce-pre-orders.php
@@ -1,0 +1,10 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc_pre_orders',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-settings-pre_orders',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/connect/woocommerce-product-csv-import-suite.php
+++ b/includes/connect/woocommerce-product-csv-import-suite.php
@@ -1,0 +1,5 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_woocommerce_csv_import_suite',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/connect/woocommerce-product-search.php
+++ b/includes/connect/woocommerce-product-search.php
@@ -1,0 +1,10 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-settings-product-search',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-reports-search',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/connect/woocommerce-product-vendors.php
+++ b/includes/connect/woocommerce-product-vendors.php
@@ -1,0 +1,16 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'toplevel_page_wcpv-commissions',
+	'menu'      => 'wcpv-commissions',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-reports-vendors',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'product_page_product_attributes',
+	'menu'      => 'edit.php?post_type=product',
+	'submenu'   => 'edit-tags.php?taxonomy=wcpv_product_vendors&post_type=product',
+) );

--- a/includes/connect/woocommerce-shipping-local-pickup-plus.php
+++ b/includes/connect/woocommerce-shipping-local-pickup-plus.php
@@ -1,0 +1,30 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'edit-wc_pickup_location',
+	'menu'      => 'edit.php?post_type=wc_pickup_location',
+	'submenu'   => 'admin.php?page=wc-settings&tab=shipping&section=local_pickup_plus',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'add-wc_pickup_location',
+	'menu'      => 'edit.php?post_type=wc_pickup_location',
+	'submenu'   => 'admin.php?page=wc-settings&tab=shipping&section=local_pickup_plus',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'wc_pickup_location',
+	'menu'      => 'edit.php?post_type=wc_pickup_location',
+	'submenu'   => 'admin.php?page=wc-settings&tab=shipping&section=local_pickup_plus',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'admin_page_wc_local_pickup_plus_import',
+	'menu'      => '',
+	'submenu'   => 'admin.php?page=wc-settings&tab=shipping&section=local_pickup_plus',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'admin_page_wc_local_pickup_plus_export',
+	'menu'      => '',
+	'submenu'   => 'admin.php?page=wc-settings&tab=shipping&section=local_pickup_plus',
+) );

--- a/includes/connect/woocommerce-social-login.php
+++ b/includes/connect/woocommerce-social-login.php
@@ -1,0 +1,5 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-settings-social_login',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/connect/woocommerce-xero.php
+++ b/includes/connect/woocommerce-xero.php
@@ -1,0 +1,5 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_woocommerce_xero',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/page-controller.php
+++ b/includes/page-controller.php
@@ -37,6 +37,13 @@ function wc_calypso_bridge_get_current_screen_id() {
 			$current_screen_id = $current_screen_id . '-' . $tab;
 		}
 	}
+
+	$allowed_importers = array( 'woocommerce_coupon_csv', 'woocommerce_customer_csv', 'woocommerce_order_csv' );
+
+	if ( ! empty( $_GET['import'] ) && in_array( $_GET['import'], $allowed_importers ) ) {
+		return 'importer_' . $_GET['import'];
+	}
+
 	return $current_screen_id;
 }
 


### PR DESCRIPTION
This PR adds extension support for 24 more extensions. See #63. p90Yrv-Po-p2.

Extensions Tested:

- customerorder-csv-import-suite 
- product-search 
- product-vendors 
- measurement-price-calculator 
- one-page-checkout 
- name-your-price 
- order-status-manager 
- cost-of-goods
- checkout-add-ons 
- variation-swatches-and-photos 
- google-analytics-pro 
- pre-orders 
- local-pickup-plus 
- per-product-shipping 
- minmax-quantities 
- points-and-rewards 
- sequential-order-numbers-pro 
- product-csv-import-suite 
- xero 
- intuit-qbms 
- social-login 
- worldpay 
- catalog-visibility-options 
- firstdata 

To Test:

Install some (or all) of these extensions and verify they show up in the right section.