### PR TITLE
Update large buttons 

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -105,6 +105,7 @@ div.woocommerce-message, .wc-helper .start-container {
 /* Large Buttons */
 .wp-core-ui button.button.button-large,
 .wp-core-ui input.button.button-large,
+.checklist__task-secondary .button-primary,
 #postbox-container-1 .button-primary,
 .wp-core-ui .woocommerce-save-button,
 .wc_addons_wrap .addons-button-solid,

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -103,7 +103,15 @@ div.woocommerce-message, .wc-helper .start-container {
 }
 
 /* Large Buttons */
-.wp-core-ui button.button.button-large {
+.wp-core-ui button.button.button-large,
+.wp-core-ui input.button.button-large,
+#postbox-container-1 .button-primary,
+.wp-core-ui .woocommerce-save-button,
+.wc_addons_wrap .addons-button-solid,
+.wc_addons_wrap .addons-button-outline-green,
+.wc_addons_wrap .addons-button-outline-white,
+.edit-tag-actions .button-primary,
+.woocommerce-BlankState a.button {
 	font-size: 14px !important;
 	padding: 7px 14px 9px !important;
 	line-height: 21px !important;
@@ -143,6 +151,18 @@ div.woocommerce-message, .wc-helper .start-container {
 }
 .wc-helper .button-update .dashicons, .wc-helper .button-update:hover .dashicons {
 	height: 13px;
+}
+
+/* Delete buttons */
+#all-plugins-table .plugins a.delete, #delete-link a.delete, #media-items a.delete, #media-items a.delete-permanently, #nav-menu-footer .menu-delete, #search-plugins-table .plugins a.delete, .plugins a.delete, .row-actions span.delete a, .row-actions span.spam a, .row-actions span.trash a, .submitbox .submitdelete {
+	color: #d94f4f;
+}
+#delete-link {
+    line-height: 38px;
+    margin-left: 12px;
+    font-size: 14px;
+    font-weight: 500;
+    color: #d94f4f;
 }
 
 /* White background behind the WooCommerce helper extensions navigation */
@@ -212,6 +232,15 @@ div.woocommerce-message, .wc-helper .start-container {
 
 #adminmenu li.current a.menu-top.toplevel_page_mailchimp-woocommerce .svg {
 	filter: none;
+}
+
+/* WooCommercer Orders */
+.order_actions li.wide {
+	display: flex;
+	align-items: center;
+}
+.order_actions li .save_order {
+	margin-left: auto;
 }
 
 /* Shipping zones */

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -320,7 +320,7 @@ table.widefat {
 }
 
 /* Removes table footer actions */
-.tablenav.bottom {
+.tablenav.bottom .actions, .tablenav.bottom .tablenav-pages {
 	display: none;
 }
 


### PR DESCRIPTION
Fixes #119 

This PR makes the following buttons large:

* Blank state action buttons (e.g., no products or coupons set yet)
* Save/update actions
* Extension buttons
* Checklist action buttons

### Screenshots
<img width="302" alt="screen shot 2018-10-31 at 11 46 12 am" src="https://user-images.githubusercontent.com/10561050/47807090-3ba65200-dd09-11e8-8cfa-c3fdf2432136.png">
<img width="394" alt="screen shot 2018-10-31 at 11 46 24 am" src="https://user-images.githubusercontent.com/10561050/47807091-3ba65200-dd09-11e8-8824-a6bbeac42666.png">
<img width="310" alt="screen shot 2018-10-31 at 11 57 54 am" src="https://user-images.githubusercontent.com/10561050/47807092-3ba65200-dd09-11e8-8428-c788a74084fa.png">
<img width="1200" alt="screen shot 2018-10-31 at 12 02 47 pm" src="https://user-images.githubusercontent.com/10561050/47807093-3c3ee880-dd09-11e8-8448-6b815cb07263.png">
<img width="570" alt="screen shot 2018-10-31 at 12 13 35 pm" src="https://user-images.githubusercontent.com/10561050/47807095-3c3ee880-dd09-11e8-90fd-131d95603476.png">
<img width="798" alt="screen shot 2018-10-31 at 12 30 03 pm" src="https://user-images.githubusercontent.com/10561050/47807096-3c3ee880-dd09-11e8-8c5c-9b4812ca536a.png">

### Testing

Make sure Calypsoify is enabled and check the following areas for proper button stying:

* Blank slate area (i.e., no coupons/orders) `/wp-admin/edit.php?post_type=shop_order`
* Save/update buttons for products, orders, categories.
* Extension buttons `/wp-admin/admin.php?page=wc-addons`
* Checklist action buttons `/wp-admin/admin.php?page=wc-setup-checklist` (you'll need to merge `add/checklist-steps` to test)