### PR TITLE
Change shipping zone colors from purple to blue

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -129,6 +129,35 @@ div.woocommerce-message, .wc-helper .start-container {
 	filter: none;
 }
 
+/* Shipping zones */
+table.wc-shipping-classes td.wc-shipping-zone-method-blank-state, table.wc-shipping-classes td.wc-shipping-zones-blank-state, table.wc-shipping-zone-methods td.wc-shipping-zone-method-blank-state, table.wc-shipping-zone-methods td.wc-shipping-zones-blank-state, table.wc-shipping-zones td.wc-shipping-zone-method-blank-state, table.wc-shipping-zones td.wc-shipping-zones-blank-state {
+	background: #fff !important;
+}
+table.wc-shipping-classes td.wc-shipping-zone-method-blank-state li, table.wc-shipping-classes td.wc-shipping-zone-method-blank-state p, table.wc-shipping-classes td.wc-shipping-zones-blank-state li, table.wc-shipping-classes td.wc-shipping-zones-blank-state p, table.wc-shipping-zone-methods td.wc-shipping-zone-method-blank-state li, table.wc-shipping-zone-methods td.wc-shipping-zone-method-blank-state p, table.wc-shipping-zone-methods td.wc-shipping-zones-blank-state li, table.wc-shipping-zone-methods td.wc-shipping-zones-blank-state p, table.wc-shipping-zones td.wc-shipping-zone-method-blank-state li, table.wc-shipping-zones td.wc-shipping-zone-method-blank-state p, table.wc-shipping-zones td.wc-shipping-zones-blank-state li, table.wc-shipping-zones td.wc-shipping-zones-blank-state p {
+	color: #668eaa;
+	font-size: 14px;
+}
+table.wc-shipping-classes td.wc-shipping-zone-method-blank-state::before, table.wc-shipping-classes td.wc-shipping-zones-blank-state::before, table.wc-shipping-zone-methods td.wc-shipping-zone-method-blank-state::before, table.wc-shipping-zone-methods td.wc-shipping-zones-blank-state::before, table.wc-shipping-zones td.wc-shipping-zone-method-blank-state::before, table.wc-shipping-zones td.wc-shipping-zones-blank-state::before {
+    color: #fff;
+}
+table.wc-shipping-classes td.wc-shipping-zone-method-blank-state .button-primary, table.wc-shipping-classes td.wc-shipping-zones-blank-state .button-primary, table.wc-shipping-zone-methods td.wc-shipping-zone-method-blank-state .button-primary, table.wc-shipping-zone-methods td.wc-shipping-zones-blank-state .button-primary, table.wc-shipping-zones td.wc-shipping-zone-method-blank-state .button-primary, table.wc-shipping-zones td.wc-shipping-zones-blank-state .button-primary {
+    background-color: #00aadc;
+    border-color: #008ab3;
+	text-shadow: none;
+	padding: 7px;
+    font-size: 12px;
+	line-height: 1;
+	font-weight: 500;
+	border-style: solid;
+    border-width: 1px 1px 2px;
+}
+table.wc-shipping-classes td.wc-shipping-zone-method-blank-state li.main, table.wc-shipping-classes td.wc-shipping-zone-method-blank-state p.main, table.wc-shipping-classes td.wc-shipping-zones-blank-state li.main, table.wc-shipping-classes td.wc-shipping-zones-blank-state p.main, table.wc-shipping-zone-methods td.wc-shipping-zone-method-blank-state li.main, table.wc-shipping-zone-methods td.wc-shipping-zone-method-blank-state p.main, table.wc-shipping-zone-methods td.wc-shipping-zones-blank-state li.main, table.wc-shipping-zone-methods td.wc-shipping-zones-blank-state p.main, table.wc-shipping-zones td.wc-shipping-zone-method-blank-state li.main, table.wc-shipping-zones td.wc-shipping-zone-method-blank-state p.main, table.wc-shipping-zones td.wc-shipping-zones-blank-state li.main, table.wc-shipping-zones td.wc-shipping-zones-blank-state p.main {
+    font-size: 14px;
+}
+table.wc-shipping-classes td.wc-shipping-zone-method-blank-state, table.wc-shipping-classes td.wc-shipping-zones-blank-state, table.wc-shipping-zone-methods td.wc-shipping-zone-method-blank-state, table.wc-shipping-zone-methods td.wc-shipping-zones-blank-state, table.wc-shipping-zones td.wc-shipping-zone-method-blank-state, table.wc-shipping-zones td.wc-shipping-zones-blank-state {
+    padding: 2.5em 3.5%!important;
+}
+
 /* Onboarding wizard */
 .wc-setup {
     background: transparent;


### PR DESCRIPTION
Fixes #88 

Change the purple color from WC to match calypso styles (turns the background and icon white) as well as change button color and padding in empty shipping container.

### Screenshots
<img width="1378" alt="screen shot 2018-10-29 at 10 04 52 am" src="https://user-images.githubusercontent.com/10561050/47659157-538fa180-db62-11e8-9ce8-4edc25503cb1.png">
<img width="1127" alt="screen shot 2018-10-29 at 10 05 07 am" src="https://user-images.githubusercontent.com/10561050/47659160-538fa180-db62-11e8-8918-942f7be77078.png">


### Testing
1.  Visit `/wp-admin/admin.php?page=wc-settings&tab=shipping`
2.  Remove all shipping zones and verify that area is styled appropriately when no zone is set.
3.  Add a shipping zone and click its link to see available shipping methods.
4.  Verify styling when no shipping methods are set for this zone.