### PR TITLE
Setup checklist: Add missing conditionals and sidebar count

### DIFF
--- a/assets/css/setup-checklist.css
+++ b/assets/css/setup-checklist.css
@@ -411,3 +411,10 @@
 	-webkit-transition: width 200ms;
 	transition: width 200ms;
 }
+
+
+/** Removes klarna setup banner from top of setup screen */
+
+#klarna-kp-banner, #klarna-banner {
+	display: none;
+}


### PR DESCRIPTION
This PR adds the missing Canada Post task. It also adds the missing conditionals for the following tasks: Add product, view & customize, review shipping, Square, Stripe, Klarna payments, Klarna checkout, eWay, Payfast, TaxJar, Facebook, and Mailchimp.

It also adds an uncompleted task count to the sidebar. The number of uncompleted items is cached, because I don't want to do the settings checks on every single page. I've added some logic to bust the cache when the various plugins are configured. Because of this, I changed the tracking on the product task. I attempted to rely on product count, but trying to bust the cache on product create accurately wasn't trivial. I think this is fine for v1 (considering we were going to do this for all links previously).

<img width="1008" alt="screen shot 2018-10-31 at 4 01 49 pm" src="https://user-images.githubusercontent.com/689165/47816479-ab2c3980-dd29-11e8-9969-f3d0d843b4cd.png">

To test:
* Try configuring a few steps and verifying that the count updates and the task completes.
