### PR TITLE
Add setup tasks and base list rendering code

### DIFF
--- a/assets/css/setup-checklist.css
+++ b/assets/css/setup-checklist.css
@@ -1,0 +1,412 @@
+/** Copied from Calypso code generated on 10/29/2018 */
+
+.checklist {
+	margin: 20px 30px 25px 15px;
+}
+
+.checklist-card {
+	display: block;
+	position: relative;
+	margin: 0 auto 10px auto;
+	padding: 16px;
+	-webkit-box-sizing: border-box;
+	box-sizing: border-box;
+	background: #fff;
+	-webkit-box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5), 0 1px 2px #e9eff3;
+	box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5), 0 1px 2px #e9eff3;
+}
+
+.checklist-card:after {
+	content: ".";
+	display: block;
+	height: 0;
+	width: 0;
+	clear: both;
+	visibility: hidden;
+	overflow: hidden;
+}
+
+@media (min-width: 481px) {
+	.checklist-card {
+		margin-bottom: 16px;
+		padding: 24px;
+	}
+}
+
+.checklist-card.is-compact {
+	margin-bottom: 1px;
+}
+
+@media (min-width: 481px) {
+	.checklist-card.is-compact {
+		margin-bottom: 1px;
+		padding: 16px 24px;
+	}
+}
+
+.checklist__header {
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-orient: horizontal;
+	-webkit-box-direction: normal;
+	-ms-flex-direction: row;
+	flex-direction: row;
+}
+
+.checklist__header-main {
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-flex: 1;
+	-ms-flex: 1 1;
+	flex: 1 1;
+	-webkit-box-orient: vertical;
+	-webkit-box-direction: normal;
+	-ms-flex-direction: column;
+	flex-direction: column;
+	max-width: 40%;
+}
+
+.checklist__header-progress {
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-orient: horizontal;
+	-webkit-box-direction: normal;
+	-ms-flex-direction: row;
+	flex-direction: row;
+	font-size: 14px;
+	white-space: nowrap;
+	margin-bottom: 5px;
+}
+
+.checklist__header-progress-text {
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-flex: 1;
+	-ms-flex: 1 1;
+	flex: 1 1;
+	margin: 0;
+	color: #537994;
+	font-size: 14px;
+	font-weight: normal;
+}
+
+.checklist__header-progress-number {
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	color: #537994;
+	padding-left: 1em;
+}
+
+.checklist__header-summary {
+	font-size: 12px;
+	line-height: 24px;
+	color: #537994;
+	cursor: pointer;
+}
+
+.checklist__header-action {
+	position: absolute;
+	top: 0;
+	right: 0;
+	width: 48px;
+	height: 100%;
+	border: 0;
+	border-left: 1px solid #f3f6f8;
+	cursor: pointer;
+}
+
+.checklist__header-action .gridicon {
+	fill: #87a6bc;
+	vertical-align: middle;
+	-webkit-box-align: center;
+	-ms-flex-align: center;
+	align-items: center;
+	-webkit-transition: color 0.2s ease-in, -webkit-transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+	transition: color 0.2s ease-in, -webkit-transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+	transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), color 0.2s ease-in;
+	transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), color 0.2s ease-in, -webkit-transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+.checklist.is-expanded .checklist__header-action .gridicon {
+	-webkit-transform: rotate(180deg);
+	transform: rotate(180deg);
+}
+
+.checklist.is-expanded .checklist__header-action .gridicon {
+	-webkit-transform: rotate(180deg);
+	transform: rotate(180deg);
+}
+
+.checklist__header .progress-bar__progress {
+	background-color: #4ab866;
+}
+
+.checklist__tasks {
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-orient: vertical;
+	-webkit-box-direction: normal;
+	-ms-flex-direction: column;
+	flex-direction: column;
+}
+
+.checklist__task {
+	width: 100%;
+	-webkit-box-ordinal-group: 101;
+	-ms-flex-order: 100;
+	order: 100;
+}
+
+.checklist__task.is-completed {
+	-webkit-box-ordinal-group: 1;
+	-ms-flex-order: 0;
+	order: 0;
+}
+
+.checklist__task.checklist-card {
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-orient: horizontal;
+	-webkit-box-direction: normal;
+	-ms-flex-direction: row;
+	flex-direction: row;
+	padding: 16px 16px 16px 56px;
+}
+
+@media (max-width: 480px) {
+	.checklist__task.checklist-card {
+		-webkit-box-orient: vertical;
+		-webkit-box-direction: normal;
+		-ms-flex-direction: column;
+		flex-direction: column;
+	}
+}
+
+.checklist__task.checklist-card.is-completed {
+	-webkit-box-orient: horizontal;
+	-webkit-box-direction: normal;
+	-ms-flex-direction: row;
+	flex-direction: row;
+}
+
+.checklist__task::before {
+	content: '';
+	display: block;
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 34px;
+	border-left: 1px solid #c8d7e1;
+}
+
+.checklist__task-icon {
+	display: block;
+	position: absolute;
+	top: 18px;
+	left: 24px;
+	width: 16px;
+	height: 16px;
+	border: 2px solid #c8d7e1;
+	border-radius: 16px;
+	background: #fff;
+	cursor: pointer;
+}
+
+.checklist__task-icon .gridicons-checkmark {
+	display: none;
+	fill: #fff;
+	position: absolute;
+	top: -1px;
+	left: 1px;
+}
+
+.checklist__task-icon:hover,
+.checklist__task-icon:focus {
+	background: #4ab866;
+	border-color: #4ab866;
+}
+
+.checklist__task-icon:hover .gridicons-checkmark,
+.checklist__task-icon:focus .gridicons-checkmark {
+	display: block;
+}
+
+.checklist__task-icon:active {
+	background: #00aadc;
+	border-color: #00aadc;
+}
+
+.checklist__task-primary {
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-orient: vertical;
+	-webkit-box-direction: normal;
+	-ms-flex-direction: column;
+	flex-direction: column;
+	-webkit-box-flex: 1;
+	-ms-flex: 1 1 90%;
+	flex: 1 1 90%;
+}
+
+.checklist__task-secondary {
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-flex: 1;
+	-ms-flex: 1 1 10%;
+	flex: 1 1 10%;
+	-webkit-box-align: start;
+	-ms-flex-align: start;
+	align-items: start;
+	padding-left: 10px;
+}
+
+@media (max-width: 480px) {
+	.checklist__task-secondary {
+		padding-left: 0;
+		-webkit-box-align: center;
+		-ms-flex-align: center;
+		align-items: center;
+	}
+}
+
+.checklist__task-title {
+	margin-bottom: 0;
+	margin-top: 0;
+}
+
+.checklist__task-title a {
+	padding: 0;
+	color: #0087be;
+	font-weight: 400;
+	font-size: 16px;
+	text-decoration: none;
+}
+
+.checklist__task-title a.task-is-completed {
+	color: #537994;
+	font-size: 14px;
+	cursor: default;
+	line-height: 26px;
+}
+
+.checklist__task-description {
+	word-break: break-word;
+	font-size: 14px;
+	margin-top: 0;
+}
+
+.checklist__task-description a {
+	text-decoration: none;
+}
+
+.checklist__task-duration {
+	font-size: 12px;
+	color: #537994;
+}
+
+.checklist__task-primary .checklist__task-duration {
+	display: inline-block;
+}
+
+.checklist__task-secondary .checklist__task-duration {
+	display: none;
+}
+
+@media (max-width: 480px) {
+	.checklist__task-primary .checklist__task-duration {
+		display: none;
+	}
+	.checklist__task-secondary .checklist__task-duration {
+		display: inline-block;
+		margin-left: 1.5em;
+	}
+}
+
+.checklist__task-action {
+	white-space: nowrap;
+}
+
+.checklist__task.is-completed {
+	padding-top: 12px;
+	padding-bottom: 12px;
+	background: #f3f6f8;
+}
+
+.checklist__task.is-completed .checklist__task-icon {
+	top: 13px;
+	background: #4ab866;
+	border-color: #4ab866;
+}
+
+.checklist__task.is-completed .checklist__task-icon:hover {
+	cursor: default;
+}
+
+.checklist__task.is-completed .gridicons-checkmark {
+	display: block;
+}
+
+.checklist__task.is-completed .checklist__task-description,
+.checklist__task.is-completed .checklist__task-duration,
+.checklist__task.is-completed .checklist__task-secondary {
+	display: none;
+}
+
+.checklist__task.is-completed.has-actionlink .checklist__task-secondary {
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+}
+
+.checklist__task.is-completed.has-actionlink .checklist__task-action {
+	background: transparent;
+	border: 0;
+	padding: 0;
+	text-decoration: underline;
+	color: #537994;
+	font-size: 12px;
+	font-weight: 400;
+	width: 100%;
+	text-align: right;
+	box-shadow: none;
+}
+
+@media (max-width: 480px) {
+	.checklist__task.is-completed.has-actionlink .checklist__task-action {
+		padding-right: 0;
+	}
+}
+
+.progress-bar {
+	width: 100%;
+	display: inline-block;
+	position: relative;
+	height: 9px;
+	background-color: #c8d7e1;
+	border-radius: 4.5px;
+}
+
+.progress-bar.is-compact {
+	height: 4px;
+}
+
+.progress-bar__progress {
+	display: inline-block;
+	position: absolute;
+	top: 0;
+	left: 0;
+	height: 100%;
+	background-color: #006fb5;
+	border-radius: 4.5px;
+	-webkit-transition: width 200ms;
+	transition: width 200ms;
+}

--- a/assets/css/setup-checklist.css
+++ b/assets/css/setup-checklist.css
@@ -267,6 +267,7 @@
 	-ms-flex-align: start;
 	align-items: start;
 	padding-left: 10px;
+	justify-content: flex-end;
 }
 
 @media (max-width: 480px) {

--- a/includes/class-wc-calypso-bridge-admin-setup-checklist.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-checklist.php
@@ -38,22 +38,37 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 
 		// If setup has been completed, do nothing.
 		if ( true === (bool) get_option( 'atomic-ecommerce-setup-checklist-complete', false ) ) {
+			// Redirect to orders if setup is complete.
+			if ( isset( $_GET['page'] ) && 'wc-setup-checklist' === $_GET['page'] ) {
+				wp_redirect( admin_url( 'edit.php?post_type=shop_order' ) );
+				exit;
+			}
 			return;
 		}
 
 		add_action( 'admin_menu', array( $this, 'admin_menu' ) );
-		add_action( 'admin_head', array( $this, 'remove_notices' ) );
 		// priority is 20 to run after https://github.com/woocommerce/woocommerce/blob/a55ae325306fc2179149ba9b97e66f32f84fdd9c/includes/admin/class-wc-admin-menus.php#L165.
 		add_action( 'admin_head', array( $this, 'admin_menu_structure' ), 20 );
+
+		if ( isset( $_GET['page'] ) && 'wc-setup-checklist' === $_GET['page'] ) {
+			add_action( 'admin_head', array( $this, 'remove_notices' ) );
+			add_action( 'admin_enqueue_scripts', array( $this, 'load_checklist_styles' ) );
+		}
 	}
 
 	/**
 	 * Remove all admin notices
 	 */
 	public function remove_notices() {
-		if ( isset( $_GET['page'] ) && 'wc-setup-checklist' === $_GET['page'] ) {
-			remove_all_actions( 'admin_notices' );
-		}
+		remove_all_actions( 'admin_notices' );
+	}
+
+	/**
+	 * Loads checklist CSS
+	 */
+	public function load_checklist_styles() {
+		$asset_path = WC_Calypso_Bridge::$plugin_asset_path ? WC_Calypso_Bridge::$plugin_asset_path : WC_Calypso_Bridge::MU_PLUGIN_ASSET_PATH;
+		wp_enqueue_style( 'wc-calypso-bridge-setup-checklist', $asset_path . 'assets/css/setup-checklist.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION, 'all' );
 	}
 
 	/**
@@ -101,13 +116,294 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 		array_unshift( $submenu['woocommerce'], $menu );
 	}
 
-	/**
-	 * Render the checklist
-	 */
-	public function checklist() {
 
+	/**
+	 * Returns an array of relevent setup tasks and meta information (completed tasks, uncompleted, etc).
+	 *
+	 * New tasks can be added to the array below. They use the following format:
+	 * title - Task title (e.g. 'Add a product')
+	 * completed_title - Used for the action link once a task is completed (e.g. 'View settings')
+	 * description - A description of the task
+	 * estimate - An estimate in minutes how long the task will take
+	 * link - Destination for the action button
+	 * learn_more - If present, a learn more link will be appended to the description.
+	 * extension - Plugin slug (can be taken from  wp-admin's plugin page). If present, this task will only show when the extension is active.
+	 * condition - A conditional to determine if the task is completed or not.
+	 */
+	private function get_task_data() {
+		// TODO Double check against setup tasks in the spreadsheet. Needs Canada Post here.
+		// Variables used in the conditions below.
+		$count_posts    = wp_count_posts( 'product' );
+		$total_products = $count_posts->publish;
+		$ups_settings   = get_option( 'woocommerce_ups_settings' );
+		$square_merchant_access_token = get_option( 'woocommerce_square_merchant_access_token' );
+
+		$all_tasks = array(
+			array(
+				'title' => __( 'Add a product', 'wc-calypso-bridge' ),
+				'completed_title' => __( 'Add another product', 'wc-calypso-bridge' ),
+				'description' => __( 'Start by adding your first product to your store.', 'wc-calypso-bridge' ),
+				'estimate' => '2',
+				'link' => 'post-new.php?post_type=product',
+				'condition' => $total_products > 0,
+			),
+
+			array(
+				'title' => __( 'View and customize', 'wc-calypso-bridge' ),
+				'completed_title' => __( 'Open customizer', 'wc-calypso-bridge' ),
+				'description' => __( 'You have access to a few themes with your plan. See the options, chose the right one for you and customize your store.', 'wc-calypso-bridge' ),
+				'estimate' => '2',
+				'link' => 'customize.php?return=%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-setup-checklist',
+				'condition' => false, // TODO Condition logic here. Based on click?
+			),
+
+			array(
+				'title' => __( 'Review shipping', 'wc-calypso-bridge' ),
+				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
+				'description' => __( "We've set up a few shipping options based on your store location. Check them out to see if they're right for you.", 'wc-calypso-bridge' ),
+				'estimate' => '2',
+				'link' => 'admin.php?page=wc-settings&tab=shipping',
+				'condition' => false, // TODO Condition logic here. Based on click?
+			),
+
+			array(
+				'title' => __( 'Add live rates with UPS', 'wc-calypso-bridge' ),
+				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
+				'description' => __( "Showing shipping rates directly from UPS during checkout ensures you're charging customers the right amount for shipping.", 'wc-calypso-bridge' ),
+				'estimate' => '2',
+				'link' => 'admin.php?page=wc-settings&tab=shipping&section=ups',
+				'condition' => ! empty( $ups_settings['user_id'] ) &&
+							   ! empty( $ups_settings['password'] ) &&
+							   ! empty( $ups_settings['access_key'] ) &&
+							   ! empty( $ups_settings['shipper_number'] ),
+				'extension' => 'woocommerce-shipping-ups/woocommerce-shipping-ups.php',
+			),
+
+			array(
+				'title' => __( 'Setup payments with Square', 'wc-calypso-bridge' ),
+				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
+				'description' => __( 'Connect your Square account to accept credit and debit card, to track sales and sync inventory.', 'wc-calypso-bridge' ),
+				'estimate' => '2',
+				'link' => 'admin.php?page=wc-settings&tab=integration&section=squareconnect',
+				'learn_more' => 'https://woocommerce.com/products/square/',
+				'condition' => ! empty( $square_merchant_access_token ),
+				'extension' => 'woocommerce-square/woocommerce-square.php',
+			),
+
+			array(
+				'title' => __( 'Setup payments with PayPal', 'wc-calypso-bridge' ),
+				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
+				'description' => __( 'Connect your PayPal account to let customers to conveniently checkout directly with PayPal.', 'wc-calypso-bridge' ),
+				'estimate' => '2',
+				'link' => 'admin.php?page=wc-settings&tab=checkout&section=ppec_paypal',
+				'learn_more' => 'https://woocommerce.com/products/woocommerce-gateway-paypal-checkout/',
+				'condition' => false, // TODO Condition logic here.
+				'extension' => 'woocommerce-gateway-paypal-express-checkout/woocommerce-gateway-paypal-express-checkout.php',
+			),
+
+			array(
+				'title' => __( 'Setup payments with Stripe', 'wc-calypso-bridge' ),
+				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
+				'description' => __( 'Connect your Stripe account to accept credit and debit card payments.', 'wc-calypso-bridge' ),
+				'estimate' => '2',
+				'link' => 'admin.php?page=wc-settings&tab=checkout&section=ppec_paypal',
+				'learn_more' => 'https://woocommerce.com/products/stripe/',
+				'condition' => false, // TODO Condition logic here.
+				'extension' => 'woocommerce-gateway-stripe/woocommerce-gateway-stripe.php',
+			),
+
+			array(
+				'title' => __( 'Setup payments with Klarna', 'wc-calypso-bridge' ),
+				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
+				'description' => __( 'Connect your Klarna account to take payments with pay now, pay later and slice it.', 'wc-calypso-bridge' ),
+				'estimate' => '2',
+				'link' => 'admin.php?page=wc-settings&tab=checkout&section=klarna_payments',
+				'learn_more' => 'https://woocommerce.com/products/klarna-payments/',
+				'condition' => false, // TODO Condition logic here.
+				'extension' => 'klarna-payments-for-woocommerce/klarna-payments-for-woocommerce.php',
+			),
+
+			array(
+				'title' => __( 'Setup checkout with Klarna', 'wc-calypso-bridge' ),
+				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
+				'description' => __( 'Setup to provide a full checkout experience with pay now, pay later and slice it.', 'wc-calypso-bridge' ),
+				'estimate' => '2',
+				'link' => 'admin.php?page=wc-settings&tab=checkout&section=kco',
+				'learn_more' => 'https://woocommerce.com/products/klarna-checkout/',
+				'condition' => false, // TODO Condition logic here.
+				'extension' => 'klarna-checkout-for-woocommerce/klarna-checkout-for-woocommerce.php',
+			),
+
+			array(
+				'title' => __( 'Setup payments with eWAY', 'wc-calypso-bridge' ),
+				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
+				'description' => __( 'Connect your eWay account to take credit card payments directly on your store.', 'wc-calypso-bridge' ),
+				'estimate' => '2',
+				'link' => 'admin.php?page=wc-settings&tab=checkout&section=eway',
+				'condition' => false, // TODO Condition logic here.
+				'extension' => 'woocommerce-gateway-eway/woocommerce-gateway-eway.php',
+			),
+
+			array(
+				'title' => __( 'Setup payments with PayFast', 'wc-calypso-bridge' ),
+				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
+				'description' => __( 'Connect your PayFast account to accept payments by credit card and Electronic Fund Transfer.', 'wc-calypso-bridge' ),
+				'estimate' => '2',
+				'link' => 'admin.php?page=wc-settings&tab=checkout&section=payfast',
+				'condition' => false, // TODO Condition logic here.
+				'extension' => 'woocommerce-payfast-gateway/gateway-payfast.php',
+			),
+
+			array(
+				'title' => __( 'Enable automatic tax rates with Taxjar', 'wc-calypso-bridge' ),
+				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
+				'description' => __( 'Automatically collect sales tax at checkout by connecting with TaxJar.', 'wc-calypso-bridge' ),
+				'estimate' => '2',
+				'link' => 'admin.php?page=wc-settings&tab=integration&section=taxjar-integration',
+				'condition' => false, // TODO Condition logic here.
+				'extension' => 'taxjar-simplified-taxes-for-woocommerce/taxjar-woocommerce.php',
+			),
+
+			array(
+				'title' => __( 'Integrate with Facebook', 'wc-calypso-bridge' ),
+				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
+				'description' => __( 'Integrating Facebook with your store and drive sales.', 'wc-calypso-bridge' ),
+				'estimate' => '20',
+				'link' => 'admin.php?page=wc-settings&tab=integration&section=facebookcommerce',
+				'learn_more' => 'https://www.facebook.com/business/help/900699293402826',
+				'condition' => false, // TODO Condition logic here.
+				'extension' => 'facebook-for-woocommerce/facebook-for-woocommerce.php',
+			),
+
+			array(
+				'title' => __( 'Integrate with Mailchimp', 'wc-calypso-bridge' ),
+				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
+				'description' => __( 'Connect your store to bring the power of email marketing to your business.', 'wc-calypso-bridge' ),
+				'estimate' => '20',
+				'link' => 'options-general.php?page=mailchimp-woocommerce',
+				'learn_more' => 'https://wordpress.org/plugins/mailchimp-for-woocommerce/',
+				'condition' => false, // TODO Condition logic here.
+				'extension' => 'mailchimp-for-woocommerce/mailchimp-woocommerce.php',
+			),
+		);
+
+		$completed = 0;
+		$tasks     = array();
+		foreach ( $all_tasks as $task ) {
+			// Remove tasks for extensions that are not active.
+			if ( isset( $task['extension'] ) ) {
+				if ( ! is_plugin_active( $task['extension'] ) ) {
+					continue;
+				}
+			}
+
+			$tasks[] = $task;
+			if ( true === $task['condition'] ) {
+				$completed++;
+			}
+		}
+		$total = count( $tasks );
+
+		return( array(
+			'tasks'       => $tasks,
+			'completed'   => $completed,
+			'uncompleted' => $total - $completed,
+			'total'       => $total,
+		) );
 	}
 
+	/**
+	 * Renders the checklist display.
+	 */
+	public function checklist() {
+		$data = $this->get_task_data();
+		$percentage = floor( ( $data['completed'] / $data['total'] ) * 100 );
+		?>
+			<div class="checklist">
+				<div class="checklist-card checklist__header is-compact">
+					<div class="checklist__header-main">
+						<div class="checklist__header-progress">
+							<h2 class="checklist__header-progress-text"><?php esc_html_e( 'Your setup list', 'wc-calypso-bridge' ); ?></h2>
+							<span class="checklist__header-progress-number"><?php echo esc_html( $data['completed'] ); ?>/<?php echo esc_html( $data['total'] ); ?></span>
+						</div>
+						<div class="progress-bar is-compact">
+							<div class="progress-bar__progress" style="width: <?php echo intval( $percentage ); ?>%;"></div>
+						</div>
+					</div>
+				</div>
+				<div class="checklist__tasks">
+					<?php
+					foreach ( $data['tasks'] as $task ) {
+						$this->render_task( $task );
+					}
+					?>
+				</div>
+			</div>
+		<?php
+	}
+
+	/**
+	 * Renders a specific task.
+	 *
+	 * @param array $task Array of task information.
+	 */
+	public function render_task( $task ) {
+		$task_url = admin_url( $task['link'] );
+		?>
+		<div class="checklist-card checklist__task has-actionlink is-compact
+		<?php
+		if ( true === $task['condition'] ) {
+			echo ' is-completed';
+		}
+		?>
+		">
+		<div class="checklist__task-primary">
+			<h3 class="checklist__task-title">
+				<?php
+					echo '<a href="' . esc_url( $task_url ) . '" class="' . ( true === $task['condition'] ? 'task-is-completed' : '' ) . '">' . esc_html( $task['title'] ) . '</a>';
+				?>
+			</h3>
+			<p class="checklist__task-description">
+				<?php echo esc_html( $task['description'] ); ?>
+				<?php
+				if ( ! empty( $task['learn_more'] ) ) {
+					echo '<a href="' . esc_html( $task['learn_more'] ) . '" target="_blank"> ' . esc_html__( 'Learn more.', 'wc-calypso-bridge' ) . '</a>';
+				}
+				?>
+			</p>
+			<small class="checklist__task-duration">
+				<?php
+				/* translators: %s: Estimated amount of minutes for the task. */
+				printf( esc_html__( 'Estimated time: %d minutes', 'wc-calypso-bridge' ), intval( $task['estimate'] ) );
+				?>
+			</small>
+		</div>
+		<div class="checklist__task-secondary">
+			<?php
+			if ( true === $task['condition'] ) {
+				$action_link_secondary_class = 'checklist__task-action';
+				$title = $task['completed_title'];
+			} else {
+				$action_link_secondary_class = 'button-primary';
+				$title = $task['title'];
+			}
+			echo '<a href="' . esc_url( $task_url ) . '" class=" ' . esc_html( $action_link_secondary_class ) . '">' . esc_html( $title ) . '</a>';
+			?>
+			<small class="checklist__task-duration">
+				<?php
+				/* translators: %s: Estimated amount of minutes for the task. */
+				printf( esc_html__( 'Estimated time: %d minutes', 'wc-calypso-bridge' ), intval( $task['estimate'] ) );
+				?>
+			</small>
+		</div>
+		<?php if ( true === $task['condition'] ) { ?>
+			<div class="checklist__task-icon">
+				<svg class="gridicon gridicons-checkmark" height="18" width="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"></path></g></svg>
+			</div>
+		<?php } ?>
+		</div>
+		<?php
+	}
 }
 
 $wc_calypso_bridge_admin_setup_checklist = WC_Calypso_Bridge_Admin_Setup_Checklist::get_instance();

--- a/includes/class-wc-calypso-bridge-admin-setup-checklist.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-checklist.php
@@ -206,7 +206,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
 				'description' => __( 'Connect your Stripe account to accept credit and debit card payments.', 'wc-calypso-bridge' ),
 				'estimate' => '2',
-				'link' => 'admin.php?page=wc-settings&tab=checkout&section=ppec_paypal',
+				'link' => 'admin.php?page=wc-settings&tab=checkout&section=stripe',
 				'learn_more' => 'https://woocommerce.com/products/stripe/',
 				'condition' => false, // TODO Condition logic here.
 				'extension' => 'woocommerce-gateway-stripe/woocommerce-gateway-stripe.php',
@@ -255,7 +255,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 			),
 
 			array(
-				'title' => __( 'Enable automatic tax rates with Taxjar', 'wc-calypso-bridge' ),
+				'title' => __( 'Enable automatic tax rates with TaxJar', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
 				'description' => __( 'Automatically collect sales tax at checkout by connecting with TaxJar.', 'wc-calypso-bridge' ),
 				'estimate' => '2',
@@ -350,58 +350,52 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 	public function render_task( $task ) {
 		$task_url = admin_url( $task['link'] );
 		?>
-		<div class="checklist-card checklist__task has-actionlink is-compact
-		<?php
-		if ( true === $task['condition'] ) {
-			echo ' is-completed';
-		}
-		?>
-		">
-		<div class="checklist__task-primary">
-			<h3 class="checklist__task-title">
-				<?php
-					echo '<a href="' . esc_url( $task_url ) . '" class="' . ( true === $task['condition'] ? 'task-is-completed' : '' ) . '">' . esc_html( $task['title'] ) . '</a>';
-				?>
-			</h3>
-			<p class="checklist__task-description">
-				<?php echo esc_html( $task['description'] ); ?>
-				<?php
-				if ( ! empty( $task['learn_more'] ) ) {
-					echo '<a href="' . esc_html( $task['learn_more'] ) . '" target="_blank"> ' . esc_html__( 'Learn more.', 'wc-calypso-bridge' ) . '</a>';
-				}
-				?>
-			</p>
-			<small class="checklist__task-duration">
-				<?php
-				/* translators: %s: Estimated amount of minutes for the task. */
-				printf( esc_html__( 'Estimated time: %d minutes', 'wc-calypso-bridge' ), intval( $task['estimate'] ) );
-				?>
-			</small>
-		</div>
-		<div class="checklist__task-secondary">
-			<?php
-			if ( true === $task['condition'] ) {
-				$action_link_secondary_class = 'checklist__task-action';
-				$title = $task['completed_title'];
-			} else {
-				$action_link_secondary_class = 'button-primary';
-				$title = $task['title'];
-			}
-			echo '<a href="' . esc_url( $task_url ) . '" class=" ' . esc_html( $action_link_secondary_class ) . '">' . esc_html( $title ) . '</a>';
-			?>
-			<small class="checklist__task-duration">
-				<?php
-				/* translators: %s: Estimated amount of minutes for the task. */
-				printf( esc_html__( 'Estimated time: %d minutes', 'wc-calypso-bridge' ), intval( $task['estimate'] ) );
-				?>
-			</small>
-		</div>
-		<?php if ( true === $task['condition'] ) { ?>
-			<div class="checklist__task-icon">
-				<svg class="gridicon gridicons-checkmark" height="18" width="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"></path></g></svg>
+		<div class="checklist-card checklist__task has-actionlink is-compact <?php echo $task['condition'] ? 'is-completed' : ''; ?>">
+			<div class="checklist__task-primary">
+				<h3 class="checklist__task-title">
+					<?php
+						echo '<a href="' . esc_url( $task_url ) . '" class="' . ( true === $task['condition'] ? 'task-is-completed' : '' ) . '">' . esc_html( $task['title'] ) . '</a>';
+					?>
+				</h3>
+				<p class="checklist__task-description">
+					<?php echo esc_html( $task['description'] ); ?>
+					<?php
+					if ( ! empty( $task['learn_more'] ) ) {
+						echo '<a href="' . esc_html( $task['learn_more'] ) . '" target="_blank"> ' . esc_html__( 'Learn more.', 'wc-calypso-bridge' ) . '</a>';
+					}
+					?>
+				</p>
+				<small class="checklist__task-duration">
+					<?php
+					/* translators: %s: Estimated amount of minutes for the task. */
+					printf( esc_html__( 'Estimated time: %d minutes', 'wc-calypso-bridge' ), intval( $task['estimate'] ) );
+					?>
+				</small>
 			</div>
-		<?php } ?>
-		</div>
+			<div class="checklist__task-secondary">
+				<?php
+				if ( true === $task['condition'] ) {
+					$action_link_secondary_class = 'checklist__task-action';
+					$title = $task['completed_title'];
+				} else {
+					$action_link_secondary_class = 'button-primary';
+					$title = __( 'Do it', 'wc-calypso-bridge' );
+				}
+				echo '<a href="' . esc_url( $task_url ) . '" class=" ' . esc_html( $action_link_secondary_class ) . '">' . esc_html( $title ) . '</a>';
+				?>
+				<small class="checklist__task-duration">
+					<?php
+					/* translators: %s: Estimated amount of minutes for the task. */
+					printf( esc_html__( 'Estimated time: %d minutes', 'wc-calypso-bridge' ), intval( $task['estimate'] ) );
+					?>
+				</small>
+			</div>
+			<?php if ( true === $task['condition'] ) { ?>
+				<div class="checklist__task-icon">
+					<svg class="gridicon gridicons-checkmark" height="18" width="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"></path></g></svg>
+				</div>
+			<?php } ?>
+			</div>
 		<?php
 	}
 }


### PR DESCRIPTION
This PR adds the base rendering for the task list, and implements steps from the OBW spreadsheet. See #64.

There are still some items to do. Mainly, add missing tasks like Canada Post, and finish implementing the conditionals for if a task is completed or not.

In the meantime, I wanted to get this PR up before it got much larger. Sorry for the size. However, ~400 lines are CSS generated by the current Calypso checklist component.

<img width="794" alt="screen shot 2018-10-30 at 3 37 59 pm" src="https://user-images.githubusercontent.com/689165/47745335-cf204a00-dc59-11e8-8aa6-fc2dfdafd859.png">

To Test:
* Activate Calypsoify and go to `/wp-admin/admin.php?page=wc-setup-checklist`.
* Activate and deactivate some of the bundled extensions for the plan (Stripe, Klarna, etc). Verify the tasks no longer show up if the extension is disabled.
* Test the conditionals for the following tasks to test their completed mode: Add a product and verify the task is complete, configure UPS live rate settings (fill out all fields), Connect square (set a merchant token).