### PR TITLE
Fix design issues with core

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1,0 +1,84 @@
+/**
+ * Styles to override Jetpack Calypsoify styles for OBW and some WooCommerce screens
+ */
+ 
+/* Updates purple notice color to green */
+div.woocommerce-message, .wc-helper .start-container {
+	border-left-color: #46b450 !important;
+}
+
+/* Adds padding between pagination and the table of items on management screens */
+.tablenav .tablenav-pages {
+	margin-bottom: 8px;
+}
+
+/* Update purple buttons to Calypso primary colors */
+.woocommerce-BlankState a.button-primary,
+.wc_addons_wrap .addons-button-solid,
+.woocommerce-BlankState a.button-primary:hover,
+.wc-helper .button,
+.wc-helper .button:hover {
+	background: #00aadc;
+	border-color: #008ab3;
+	text-shadow: none;
+	box-shadow: none;
+	border-width: 1px;
+	border-style: solid;
+}
+
+.woocommerce-BlankState a.button-primary:hover,
+.wc_addons_wrap .addons-button-solid:hover,
+.wc-helper .button:hover {
+	border-color: #005082;
+	opacity: 1;
+}
+
+.wc-helper .button,
+.wc-helper .button:hover {
+	height: 38px;
+}
+
+.subscriptions-header .button {
+	height: 30px;
+	color: #fff;
+	opacity: 1;
+}
+
+.subscriptions-header .button:hover {
+	height: 30px;
+	color: #fff;
+}
+
+/* White background behind the WooCommerce helper extensions navigation */
+.subscription-filter {
+	margin: 10px 0 25px;
+	background: #fff;
+	border: 1px solid rgba(200,215,225,0.5);
+	width: 100%;
+	box-shadow: none;
+	list-style: none;
+	padding: 16px 8px 8px 8px;
+	float: left;
+	color: #666;
+	line-height: normal;
+}
+
+.wc-helper .subscription-filter .count {
+	border: 0;
+}
+
+/* Pill toggle styles */
+.woocommerce-input-toggle {
+	background: #00aadc;
+	border: 2px solid #00aadc;
+}
+
+.woocommerce-input-toggle.woocommerce-input-toggle--disabled {
+	border-color: #a8bece;
+	background: #a8bece;
+}
+
+/* Status enabled checkmarks (email management) */
+.status-enabled::before {
+	color: #00aadc;
+}

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -40,6 +40,8 @@ div.woocommerce-message, .wc-helper .start-container {
 
 .subscriptions-header .button {
 	height: 30px;
+	line-height: 22px;
+	font-weight: normal;
 	color: #fff;
 	opacity: 1;
 }
@@ -50,17 +52,25 @@ div.woocommerce-message, .wc-helper .start-container {
 }
 
 /* White background behind the WooCommerce helper extensions navigation */
-.subscription-filter {
+.subscription-filter li {
 	margin: 10px 0 25px;
 	background: #fff;
 	border: 1px solid rgba(200,215,225,0.5);
-	width: 100%;
+	border-left: 0;
 	box-shadow: none;
 	list-style: none;
-	padding: 16px 8px 8px 8px;
+	padding: 12px !important;
 	float: left;
 	color: #666;
 	line-height: normal;
+}
+
+.subscription-filter li:first-of-type {
+	border-left: 1px solid rgba(200,215,225,0.5);
+}
+
+.wc-helper .subscription-filter li::before {
+	background-color: transparent;
 }
 
 .wc-helper .subscription-filter .count {
@@ -78,7 +88,20 @@ div.woocommerce-message, .wc-helper .start-container {
 	background: #a8bece;
 }
 
+.form-toggle.active+.form-toggle__label .form-toggle__switch {
+	background: #00aadc;
+}
+
+.form-toggle+.form-toggle__label .form-toggle__switch {
+	background: #a8bece;
+}
+
 /* Status enabled checkmarks (email management) */
 .status-enabled::before {
 	color: #00aadc;
+}
+
+.wc-helper .wp-list-table__row:last-child td {
+	border-bottom: none;
+	box-shadow: none;
 }

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2,9 +2,9 @@
  * Styles to override Jetpack Calypsoify styles for OBW and some WooCommerce screens
  */
  
-/* Updates purple notice color to green */
+/* Updates purple notice color */
 div.woocommerce-message, .wc-helper .start-container {
-	border-left-color: #46b450 !important;
+	border-left-color: #00a0d2 !important;
 }
 
 /* Adds padding between pagination and the table of items on management screens */
@@ -13,6 +13,8 @@ div.woocommerce-message, .wc-helper .start-container {
 }
 
 /* Update purple buttons to Calypso primary colors */
+.woocommerce-message a.button-primary,
+.woocommerce-message button.button-primary,
 .woocommerce-BlankState a.button-primary,
 .wc_addons_wrap .addons-button-solid,
 .woocommerce-BlankState a.button-primary:hover,
@@ -31,6 +33,13 @@ div.woocommerce-message, .wc-helper .start-container {
 .wc-helper .button:hover {
 	border-color: #005082;
 	opacity: 1;
+}
+
+.woocommerce-message a.button-primary:hover,
+.woocommerce-message button.button-primary:hover {
+	background: #008ec2;
+	border-color: #006799;
+	box-shadow: none;
 }
 
 .wc-helper .button,
@@ -104,4 +113,18 @@ div.woocommerce-message, .wc-helper .start-container {
 .wc-helper .wp-list-table__row:last-child td {
 	border-bottom: none;
 	box-shadow: none;
+}
+
+/* WooCommerce Checkout Field Editor: field names */
+#wc_checkout_fields strong.core-field {
+	color: #0073aa !important;
+}
+
+/* MailChimp for WooCommerce: Menu item */
+#adminmenu li.current a.menu-top.toplevel_page_mailchimp-woocommerce div.wp-menu-name {
+	color: #fff !important;
+}
+
+#adminmenu li.current a.menu-top.toplevel_page_mailchimp-woocommerce .svg {
+	filter: none;
 }

--- a/wc-calypso-bridge-class.php
+++ b/wc-calypso-bridge-class.php
@@ -19,6 +19,9 @@ class WC_Calypso_Bridge {
 	 */
 	public function __construct() {
 		$this->includes();
+
+		// Hook on `admin_print_styles`, after some WC CSS is hooked, so we can override a few '!important' styles.
+		add_action( 'admin_print_styles', array( $this, 'possibly_add_calypsoify_styles' ), 11 );
 	}
 
 	/**
@@ -51,6 +54,17 @@ class WC_Calypso_Bridge {
 		}
 
 		return self::$instance;
+	}
+
+	/**
+	 * Add calypsoify styles if calypsoify is enabled
+	 */
+	public function possibly_add_calypsoify_styles() {
+		if ( 1 == (int) get_user_meta( get_current_user_id(), 'calypsoify', true ) ) {
+			$asset_path = WC_Calypso_Bridge::$plugin_asset_path ? WC_Calypso_Bridge::$plugin_asset_path : WC_Calypso_Bridge::MU_PLUGIN_ASSET_PATH;
+			wp_enqueue_style( 'wc-calypso-bridge-calypsoify', $asset_path . 'assets/css/calypsoify.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION, 'all' );
+			add_filter( 'woocommerce_display_admin_footer_text', '__return_false' );
+		}
 	}
 }
 


### PR DESCRIPTION
This PR fixes some CSS/design issues with WooCommerce and the Calypsoify skin.

It fixes all the items in the "core issues" section of #61. Extensions will be fixed in another PR:

* Removed WooCommerce rating footer text.
* Fixed padding between pagination numbers and the post type table.
* Updated .woocommerce-message color to use a normal notice color instead of purple.
* “Create your first coupon”/Call to action button classes are now calypso colors
*  Extensions management - purple buttons updated to Calypso colors
 * WooCommerce Helper - Filter bar (All | Inactive | Installed | Expired) added missing white background
 * Fixed pill button background colors

To Test:
* Load up this branch alongside Calyspoify, and verify the above issues are fixed.

Subscriptions before:
<img width="1274" alt="extension_subs_before" src="https://user-images.githubusercontent.com/689165/47453312-67ba5400-d79a-11e8-95ec-f9ccc83fd4d8.png">

Subscriptions after:
<img width="803" alt="screen shot 2018-10-25 at 10 41 54 am" src="https://user-images.githubusercontent.com/689165/47508734-a3105d80-d842-11e8-859b-6b16a92e80bd.png">

Coupons before:
<img width="1185" alt="coupon_before" src="https://user-images.githubusercontent.com/689165/47453323-6f79f880-d79a-11e8-9ea5-ed207fb90cb8.png">

Coupons after:
<img width="1288" alt="coupon_after" src="https://user-images.githubusercontent.com/689165/47453328-71dc5280-d79a-11e8-9aa1-c0df22582e35.png">

Payment methods before:
<img width="791" alt="payment-methods_before" src="https://user-images.githubusercontent.com/689165/47453338-77399d00-d79a-11e8-8371-80fb0c31ec50.png">

Payment methods after:
<img width="792" alt="payment-methods_after" src="https://user-images.githubusercontent.com/689165/47453343-7a348d80-d79a-11e8-904a-e2da3c189adb.png">
