### PR TITLE
Generic table design updates

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -160,7 +160,7 @@ table.wc-shipping-classes td.wc-shipping-zone-method-blank-state, table.wc-shipp
 
 /* Generic tables */
 
-.hndle a, .widefat tfoot td, .widefat th, .widefat thead td{
+.hndle a, .widefat tfoot td, .widefat th, .widefat thead td {
 	font-weight: 600;
 	color: #2e4453;
 	padding: 16px;
@@ -171,31 +171,42 @@ th.sortable a, th.sorted a{
 }
 
 /* Makes all rows have white background */
-.striped>tbody>:nth-child(odd), ul.striped>:nth-child(odd){
+.striped>tbody > :nth-child(odd), ul.striped > :nth-child(odd) {
 	background-color: #fff !important;
 }
+
 /* Add border to rows */
-.widefat th, .widefat td{
+.widefat th, .widefat td {
 	border-bottom: 1px solid #e9eff3;
 }
 
+/* Add on hover background color to rows*/
+.widefat tr:hover {
+	background: #fafbfc !important;
+}
+
+/* Adds border to placeholder image */
+table.wp-list-table td.column-thumb img {
+	border: 1px solid #f3f6f8;
+}
+
 /* Hides table footer*/
-.wp-list-table tfoot{
+.wp-list-table tfoot {
 	display: none;
 }
 
-.wp-list-table .row-title{
+.wp-list-table .row-title {
 	color: #0087be;
 }
+
 /* Removes table shadow */
-table.widefat{
+table.widefat {
 	border-color: #c8d7e1;
 	box-shadow: none;
 }
 
 /* Removes table footer actions */
-
-.tablenav.bottom{
+.tablenav.bottom {
 	display: none;
 }
 

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -158,6 +158,39 @@ table.wc-shipping-classes td.wc-shipping-zone-method-blank-state, table.wc-shipp
 	padding: 2.5em 3.5%!important;
 }
 
+/* Generic tables */
+
+.hndle a, .widefat tfoot td, .widefat th, .widefat thead td{
+	font-weight: 600;
+	color: #2e4453;
+	padding: 16px;
+}
+
+th.sortable a, th.sorted a{
+	color: #0087be;
+}
+
+/* Makes all rows have white background */
+.striped>tbody>:nth-child(odd), ul.striped>:nth-child(odd){
+	background-color: #fff !important;
+}
+
+/* Hides table footer*/
+.wp-list-table tfoot{
+	display: none;
+}
+/* Removes table shadow */
+table.widefat{
+	border-color: #c8d7e1;
+	box-shadow: none;
+}
+
+/* Removes table footer actions */
+
+.tablenav.bottom{
+	display: none;
+}
+
 /* Onboarding wizard */
 .wc-setup-page {
 	background: #F3F6F8;
@@ -553,7 +586,7 @@ table.wc-shipping-classes td.wc-shipping-zone-method-blank-state, table.wc-shipp
 }
 .wc-wizard-service-item .wc-wizard-service-description p {
 	margin: 0;
-	color: #537994;	
+	color: #537994;
 }
 .wc-wizard-service-item .wc-wizard-service-name, .wc-wizard-services-list-toggle .wc-wizard-service-name {
 	min-width: 100px;

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -179,6 +179,10 @@ th.sortable a, th.sorted a{
 .wp-list-table tfoot{
 	display: none;
 }
+
+.wp-list-table .row-title{
+	color: #0087be;
+}
 /* Removes table shadow */
 table.widefat{
 	border-color: #c8d7e1;

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -181,7 +181,7 @@ th.sortable a, th.sorted a{
 }
 
 /* Add on hover background color to rows*/
-.widefat tr:hover {
+.widefat tbody tr:hover {
 	background: #fafbfc !important;
 }
 

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -174,6 +174,10 @@ th.sortable a, th.sorted a{
 .striped>tbody>:nth-child(odd), ul.striped>:nth-child(odd){
 	background-color: #fff !important;
 }
+/* Add border to rows */
+.widefat th, .widefat td{
+	border-bottom: 1px solid #e9eff3;
+}
 
 /* Hides table footer*/
 .wp-list-table tfoot{


### PR DESCRIPTION
Adds style updates to make the tables closer to the calypso styles:

![screen shot 2018-10-30 at 16 35 23](https://user-images.githubusercontent.com/57050/47734205-d4819280-dc61-11e8-813f-9bff339fa0a4.png)


Headers:
- updates padding, colors and text-styles

Rows:
- Removes stripped rows
- Updates colors 
- Adds bottom border

Table:
- hides footer actions and items counter
- removes table shadow

