### PR TITLE
Fix some design issues with WooCommerce extensions

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2,9 +2,9 @@
  * Styles to override Jetpack Calypsoify styles for OBW and some WooCommerce screens
  */
  
-/* Updates purple notice color to green */
+/* Updates purple notice color */
 div.woocommerce-message, .wc-helper .start-container {
-	border-left-color: #46b450 !important;
+	border-left-color: #00a0d2 !important;
 }
 
 /* Adds padding between pagination and the table of items on management screens */
@@ -13,6 +13,8 @@ div.woocommerce-message, .wc-helper .start-container {
 }
 
 /* Update purple buttons to Calypso primary colors */
+.woocommerce-message a.button-primary,
+.woocommerce-message button.button-primary,
 .woocommerce-BlankState a.button-primary,
 .wc_addons_wrap .addons-button-solid,
 .woocommerce-BlankState a.button-primary:hover,
@@ -31,6 +33,13 @@ div.woocommerce-message, .wc-helper .start-container {
 .wc-helper .button:hover {
 	border-color: #005082;
 	opacity: 1;
+}
+
+.woocommerce-message a.button-primary:hover,
+.woocommerce-message button.button-primary:hover {
+	background: #008ec2;
+	border-color: #006799;
+	box-shadow: none;
 }
 
 .wc-helper .button,
@@ -104,4 +113,18 @@ div.woocommerce-message, .wc-helper .start-container {
 .wc-helper .wp-list-table__row:last-child td {
 	border-bottom: none;
 	box-shadow: none;
+}
+
+/* WooCommerce Checkout Field Editor: field names */
+#wc_checkout_fields strong.core-field {
+	color: #0073aa !important;
+}
+
+/* MailChimp for WooCommerce: Menu item */
+#adminmenu li.current a.menu-top.toplevel_page_mailchimp-woocommerce div.wp-menu-name {
+	color: #fff !important;
+}
+
+#adminmenu li.current a.menu-top.toplevel_page_mailchimp-woocommerce .svg {
+	filter: none;
 }


### PR DESCRIPTION
This PR fixes out all the issues I discovered during my audit (fixes #61). Depends on #82.

* Extension: Checkout Field Editor - Updated purple field names to blue
* Updated `div.woocommerce-message` status color to be a blue instead of green or purple (not all messages used this way should be green/success).
* Fixed some of the button styles in various extension notices
* Extension: MailChimp - Fixed sidebar item styles.

Menu before:
<img width="295" alt="screen shot 2018-10-25 at 11 43 26 am" src="https://user-images.githubusercontent.com/689165/47513724-da840780-d84c-11e8-80a1-a1b924e30de9.png">

Menu after:
<img width="282" alt="screen shot 2018-10-25 at 11 49 19 am" src="https://user-images.githubusercontent.com/689165/47513735-e079e880-d84c-11e8-9cfe-541ae98fabaf.png">

Checkout fields before:
<img width="817" alt="screen shot 2018-10-25 at 11 42 51 am" src="https://user-images.githubusercontent.com/689165/47513744-e5d73300-d84c-11e8-9fef-b0fadbfb4470.png">

Checkout fields after:
<img width="795" alt="screen shot 2018-10-25 at 11 42 15 am" src="https://user-images.githubusercontent.com/689165/47513762-ee2f6e00-d84c-11e8-8aff-71b6a9b62678.png">

Notice:
<img width="817" alt="screen shot 2018-10-25 at 11 41 52 am" src="https://user-images.githubusercontent.com/689165/47513776-f4bde580-d84c-11e8-95af-6da421c7287b.png">

To Test:
* Activate the above extensions, and verify the issues are fixed.

