### PR TITLE
Add calypso notice styling

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -973,12 +973,12 @@ TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10507
 div.notice,
 div.updated, 
 div.error {
-	display: none !important;
+	display: none;
 }
 .wc-calypso-bridge-notices div.notice,
 .wc-calypso-bridge-notices div.updated, 
 .wc-calypso-bridge-notices div.error {
-	display: flex !important;
+	display: flex;
 	position: relative;
 	width: 100%;
 	margin: 0 0 24px 0;
@@ -992,6 +992,9 @@ div.error {
 	line-height: 1.5;
 	border: 0;
 	overflow: hidden;
+}
+.wc-calypso-bridge-notices div:not(.hidden) {
+	display: flex !important;
 }
 div.notice > p,
 div.updated > p, 

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -963,9 +963,9 @@ TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10507
 	height: auto;
 }
 /* Notices */
-div.notice,
-div.updated, 
-div.error {
+.wrap div.notice,
+.wrap div.updated, 
+.wrap div.error {
 	display: flex;
 	position: relative;
 	width: 100%;
@@ -981,9 +981,9 @@ div.error {
 	border: 0;
 	overflow: hidden;
 }
-div.notice > p,
-div.updated > p, 
-div.error > p,
+.wrap div.notice > p,
+.wrap div.updated > p, 
+.wrap div.error > p,
 .wc-calypso-bridge-notice-content {
 	padding: 8px 13px;
 	margin: 0;
@@ -993,14 +993,14 @@ div.error > p,
 	margin: 5px 0;
 	font-size: 14px;
 }
-div.notice a,
-div.updated a, 
-div.error a {
+.wrap div.notice a,
+.wrap div.updated a, 
+.wrap div.error a {
 	color: #fff;
 }
-div.notice p.submit,
-div.updated p.submit, 
-div.error p.submit {
+.wrap div.notice p.submit,
+.wrap div.updated p.submit, 
+.wrap div.error p.submit {
 	display: flex;
 	-ms-flex-negative: 1;
 	flex-shrink: 1;
@@ -1011,12 +1011,12 @@ div.error p.submit {
 	padding: 13px 16px;
 	justify-content: center;
 }
-div.notice .button,
-div.notice .button-primary,
-div.updated .button, 
-div.updated .button-primary, 
-div.error .button,
-div.error .button-primary {
+.wrap div.notice .button,
+.wrap div.notice .button-primary,
+.wrap div.updated .button, 
+.wrap div.updated .button-primary, 
+.wrap div.error .button,
+.wrap div.error .button-primary {
 	color: #a8bece;
 	background: transparent !important;
 	border-width: 0 !important;
@@ -1024,21 +1024,21 @@ div.error .button-primary {
 	font-weight: 400 !important;
 	padding: 0 !important;
 }
-div.notice .button:hover,
-div.notice .button-primary:hover,
-div.updated .button:hover, 
-div.updated .button-primary:hover, 
-div.error .button:hover,
-div.error .button-primary:hover {
+.wrap div.notice .button:hover,
+.wrap div.notice .button-primary:hover,
+.wrap div.updated .button:hover, 
+.wrap div.updated .button-primary:hover, 
+.wrap div.error .button:hover,
+.wrap div.error .button-primary:hover {
 	color: #fff;
 	background: transparent !important;
 }
-div.notice .button:active,
-div.notice .button-primary:active,
-div.updated .button:active, 
-div.updated .button-primary:active, 
-div.error .button:active,
-div.error .button-primary:active {
+.wrap div.notice .button:active,
+.wrap div.notice .button-primary:active,
+.wrap div.updated .button:active, 
+.wrap div.updated .button-primary:active, 
+.wrap div.error .button:active,
+.wrap div.error .button-primary:active {
 	vertical-align: baseline;
 }
 .wc-calypso-bridge-notice-icon-wrapper {
@@ -1093,15 +1093,15 @@ div.error .button-primary:active {
 	fill: #fff;
 }
 @media screen and (max-width: 480px) {
-	div.notice p,
-	div.notice a.button,
-	div.notice a.button-primary,
-	div.error p,
-	div.error a.button,
-	div.error a.button-primary,
-	div.updated p,
-	div.updated a.button,
-	div.updated a.button-primary {
+	.wrap div.notice p,
+	.wrap div.notice a.button,
+	.wrap div.notice a.button-primary,
+	.wrap div.error p,
+	.wrap div.error a.button,
+	.wrap div.error a.button-primary,
+	.wrap div.updated p,
+	.wrap div.updated a.button,
+	.wrap div.updated a.button-primary {
 		font-size: 12px !important;
 	}
 }

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1105,3 +1105,23 @@ div.error .button-primary:active {
 .notice-dismiss:hover svg path {
 	fill: #fff;
 }
+@media screen and (max-width: 480px) {
+	.wc-calypso-bridge-notices {
+		top: auto;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		max-width: 100%;
+	}
+	.wc-calypso-bridge-notices div.notice,
+	.wc-calypso-bridge-notices div.updated,
+	.wc-calypso-bridge-notices div.error {
+		margin-bottom: 0;
+		border-radius: 0;
+	}
+	.wc-calypso-bridge-notices p,
+	.wc-calypso-bridge-notices a.button,
+	.wc-calypso-bridge-notices a.button-primary {
+		font-size: 12px !important;
+	}
+}

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -963,21 +963,9 @@ TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10507
 	height: auto;
 }
 /* Notices */
-.wc-calypso-bridge-notices {
-	position: fixed;
-	top: 73px;
-	right: 32px;
-	z-index: 10000;
-	max-width: calc( 100% - 64px);
-}
 div.notice,
 div.updated, 
 div.error {
-	display: none;
-}
-.wc-calypso-bridge-notices div.notice,
-.wc-calypso-bridge-notices div.updated, 
-.wc-calypso-bridge-notices div.error {
 	display: flex;
 	position: relative;
 	width: 100%;
@@ -992,9 +980,6 @@ div.error {
 	line-height: 1.5;
 	border: 0;
 	overflow: hidden;
-}
-.wc-calypso-bridge-notices div:not(.hidden) {
-	display: flex !important;
 }
 div.notice > p,
 div.updated > p, 
@@ -1108,22 +1093,15 @@ div.error .button-primary:active {
 	fill: #fff;
 }
 @media screen and (max-width: 480px) {
-	.wc-calypso-bridge-notices {
-		top: auto;
-		bottom: 0;
-		left: 0;
-		right: 0;
-		max-width: 100%;
-	}
-	.wc-calypso-bridge-notices div.notice,
-	.wc-calypso-bridge-notices div.updated,
-	.wc-calypso-bridge-notices div.error {
-		margin-bottom: 0;
-		border-radius: 0;
-	}
-	.wc-calypso-bridge-notices p,
-	.wc-calypso-bridge-notices a.button,
-	.wc-calypso-bridge-notices a.button-primary {
+	div.notice p,
+	div.notice a.button,
+	div.notice a.button-primary,
+	div.error p,
+	div.error a.button,
+	div.error a.button-primary,
+	div.updated p,
+	div.updated a.button,
+	div.updated a.button-primary {
 		font-size: 12px !important;
 	}
 }

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -967,14 +967,13 @@ TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10507
 	position: fixed;
 	top: 73px;
 	right: 32px;
-	z-index: 100;
+	z-index: 10000;
 	max-width: calc( 100% - 64px);
 }
-
-.wc-calypso-bridge-notices .notice,
-.wc-calypso-bridge-notices div.updated, 
-.wc-calypso-bridge-notices div.error {
-	display: flex;
+div.notice,
+div.updated, 
+div.error {
+	display: flex !important;
 	position: relative;
 	width: 100%;
 	margin: 0 0 24px 0;
@@ -989,29 +988,39 @@ TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10507
 	border: 0;
 	overflow: hidden;
 }
-.wc-calypso-bridge-notices .notice p,
-.wc-calypso-bridge-notices div.updated p, 
-.wc-calypso-bridge-notices div.error p {
+div.notice p,
+div.updated p, 
+div.error p {
 	padding: 13px;
 	margin: 0;
 }
-.wc-calypso-bridge-notices a {
+div.notice a,
+div.updated a, 
+div.error a {
 	color: #fff;
 }
-.wc-calypso-bridge-notices p.submit {
-    -ms-flex-negative: 1;
-    flex-shrink: 1;
-    -webkit-box-flex: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    -webkit-box-align: center;
-    -ms-flex-align: center;
-    align-items: center;
-    border-radius: 0;
-    margin: 0 0 0 auto !important;
-    padding: 13px 16px;
+div.notice p.submit,
+div.updated p.submit, 
+div.error p.submit {
+	display: flex;
+	-ms-flex-negative: 1;
+	flex-shrink: 1;
+	-webkit-box-flex: 0;
+	-ms-flex-positive: 0;
+	flex-grow: 0;
+	-webkit-box-align: center;
+	-ms-flex-align: center;
+	align-items: center;
+	border-radius: 0;
+	margin: 0 0 0 auto !important;
+	padding: 13px 16px;
 }
-.wc-calypso-bridge-notices p.submit a.button-primary {
+div.notice .button,
+div.notice .button-primary,
+div.updated .button, 
+div.updated .button-primary, 
+div.error .button,
+div.error .button-primary {
 	color: #a8bece;
 	background: transparent !important;
 	border-width: 0 !important;
@@ -1019,40 +1028,69 @@ TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10507
 	font-weight: 400 !important;
 	padding: 0 !important;
 }
-.wc-calypso-bridge-notices p.submit a.button-primary:hover {
+div.notice .button:hover,
+div.notice .button-primary:hover,
+div.updated .button:hover, 
+div.updated .button-primary:hover, 
+div.error .button:hover,
+div.error .button-primary:hover {
 	color: #fff;
+	background: transparent !important;
 }
-.wc-calypso-bridge-notices p.submit a.button-primary:active {
-	border-width: 0;
+div.notice .button:active,
+div.notice .button-primary:active,
+div.updated .button:active, 
+div.updated .button-primary:active, 
+div.error .button:active,
+div.error .button-primary:active {
+	vertical-align: baseline;
 }
 
 .wc-calypso-bridge-notice-icon-wrapper {
 	position: relative;
-    background: #537994;
-    color: #fff;
-    display: -webkit-box;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-box-align: baseline;
-    -ms-flex-align: baseline;
-    align-items: baseline;
-    width: 47px;
-    -webkit-box-pack: center;
-    -ms-flex-pack: center;
-    justify-content: center;
-    border-radius: 3px 0 0 3px;
-    -ms-flex-negative: 0;
-    flex-shrink: 0;
-    -ms-flex-item-align: stretch;
+	background: #537994;
+	color: #fff;
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-align: baseline;
+	-ms-flex-align: baseline;
+	align-items: baseline;
+	width: 47px;
+	-webkit-box-pack: center;
+	-ms-flex-pack: center;
+	justify-content: center;
+	border-radius: 3px 0 0 3px;
+	-ms-flex-negative: 0;
+	flex-shrink: 0;
+	-ms-flex-item-align: stretch;
 	align-self: stretch;
 	align-items: center;
 }
 .wc-calypso-bridge-notice-icon-wrapper svg path {
-    fill: #fff;
+	fill: #fff;
 }
 .error .wc-calypso-bridge-notice-icon-wrapper {
-    background: #ea4149;
+	background: #ea4149;
 }
 .notice-success .wc-calypso-bridge-notice-icon-wrapper {
-    background: #4ab866;
+	background: #4ab866;
+}
+.notice-warning .wc-calypso-bridge-notice-icon-wrapper {
+	background: #f0b849;
+}
+.notice-dismiss {
+	height: 100%;
+}
+.notice-dismiss:before {
+	display: none;
+}
+.notice-dismiss:focus {
+	box-shadow: none;
+}
+.notice-dismiss svg path {
+	fill: #a8bece;
+}
+.notice-dismiss:hover svg path {
+	fill: #fff;
 }

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -973,6 +973,11 @@ TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10507
 div.notice,
 div.updated, 
 div.error {
+	display: none !important;
+}
+.wc-calypso-bridge-notices div.notice,
+.wc-calypso-bridge-notices div.updated, 
+.wc-calypso-bridge-notices div.error {
 	display: flex !important;
 	position: relative;
 	width: 100%;
@@ -988,11 +993,15 @@ div.error {
 	border: 0;
 	overflow: hidden;
 }
-div.notice p,
-div.updated p, 
-div.error p {
-	padding: 13px;
+div.notice > p,
+div.updated > p, 
+div.error > p,
+.wc-calypso-bridge-notice-content {
+	padding: 8px 13px;
 	margin: 0;
+}
+.wc-calypso-bridge-notice-content p {
+	margin: 5px 0;
 }
 div.notice a,
 div.updated a, 
@@ -1045,7 +1054,6 @@ div.error .button:active,
 div.error .button-primary:active {
 	vertical-align: baseline;
 }
-
 .wc-calypso-bridge-notice-icon-wrapper {
 	position: relative;
 	background: #537994;

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1002,9 +1002,11 @@ div.error > p,
 .wc-calypso-bridge-notice-content {
 	padding: 8px 13px;
 	margin: 0;
+	flex-direction: column;
 }
 .wc-calypso-bridge-notice-content p {
 	margin: 5px 0;
+	font-size: 14px;
 }
 div.notice a,
 div.updated a, 
@@ -1020,12 +1022,9 @@ div.error p.submit {
 	-webkit-box-flex: 0;
 	-ms-flex-positive: 0;
 	flex-grow: 0;
-	-webkit-box-align: center;
-	-ms-flex-align: center;
-	align-items: center;
-	border-radius: 0;
 	margin: 0 0 0 auto !important;
 	padding: 13px 16px;
+	justify-content: center;
 }
 div.notice .button,
 div.notice .button-primary,
@@ -1092,6 +1091,9 @@ div.error .button-primary:active {
 }
 .notice-dismiss {
 	height: 100%;
+	margin: 0 0 0 auto !important;
+	position: static;
+	padding: 9px !important;
 }
 .notice-dismiss:before {
 	display: none;

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -962,3 +962,97 @@ TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10507
 	width: 20%;
 	height: auto;
 }
+/* Notices */
+.wc-calypso-bridge-notices {
+	position: fixed;
+	top: 73px;
+	right: 32px;
+	z-index: 100;
+	max-width: calc( 100% - 64px);
+}
+
+.wc-calypso-bridge-notices .notice,
+.wc-calypso-bridge-notices div.updated, 
+.wc-calypso-bridge-notices div.error {
+	display: flex;
+	position: relative;
+	width: 100%;
+	margin: 0 0 24px 0;
+	padding: 0;
+	box-sizing: border-box;
+	animation: appear .3s ease-in-out;
+	background: #2e4453;
+	color: #fff;
+	border-radius: 3px;
+	font-size: 14px;
+	line-height: 1.5;
+	border: 0;
+	overflow: hidden;
+}
+.wc-calypso-bridge-notices .notice p,
+.wc-calypso-bridge-notices div.updated p, 
+.wc-calypso-bridge-notices div.error p {
+	padding: 13px;
+	margin: 0;
+}
+.wc-calypso-bridge-notices a {
+	color: #fff;
+}
+.wc-calypso-bridge-notices p.submit {
+    -ms-flex-negative: 1;
+    flex-shrink: 1;
+    -webkit-box-flex: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    border-radius: 0;
+    margin: 0 0 0 auto !important;
+    padding: 13px 16px;
+}
+.wc-calypso-bridge-notices p.submit a.button-primary {
+	color: #a8bece;
+	background: transparent !important;
+	border-width: 0 !important;
+	font-size: 14px !important;
+	font-weight: 400 !important;
+	padding: 0 !important;
+}
+.wc-calypso-bridge-notices p.submit a.button-primary:hover {
+	color: #fff;
+}
+.wc-calypso-bridge-notices p.submit a.button-primary:active {
+	border-width: 0;
+}
+
+.wc-calypso-bridge-notice-icon-wrapper {
+	position: relative;
+    background: #537994;
+    color: #fff;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: baseline;
+    -ms-flex-align: baseline;
+    align-items: baseline;
+    width: 47px;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
+    justify-content: center;
+    border-radius: 3px 0 0 3px;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    -ms-flex-item-align: stretch;
+	align-self: stretch;
+	align-items: center;
+}
+.wc-calypso-bridge-notice-icon-wrapper svg path {
+    fill: #fff;
+}
+.error .wc-calypso-bridge-notice-icon-wrapper {
+    background: #ea4149;
+}
+.notice-success .wc-calypso-bridge-notice-icon-wrapper {
+    background: #4ab866;
+}

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -42,5 +42,20 @@
             );
         }
     } );
+    
+    /**
+     * Move admin notices
+     */
+    $( document ).ready( function() {
+        $( 'body' ).append( '<div class="wc-calypso-bridge-notices"></div>' );
+        $( 'div.updated, div.error, div.notice' ).not( '.inline, .below-h2' ).appendTo( $( '.wc-calypso-bridge-notices' ) );
+    } );
+
+    /**
+     * Append icons to notices
+     */
+    $( 'div.notice:not(.notice-success), div.updated:not(.notice-success)' ).prepend( '<span class="wc-calypso-bridge-notice-icon-wrapper"><svg class="gridicon gridicons-info" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"/></g></svg></span>' );
+    $( 'div.error' ).prepend( '<span class="wc-calypso-bridge-notice-icon-wrapper"><svg class="gridicon gridicons-notice" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"/></g></svg></span>' );
+    $( 'div.notice-success' ).prepend( '<span class="wc-calypso-bridge-notice-icon-wrapper"><svg class="gridicon gridicons-checkmark" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"/></g></svg></span>' );
 
 } )( jQuery );

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -54,8 +54,14 @@
     /**
      * Append icons to notices
      */
-    $( 'div.notice:not(.notice-success), div.updated:not(.notice-success)' ).prepend( '<span class="wc-calypso-bridge-notice-icon-wrapper"><svg class="gridicon gridicons-info" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"/></g></svg></span>' );
-    $( 'div.error' ).prepend( '<span class="wc-calypso-bridge-notice-icon-wrapper"><svg class="gridicon gridicons-notice" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"/></g></svg></span>' );
-    $( 'div.notice-success' ).prepend( '<span class="wc-calypso-bridge-notice-icon-wrapper"><svg class="gridicon gridicons-checkmark" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"/></g></svg></span>' );
+    $( 'div.notice, div.error, div.updated, div.warning' ).each( function() {
+        var icon = '<svg class="gridicon gridicons-info" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"/></g></svg>';
+        if ( $( this ).hasClass( 'notice-success') ) {
+            icon = '<svg class="gridicon gridicons-checkmark" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"/></g></svg>';
+        } else if ( $( this ).hasClass( 'error' ) || $( this ).hasClass( 'notice-warning' ) ) {
+            icon = '<svg class="gridicon gridicons-notice" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"/></g></svg>';
+        }
+        $( this ).prepend( '<span class="wc-calypso-bridge-notice-icon-wrapper">' + icon + '</span>' );
+    } );
 
 } )( jQuery );

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -65,10 +65,21 @@
     } );
 
     /**
-     * Replace dismissal buttons
+     * Replace dismissal buttons in notices
      */
     $( document ).ready( function() {
         $( '.notice-dismiss' ).html( '<svg class="gridicon gridicons-cross" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M18.36 19.78L12 13.41l-6.36 6.37-1.42-1.42L10.59 12 4.22 5.64l1.42-1.42L12 10.59l6.36-6.36 1.41 1.41L13.41 12l6.36 6.36z"/></g></svg>' );
+    } );
+
+    /**
+     * Place notice content inside it's own tag
+     * 
+     * Used to prevent side by side content in flexbox when multiple paragraphs exist.
+     */
+    $( 'div.notice, div.error, div.updated, div.warning' ).each( function() {
+        var $noticeContent = $( '<div class="wc-calypso-bridge-notice-content"></div>' );
+        $( this ).find( '.wc-calypso-bridge-notice-icon-wrapper' ).after( $noticeContent );
+        $( this ).find( 'p:not(.submit)' ).appendTo( $noticeContent );
     } );
 
 } )( jQuery );

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -64,4 +64,11 @@
         $( this ).prepend( '<span class="wc-calypso-bridge-notice-icon-wrapper">' + icon + '</span>' );
     } );
 
+    /**
+     * Replace dismissal buttons
+     */
+    $( document ).ready( function() {
+        $( '.notice-dismiss' ).html( '<svg class="gridicon gridicons-cross" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M18.36 19.78L12 13.41l-6.36 6.37-1.42-1.42L10.59 12 4.22 5.64l1.42-1.42L12 10.59l6.36-6.36 1.41 1.41L13.41 12l6.36 6.36z"/></g></svg>' );
+    } );
+
 } )( jQuery );

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -42,14 +42,6 @@
             );
         }
     } );
-    
-    /**
-     * Move admin notices
-     */
-    $( document ).ready( function() {
-        $( 'body' ).append( '<div class="wc-calypso-bridge-notices"></div>' );
-        $( 'div.updated, div.error, div.notice' ).not( '.inline, .below-h2' ).appendTo( $( '.wc-calypso-bridge-notices' ) );
-    } );
 
     /**
      * Append icons to notices

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -48,7 +48,8 @@ class WC_Calypso_Bridge {
 		if ( 1 === (int) get_user_meta( get_current_user_id(), 'calypsoify', true ) ) {
 			$this->includes();
 			// Hook on `admin_print_styles`, after some WC CSS is hooked, so we can override a few '!important' styles.
-			add_action( 'admin_print_styles', array( $this, 'enqueue_calypsoify_styles' ), 11 );
+			add_action( 'admin_print_styles', array( $this, 'enqueue_calypsoify_scripts' ), 11 );
+			add_action( 'admin_init', array( $this, 'remove_woocommerce_footer_text' ) );
 		}
 	}
 
@@ -90,10 +91,16 @@ class WC_Calypso_Bridge {
 	/**
 	 * Add calypsoify styles
 	 */
-	public function enqueue_calypsoify_styles() {
+	public function enqueue_calypsoify_scripts() {
 		$asset_path = self::$plugin_asset_path ? self::$plugin_asset_path : self::MU_PLUGIN_ASSET_PATH;
 		wp_enqueue_style( 'wc-calypso-bridge-calypsoify', $asset_path . 'assets/css/calypsoify.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION, 'all' );
 		wp_enqueue_script( 'wc-calypso-bridge-calypsoify', $asset_path . 'assets/js/calypsoify.js', array( 'jquery' ), WC_CALYPSO_BRIDGE_CURRENT_VERSION, true );
+	}
+
+	/**
+	 * Remove WooCommerce footer text
+	 */
+	public function remove_woocommerce_footer_text() {
 		add_filter( 'woocommerce_display_admin_footer_text', '__return_false' );
 	}
 


### PR DESCRIPTION
Fixes #118 , fixes (maybe) #122 

This PR adds styling to notices to make them more like Calypso notices.  

### Screenshots
<img width="1309" alt="screen shot 2018-11-01 at 9 14 11 am" src="https://user-images.githubusercontent.com/10561050/47858069-330d5480-ddb9-11e8-8723-baf1a6d1a31a.png">
<img width="429" alt="screen shot 2018-11-01 at 9 31 05 am" src="https://user-images.githubusercontent.com/10561050/47858070-330d5480-ddb9-11e8-8f44-2ff63138ca61.png">

### Testing
1.  Visit any pages with notices with `calypsoify=1` enabled.
2.  Check that notices appear correctly with respective styles (warning, error, success, notice).
3.  Check that notices fix to bottom of screen on mobile (<480px).

### Notes

* This PR hides all notices that aren't moved into the `wc-calypso-bridge-notices` container to prevent FOUC.  It does this after the document is ready so it should capture nearly all notices, but if a plugin author added a notice via AJAX, it would most likely be hidden.
* With many notices, the screen can easily become unusable (see screenshots).  We can:
    1. Make the notice container not fixed and less Calypso like (default area for notices, but still styled like Calypso
    2. Add a dismissable button that would close the notice to temporarily make the screen more usable, however the notice would persist on next refresh.
    3. Other ideas?

@josemarques What are your thoughts on the last point?  Any other changes you think need to be made here?