### PR TITLE
Add payment gateway settings and email settings breadcrumbs

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -621,3 +621,8 @@ table.wc-shipping-classes td.wc-shipping-zone-method-blank-state, table.wc-shipp
 		margin: 0;
 	}
 }
+
+/* Breadcrumbs */
+.wc-calypso-bridge-breadcrumbs + h2 {
+	display: none;
+}

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -58,6 +58,7 @@ class WC_Calypso_Bridge {
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-menus.php';
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-setup.php';
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-admin-setup-checklist.php';
+		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-breadcrumbs.php';
 		include_once dirname( __FILE__ ) . '/includes/gutenberg.php';
 
 		$connect_files = glob( dirname( __FILE__ ) . '/includes/connect/*.php' );

--- a/includes/class-wc-calypso-bridge-breadcrumbs.php
+++ b/includes/class-wc-calypso-bridge-breadcrumbs.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Removes the back links and adds the breadcrumbs on settings pages.
+ *
+ * @package WC_Calypso_Bridge/Classes
+ * @since   1.0.0
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC Calypso Bridge Breadcrumbs
+ */
+class WC_Calypso_Bridge_Breadcrumbs {
+
+	/**
+	 * Class instance.
+	 *
+	 * @var WC_Calypso_Bridge_Breadcrumbs instance
+	 */
+	protected static $instance = false;
+
+	/**
+	 * Get class instance
+	 */
+	public static function get_instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor
+	 */
+	private function __construct() {
+		add_action( 'woocommerce_settings_checkout', array( $this, 'add_payment_gateway_breadcrumbs' ) );
+		add_action( 'woocommerce_settings_email', array( $this, 'add_email_breadcrumbs' ) );
+	}
+
+	/**
+	 * Render breadcrumbs
+	 *
+	 * @param string $parent_page_title Title of parent page.
+	 * @param string $parent_page_url URL of parent page.
+	 * @param string $current_page_title Title of current (child) page.
+	 */
+	public function render_breadcrumbs( $parent_page_title, $parent_page_url, $current_page_title ) {
+		?>
+		<h2 class="wc-calypso-bridge-breadcrumbs">
+			<a href="<?php echo esc_url( $parent_page_url ); ?>"><?php echo esc_html( $parent_page_title ); ?></a>
+			&gt;
+			<?php echo esc_html( $current_page_title ); ?>
+		</h2>
+		<?php
+	}
+
+	/**
+	 * Add payment gateway breadcrumbs
+	 */
+	public function add_payment_gateway_breadcrumbs() {
+		$payment_gateways = WC()->payment_gateways->payment_gateways();
+		if ( isset( $_GET['section'] ) && ! empty( $payment_gateways ) && isset( $payment_gateways[ $_GET['section'] ] ) ) {
+			$gateway = $payment_gateways[ $_GET['section'] ]; // WPCS: CSRF ok, sanitization ok.
+			$this->render_breadcrumbs(
+				__( 'Payment methods', 'wc-calypso-bridge' ),
+				admin_url( '/admin.php?page=wc-settings&tab=checkout' ),
+				$gateway->get_method_title()
+			);
+		}
+	}
+
+	/**
+	 * Add email breadcrumbs
+	 */
+	public function add_email_breadcrumbs() {
+		$emails = wc()->mailer()->emails;
+		$emails = array_change_key_case( $emails );
+		if ( isset( $_GET['section'] ) && ! empty( $emails ) && isset( $emails[ $_GET['section'] ] ) ) {
+			$email = $emails[ $_GET['section'] ]; // WPCS: CSRF ok, sanitization ok.
+			$this->render_breadcrumbs(
+				__( 'Email notifications', 'wc-calypso-bridge' ),
+				admin_url( '/admin.php?page=wc-settings&tab=email' ),
+				$email->get_title()
+			);
+		}
+	}
+}
+$wc_calypso_bridge_breadcrumbs = WC_Calypso_Bridge_Breadcrumbs::get_instance();


### PR DESCRIPTION
Fixes #110 

This PR adds breadcrumbs to payment and email settings pages in WC and replaces the default title.

### Screenshots
<img width="474" alt="screen shot 2018-10-30 at 4 30 56 pm" src="https://user-images.githubusercontent.com/10561050/47751996-47d6d480-dc61-11e8-9e7a-469bfe7b4972.png">
<img width="495" alt="screen shot 2018-10-30 at 4 31 11 pm" src="https://user-images.githubusercontent.com/10561050/47751997-47d6d480-dc61-11e8-80fb-2e72b26047f9.png">

### Testing
1.  Visit `/wp-admin/admin.php?page=wc-settings&tab=checkout`, click any method, and verify breadcrumbs exist and that parent link to payments works.
2.  Visit `/wp-admin/admin.php?page=wc-settings&tab=email`, click any email, and verify breadcrumbs exist and parent link to email notifications works.