### PR TITLE
Add setup class and remove unused steps

### DIFF
--- a/includes/setup.php
+++ b/includes/setup.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * WC_Calypso_Bridge_Setup.
+ * 
+ * Adds the functionality needed to bridge the WooCommerce onboarding wizard.
+ */
+class WC_Calypso_Bridge_Setup {
+
+    /**
+	 * Class instance.
+	 */
+    static $instance = false;
+
+	public static function getInstance() {
+		if ( !self::$instance ) {
+			self::$instance = new self;
+		}
+		return self::$instance;
+	}
+
+    /**
+	 * Constructor.
+	 */
+    private function __construct() {
+		add_filter( 'woocommerce_setup_wizard_steps', array( $this, 'remove_unused_steps' ) );
+    }
+    
+    /**
+     * Remove unused steps from the wizard
+     * 
+     * @param array $default_steps Default steps used by WC wizard
+     * @return array
+     */
+    public function remove_unused_steps( $default_steps ) {
+        $whitelist = array( 'store_setup', 'payment' );
+        $steps = array_intersect_key( $default_steps, array_flip( $whitelist ) );
+        return $steps;
+    }
+
+}
+
+$WC_Calypso_Bridge_Setup = WC_Calypso_Bridge_Setup::getInstance();

--- a/store-on-wpcom/inc/wc-calypso-bridge-mailchimp-add-settings-error.php
+++ b/store-on-wpcom/inc/wc-calypso-bridge-mailchimp-add-settings-error.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * add_settings_error is only available in UI contecext
+ * adding a mock version to prevent API failures
+ *
+ * @since 0.1.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+//TODO:
+//  - use this function to capture messages and feed them back to Calypso on return from API.
+
+// Parts of the MailChimp plugin reused for REST response purpose are signaling to the user via UI
+// that the information he has provided are not correct - this happens for example when some fields
+// are missing in the form user should fill in. It is done via add_settings_error.
+// This function is part of UI and within REST rest_api_ini it is not available - which makes sense
+// because REST has nothing to do with UI. Missing function was causing fata errors.
+// Loading template.php is not an option bacause it would significantly slow down the response.
+// The solution is to have dummy add_settings_error available only in REST context
+
+if ( ! function_exists( 'add_settings_error' ) && defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+	function add_settings_error( $setting, $code, $message, $type = 'error' ) {}
+}

--- a/wc-calypso-bridge-class.php
+++ b/wc-calypso-bridge-class.php
@@ -27,6 +27,7 @@ class WC_Calypso_Bridge {
 	private function includes() {
 		include_once( dirname( __FILE__ ) . '/includes/page-controller.php' );
 		include_once( dirname( __FILE__ ) . '/includes/menus.php' );
+		include_once( dirname( __FILE__ ) . '/includes/setup.php' );
 
 		$connect_files = glob( dirname( __FILE__ ) . '/includes/connect/*.php' );
 		foreach ( $connect_files as $connect_file ) {


### PR DESCRIPTION
Fixes #68 

This PR adds a setup class that we'll need to continue modifying the setup wizard going forward as well as removes the unused steps in the wizard.

### Screenshots

<img width="799" alt="screen shot 2018-10-22 at 3 29 30 pm" src="https://user-images.githubusercontent.com/10561050/47317539-74f70780-d60f-11e8-9474-b6a73a8bba3d.png">

### Testing

1.  Visit `/wp-admin/admin.php?page=wc-setup`
2.  Confirm that unused steps are not present and only 2 steps remain.