### PR TITLE
Change OBW completion redirect link

### DIFF
--- a/includes/class-wc-calypso-bridge-admin-setup-wizard.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-wizard.php
@@ -329,7 +329,7 @@ class WC_Calypso_Bridge_Admin_Setup_Wizard extends WC_Admin_Setup_Wizard {
 		}
 		$keys = array_keys( $this->steps );
 		if ( end( $keys ) === $step ) {
-			return admin_url();
+			return admin_url( '/admin.php?page=wc-setup-checklist' );
 		}
 		$step_index = array_search( $step, $keys, true );
 		if ( false === $step_index ) {


### PR DESCRIPTION
Fixes #104 

Redirects the user to the setup checklist page after clicking "Continue" on the payment steps page.

### Testing

1.  Visit `/wp-admin/admin.php?page=wc-setup&step=payment`
2.  Click "Continue"
3.  Check that you arrive at the setup page `/wp-admin/admin.php?page=wc-setup-checklist`