### PR TITLE
Fix subscription connection menu link colors

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -917,3 +917,13 @@ TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10497
 #footer-thankyou, #footer-upgrade {
 	display: none;
 }
+
+/* Connected to WooCommerce.com dropdown on extension subscription page */
+.wc-helper .user-info section a {
+	color: #0073aa;
+}
+
+.wc-helper .user-info section a:hover {
+	background: transparent;
+	color: #00a0d2;
+}


### PR DESCRIPTION
Fixes #124.

This PR fixes the purple styles in the Subscriptions screen dropdown that manages the connection to WooCommerce.com. 

<img width="325" alt="screen shot 2018-11-01 at 3 06 28 pm" src="https://user-images.githubusercontent.com/689165/47873602-0ae91a00-dde8-11e8-9842-55b6456a05b2.png">

cc @josemarques 

To Test:
* Make sure you are connected to your WooCommerce.com account.
* WooCommerce > Extensions > WooCommerce.com Subscriptions > Hover over Connected to WooCommerce.com.
* Verify link colors.