### PR TITLE
Add precommit hook for phpcs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
 		"wp-coding-standards/wpcs": "1.1.0",
 		"woocommerce/woocommerce-sniffs": "*",
 		"wimg/php-compatibility": "9.0.0",
-		"dealerdirect/phpcodesniffer-composer-installer": "0.4.4"
+		"dealerdirect/phpcodesniffer-composer-installer": "0.4.4",
+		"bjornjohansen/wp-pre-commit-hook": "^0.2.2"
 	  },
 	"scripts": {
 		"phpcs": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2bc51ba25ab617070dafa2967907d6dd",
+    "content-hash": "76cfed33e583a8dcd246def9c69b4eab",
     "packages": [
         {
             "name": "composer/installers",
@@ -128,6 +128,47 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "bjornjohansen/wp-pre-commit-hook",
+            "version": "0.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bjornjohansen/wp-pre-commit-hook.git",
+                "reference": "03b4682cb70ee4c1cace73fc0d26775c5eebbf0e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bjornjohansen/wp-pre-commit-hook/zipball/03b4682cb70ee4c1cace73fc0d26775c5eebbf0e",
+                "reference": "03b4682cb70ee4c1cace73fc0d26775c5eebbf0e",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "*",
+                "wp-coding-standards/wpcs": "*"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "BjornJohansen\\WPPreCommitHook\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "BjornJohansen\\WPPreCommitHook\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Bjørn Johansen",
+                    "email": "post@bjornjohansen.no"
+                }
+            ],
+            "description": "Pre-commit hook for WordPress projects",
+            "time": "2018-03-15T13:54:08+00:00"
+        },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v0.4.4",


### PR DESCRIPTION
Fixes #100 

This PR adds in a pre-commit hook to run PHPCS and check for WPCS validity.  Linting and PHPCS will be run on any staged git changes.

### Screenshots
<img width="528" alt="screen shot 2018-10-29 at 12 37 10 pm" src="https://user-images.githubusercontent.com/10561050/47668800-66f93780-db77-11e8-9acb-3c7646c30433.png">

### Testing
1. Run `composer install`.
2. Make changes to a php file and make sure there are coding standard errors in the PHP file. E.g., No spaces between parentheses and params for a function.
3. `git add .` and attempt to `git commit` - you should receive an error with the warnings that prevents the commit from occurring.