### PR TITLE
Fix masterbar hover state and product add-ons compatibility

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -746,3 +746,22 @@ table.widefat {
 .wc-calypso-bridge-breadcrumbs + h2 {
 	display: none;
 }
+
+/* Masterbar hover styles.
+TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10497/ is released */
+
+#wpadminbar .ab-top-menu > li.hover > .ab-item,
+#wpadminbar:not(.mobile) .ab-top-menu > li:hover > .ab-item {
+	background: #0099d8 !important;
+	color: #fff;
+}
+ #wpadminbar ul li#wp-admin-bar-ab-new-post:hover,
+#wpadminbar ul li#wp-admin-bar-ab-new-post:hover > .ab-item {
+	background: #fff !important;
+	opacity: 1;
+	border-radius: 5px;
+}
+ #wpadminbar ul li#wp-admin-bar-notes.active,
+#wpadminbar ul li#wp-admin-bar-notes.active > .ab-item {
+	background: #004967 !important;
+}

--- a/includes/connect/woocommerce-product-addons.php
+++ b/includes/connect/woocommerce-product-addons.php
@@ -1,7 +1,20 @@
 <?php
+/**
+ * Register Product Add-on Pages
+ *
+ * @package WC_Calypso_Bridge/Classes
+ */
+
 wc_calypso_bridge_connect_page(
 	array(
 		'screen_id' => 'product_page_global_addons',
+		'menu'      => 'edit.php?post_type=product',
+	)
+);
+
+wc_calypso_bridge_connect_page(
+	array(
+		'screen_id' => 'product_page_addons',
 		'menu'      => 'edit.php?post_type=product',
 	)
 );


### PR DESCRIPTION
Fixes #112.
Fixes #87.

This PR adds hover backgrounds for the masterbar to match WordPress.com.
It also makes sure the latest version of product add-ons is compatible with the menu system.

I have also posted a version of the hover state fix over at Jetpack: https://github.com/Automattic/jetpack/pull/10497/ -- however, I'm porting the change here since code freeze for 6.7 has already passed. We can remove the CSS here once the fix is actually released.

<img width="731" alt="screen shot 2018-10-31 at 12 38 35 pm" src="https://user-images.githubusercontent.com/689165/47804084-4c0afc80-dd0a-11e8-83f8-b5930ab6c128.png">

To Test:
* Hover over the masterbar items and confirm you see the light blue hover.
* Install the latest version of product add-ons (3.0.1) and go to Products > Add-ons. Verify the WooCommerce navigation sticks around.