### PR TITLE
Fix Calypsoify compatibility with WooCommerce and Gutenberg

### DIFF
--- a/includes/class-wc-calypso-bridge-menus.php
+++ b/includes/class-wc-calypso-bridge-menus.php
@@ -39,7 +39,6 @@ class WC_Calypso_Bridge_Menus {
 	 * Hooks into WordPress to overtake the menu system on WooCommerce pages.
 	 */
 	public function setup_menu_hooks() {
-		// TODO, Figure out correct loading conditions. For now we will use the same user meta as calypsoify.
 		if ( 1 != (int) get_user_meta( get_current_user_id(), 'calypsoify', true ) ) {
 			return;
 		}

--- a/includes/gutenberg.php
+++ b/includes/gutenberg.php
@@ -15,7 +15,7 @@ function wc_calypso_bridge_disable_gutenberg_for_post_type( $current_value, $pos
 		'wc_product_tab',
 		'wishlist',
 		'wc_zapier_feed',
- );
+	);
 	if ( in_array( $post_type, $wc_post_types ) ) {
 		return false;
 	}

--- a/includes/gutenberg.php
+++ b/includes/gutenberg.php
@@ -1,0 +1,24 @@
+<?php
+function wc_calypso_bridge_disable_gutenberg_for_post_type( $current_value, $post_type ) {
+	$wc_post_types = array(
+		'shop_coupon',
+		'shop_order',
+		'product',
+		'bookable_resource',
+		'wc_booking',
+		'event_ticket',
+		'wc_membership_plan',
+		'wc_user_membership',
+		'wc_voucher',
+		'wc_pickup_location',
+		'shop_subscription',
+		'wc_product_tab',
+		'wishlist',
+		'wc_zapier_feed',
+ );
+	if ( in_array( $post_type, $wc_post_types ) ) {
+		return false;
+	}
+	return $current_value;
+}
+add_filter( 'use_block_editor_for_post_type', 'wc_calypso_bridge_disable_gutenberg_for_post_type', 10, 2 );

--- a/wc-calypso-bridge-class.php
+++ b/wc-calypso-bridge-class.php
@@ -39,7 +39,7 @@ class WC_Calypso_Bridge {
 		include_once( dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-page-controller.php' );
 		include_once( dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-menus.php' );
 		include_once( dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-setup.php' );
-
+		include_once( dirname( __FILE__ ) . '/includes/gutenberg.php' );
 		$connect_files = glob( dirname( __FILE__ ) . '/includes/connect/*.php' );
 		foreach ( $connect_files as $connect_file ) {
 			include_once( $connect_file );


### PR DESCRIPTION
Fixes #62.

This PR requires you to be running the latest Jetpack `master` (which includes a fix I made for the Calypsoify module: see https://github.com/Automattic/jetpack/pull/10389).

This PR uses the hook added there, to disable Calypsoify from overtaking the screen for WooCommerce post types. All the post types here are from the supported list of extensions. I updated the directions for Calypsoifying extensions to include this step: p90Yrv-Po-p2.

To Test:
* Run latest Jetpack
* Install Gutenberg
* Visit the add new product screen, coupon screen, bookings add resource screen, or another extension like Boxoffice and see that the navigation stays and Gutenberg no longer overtakes the page