### PR TITLE
Add final batch of extensions

### DIFF
--- a/includes/connect/woocommerce-box-office.php
+++ b/includes/connect/woocommerce-box-office.php
@@ -1,0 +1,22 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'event_ticket_page_ticket_tools',
+	'menu'      => 'edit.php?post_type=event_ticket',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'event_ticket_page_create_ticket',
+	'menu'      => 'edit.php?post_type=event_ticket',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'edit-event_ticket',
+	'menu'      => 'edit.php?post_type=event_ticket',
+	'submenu'   => 'edit.php?post_type=event_ticket',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'event_ticket',
+	'menu'      => 'edit.php?post_type=event_ticket',
+	'submenu'   => 'edit.php?post_type=event_ticket',
+) );

--- a/includes/connect/woocommerce-lightspeed-pos.php
+++ b/includes/connect/woocommerce-lightspeed-pos.php
@@ -1,0 +1,5 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_lightspeed-import-page',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/connect/woocommerce-pdf-invoice.php
+++ b/includes/connect/woocommerce-pdf-invoice.php
@@ -1,0 +1,5 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_woocommerce_pdf',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/connect/woocommerce-pdf-product-vouchers.php
+++ b/includes/connect/woocommerce-pdf-product-vouchers.php
@@ -1,0 +1,24 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'edit-wc_voucher',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=wc_voucher',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'edit-wc_voucher_template',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=wc_voucher',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'add-wc_voucher',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=wc_voucher',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'wc_voucher',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=wc_voucher',
+) );

--- a/includes/connect/woocommerce-shipping-stamps.php
+++ b/includes/connect/woocommerce-shipping-stamps.php
@@ -1,0 +1,5 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-settings-stamps',
+	'menu'      => 'woocommerce',
+) );

--- a/includes/connect/woocommerce-tab-manager.php
+++ b/includes/connect/woocommerce-tab-manager.php
@@ -1,0 +1,24 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'edit-wc_product_tab',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=wc_product_tab',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'add-wc_product_tab',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=wc_product_tab',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'wc_product_tab',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=wc_product_tab',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'admin_page_tab_manager',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=wc_product_tab',
+) );

--- a/includes/connect/woocommerce-wishlists.php
+++ b/includes/connect/woocommerce-wishlists.php
@@ -1,0 +1,17 @@
+<?php
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'woocommerce_page_wc-settings-wc_wishlists',
+	'menu'      => 'woocommerce',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'edit-wishlist',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=wishlist',
+) );
+
+wc_calypso_bridge_connect_page( array(
+	'screen_id' => 'wishlist',
+	'menu'      => 'woocommerce',
+	'submenu'   => 'edit.php?post_type=wishlist',
+) );


### PR DESCRIPTION
This PR adds extension support for 20 more extensions. See #63. p90Yrv-Po-p2.

Extensions Tested:

- tab-manager
- mix-and-match-products
- gateway-paypal-pro-hosted
- realex-redirect-payment-gateway
- product-reviews-pro
- lightspeed-pos
- box-office
- waitlist
- moneris-gateway
- gateway-affirm
- url-coupons
- sage-pay-form
- wishlists
- order-status-control
- shipping-stamps
- gateway-paypal-powered-by-braintree
- pdf-product-vouchers
- elavon-vm-payment-gateway
- amazon-fulfillment
- pdf-invoices- tab-manager
- mix-and-match-products
- gateway-paypal-pro-hosted
- realex-redirect-payment-gateway
- product-reviews-pro
- lightspeed-pos
- box-office
- waitlist
- moneris-gateway
- gateway-affirm
- url-coupons
- sage-pay-form
- wishlists
- order-status-control
- shipping-stamps
- gateway-paypal-powered-by-braintree
- pdf-product-vouchers
- elavon-vm-payment-gateway
- amazon-fulfillment
- pdf-invoices

To Test:

Install some (or all) of these extensions and verify they show up in the right section.