### PR TITLE
Add WC bridge calypsoify stylesheet

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1,0 +1,3 @@
+/**
+ * Styles to override Jetpack Calypsoify styles for OBW
+ */

--- a/wc-calypso-bridge-class.php
+++ b/wc-calypso-bridge-class.php
@@ -19,6 +19,7 @@ class WC_Calypso_Bridge {
 	 */
 	public function __construct() {
 		$this->includes();
+		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_calypsoify_styles' ) );
 	}
 
 	/**
@@ -51,6 +52,16 @@ class WC_Calypso_Bridge {
 		}
 
 		return self::$instance;
+	}
+
+	/**
+	 * Add calypsoify styles if calypsoify is enabled
+	 */
+	public function possibly_add_calypsoify_styles() {
+		if ( 1 == (int) get_user_meta( get_current_user_id(), 'calypsoify', true ) ) {
+			$asset_path = WC_Calypso_Bridge::$plugin_asset_path ? WC_Calypso_Bridge::$plugin_asset_path : WC_Calypso_Bridge::MU_PLUGIN_ASSET_PATH;
+			wp_enqueue_style( 'wc-calypso-bridge-calypsoify', $asset_path . 'assets/css/calypsoify.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION, 'all' );
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #71 

Adds a stylesheet for our own calypsoify style overrides if the calypsoify query param is passed.  This stylesheet will also enqueued during the OBW once #73 is merged.

### Testing

1.  Add the `calypsoify=1` query param to the URL.
2.  Verify that `/wp-content/plugins/wc-calypso-bridge/assets/css/calypsoify.css?ver=1.0.0` is loaded on the page.