### PR TITLE
Change wc colors to calypsoify colors

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -129,10 +129,15 @@ div.woocommerce-message, .wc-helper .start-container {
 	filter: none;
 }
 
-/* Onboarding wizard style */
+/* Onboarding wizard */
 .wc-setup {
     background: transparent;
 }
+.wc-setup-content a {
+    color: #537994;
+}
+
+/* Onboarding wizard steps */
 .wc-step-heading {
 	margin-top: 116px;
 	margin-bottom: 24px;
@@ -160,4 +165,29 @@ div.woocommerce-message, .wc-helper .start-container {
 	.wc-step-heading {
 		margin-top: 71px;
 	}
+}
+
+/* Onboarding wizard footer */
+.wc-setup .wc-setup-actions {
+	display: none;
+}
+.wc-setup .wc-setup-footer {
+	margin-bottom: 80px;
+}
+.wc-setup .wc-setup-footer .button-primary {
+	height: 40px;
+	line-height: 38px;
+	font-size: 14px;
+}
+
+/* Onboarding wizard toggles */
+.wc-wizard-service-item .wc-wizard-service-toggle, .wc-wizard-services-list-toggle .wc-wizard-service-toggle {
+    height: 20px;
+    width: 36px;
+    border: 2px solid #00AADC;
+    background-color: #00AADC;
+}
+.wc-wizard-service-item .wc-wizard-service-toggle:before, .wc-wizard-services-list-toggle .wc-wizard-service-toggle:before {
+    width: 20px;
+    height: 20px;
 }

--- a/assets/js/calypsoify-obw.js
+++ b/assets/js/calypsoify-obw.js
@@ -1,0 +1,17 @@
+( function( $ ) {
+    'use strict';
+    
+    /**
+     * Simulate "next step" click on button outside form
+     */
+    $( document ).on ( 'click', '.wc-setup-footer .button-primary', function( e ) {
+        e.preventDefault();
+        $( '.wc-setup .button-next' ).click();
+
+        var form = $( '.wc-setup .button-next' ).parents( 'form' ).get( 0 );
+		if ( ( 'function' !== typeof form.checkValidity ) || form.checkValidity() ) {
+			$( this ).attr( 'disabled', true );
+		}
+    } );
+
+} )( jQuery );

--- a/includes/setup-wizard.php
+++ b/includes/setup-wizard.php
@@ -36,6 +36,7 @@ class WC_Calypso_Bridge_Admin_Setup_Wizard extends WC_Admin_Setup_Wizard {
 			add_action( 'admin_menu', array( $this, 'admin_menus' ) );
 			add_action( 'admin_init', array( $this, 'setup_wizard' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+			add_action( 'admin_enqueue_scripts', array( $this, 'possibly_enqueue_calypsoify_scripts' ) );
 		}
 	}
 
@@ -62,6 +63,9 @@ class WC_Calypso_Bridge_Admin_Setup_Wizard extends WC_Admin_Setup_Wizard {
 		<?php
 	}
 	
+	/**
+	 * Output the step header.
+	 */
 	public function setup_wizard_steps() {
 		$step = $this->steps[ $this->step ];
 		?>
@@ -114,6 +118,40 @@ class WC_Calypso_Bridge_Admin_Setup_Wizard extends WC_Admin_Setup_Wizard {
 	}
 
 	/**
+	 * Output the content for the current step.
+	 */
+	public function setup_wizard_content() {
+		echo '<div class="wc-setup-content">';
+		if ( ! empty( $this->steps[ $this->step ]['view'] ) ) {
+			call_user_func( $this->steps[ $this->step ]['view'], $this );
+		}
+		echo '</div>';
+	}
+	
+	/**
+	 * Setup Wizard Footer.
+	 */
+	public function setup_wizard_footer() {
+		?>
+			<div class="wc-setup-footer">
+				<button class="button-primary button button-large" value="<?php esc_attr_e( "Let's go!", 'woocommerce' ); ?>" name="save_step"><?php esc_html_e( "Continue", 'wc-calypso-bridge' ); ?></button>
+			</div>
+			</body>
+		</html>
+		<?php
+	}
+
+	/**
+	 * Enqueue calypsoify scripts if
+	 */
+	public function possibly_enqueue_calypsoify_scripts() {
+		if ( 1 == (int) get_user_meta( get_current_user_id(), 'calypsoify', true ) ) {
+			$asset_path = WC_Calypso_Bridge::$plugin_asset_path ? WC_Calypso_Bridge::$plugin_asset_path : WC_Calypso_Bridge::MU_PLUGIN_ASSET_PATH;
+			wp_enqueue_script( 'wc-calypso-bridge-calypsoify-obw', $asset_path . 'assets/js/calypsoify-obw.js', array( 'jquery' ), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
+		}
+	}
+
+	/**
 	 * Get the URL for the next step's screen.
 	 *
 	 * @param string $step  slug (default: current step).
@@ -137,16 +175,6 @@ class WC_Calypso_Bridge_Admin_Setup_Wizard extends WC_Admin_Setup_Wizard {
 		return add_query_arg( 'step', $keys[ $step_index + 1 ], remove_query_arg( 'activate_error' ) );
 	}
 
-	/**
-	 * Output the content for the current step.
-	 */
-	public function setup_wizard_content() {
-		echo '<div class="wc-setup-content">';
-		if ( ! empty( $this->steps[ $this->step ]['view'] ) ) {
-			call_user_func( $this->steps[ $this->step ]['view'], $this );
-		}
-		echo '</div>';
-	}
     
 }
 


### PR DESCRIPTION
Fixes #80 

This PR updates the color of the toggles, buttons, and links in the OBW to the calypso blue instead of the WC purple.

It also moves the form step button outside the form box beneath the white box area.

### Screenshots
<img width="458" alt="screen shot 2018-10-25 at 6 49 21 pm" src="https://user-images.githubusercontent.com/10561050/47536618-c4933880-d886-11e8-8603-65b6d84e1e12.png">
<img width="523" alt="screen shot 2018-10-25 at 6 49 24 pm" src="https://user-images.githubusercontent.com/10561050/47536619-c4933880-d886-11e8-88a0-8a04eb423556.png">

### Testing

1.  Visit `/wp-admin/admin.php?page=wc-setup&step=payment&calypsoify=1`
2.  Verify that the color of the toggles, buttons, and links has been updated.
3.  Check that the button height and toggles match the new styles.
4.  Confirm that the "Continue" button works (uses JS as it has to be placed outside the form).