### PR TITLE
Add nav tab active state colors

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -171,6 +171,24 @@ div.woocommerce-message, .wc-helper .start-container {
 	border: 0;
 }
 
+/* Navigation tabs */
+.woocommerce nav.woo-nav-tab-wrapper {
+	width: 100%;
+}
+.nav-tab, .subsubsub a, .filter-links li>a {
+	color: #00aadc;
+}
+.nav-tab-active, .nav-tab-active:focus, .nav-tab-active:focus:active, .nav-tab-active:hover {
+	border-bottom: 2px solid #2e4453;
+	color: #000;
+}
+.subsubsub a.current, .filter-links .current {
+	border-bottom: 2px solid #2e4453;
+}
+.subsubsub a.current {
+	font-weight: 400;
+}
+
 /* Pill toggle styles */
 .woocommerce-input-toggle {
 	background: #00aadc;


### PR DESCRIPTION
Fixes #111 

This PR adds in the correct active state colors for the nav tabs. 

### Screenshots
<img width="1350" alt="screen shot 2018-10-31 at 10 55 44 am" src="https://user-images.githubusercontent.com/10561050/47801433-3393e580-dcfc-11e8-9064-b3f4528a1584.png">

### Testing
1.  Visit `/wp-admin/admin.php?page=wc-settings&tab=shipping`
2.  Confirm that style colors are correct and no "flickering" happens when hovering the active nav tabs.  Also check that the nav and subnav are the same width.