### PR TITLE
Track events inside OBW and checklist

### DIFF
--- a/assets/js/calypsoify-obw.js
+++ b/assets/js/calypsoify-obw.js
@@ -29,7 +29,9 @@
     $( document ).on( 'click', '.toggle-store_address_edit', function( e ) {
         e.preventDefault();
         $( this ).closest( 'form' ).removeClass( 'store-address-preview-mode' );
-        window.jpTracksAJAX.record_ajax_event( 'atomic_wc_obw_edit_address', 'click' );
+        if (window.jpTracksAJAX) {
+            window.jpTracksAJAX.record_ajax_event( 'atomic_wc_obw_edit_address', 'click' );
+        }
     } );
 
 } )( jQuery );

--- a/assets/js/calypsoify-obw.js
+++ b/assets/js/calypsoify-obw.js
@@ -29,6 +29,7 @@
     $( document ).on( 'click', '.toggle-store_address_edit', function( e ) {
         e.preventDefault();
         $( this ).closest( 'form' ).removeClass( 'store-address-preview-mode' );
+        window.jpTracksAJAX.record_ajax_event( 'atomic_wc_obw_edit_address', 'click' );
     } );
 
 } )( jQuery );

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -19,4 +19,24 @@
         );
     } );
 
+    /**
+     * Track 'I'm done' completion on task list
+     */
+    $( '.setup-footer a' ).click( function(e) {
+        e.preventDefault();
+        var progressNumber = $( '.checklist__header-progress-number' ).text().split( '/' );
+        var complete = progressNumber[0];
+        var total = progressNumber[1];
+        var percentage = parseFloat( complete / total ).toFixed( 2 ) * 100;
+        window.jpTracksAJAX.record_ajax_event(
+            'atomic_wc_tasklist_finished',
+            'click',
+            { 
+                complete: complete,
+                total: total,
+                percentage: percentage
+            }
+        );
+    } );
+
 } )( jQuery );

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -7,12 +7,14 @@
     $( '.checklist__task-title a, .checklist__task-secondary a' ).click( function() {
         var $task = $( this ).closest( '.checklist__task' )
         var status = $task.hasClass( 'is-completed' ) ? 'complete' : 'incomplete';
+        var taskId = $task.data('id');
         var taskTitle = $task.data('title');
 
         window.jpTracksAJAX.record_ajax_event(
             'atomic_wc_tasklist_click',
             'click',
-            { 
+            {
+                id: parseInt( taskId ),
                 title: taskTitle, 
                 status: status,
             }

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -10,7 +10,7 @@
         var taskTitle = $task.data('title');
 
         window.jpTracksAJAX.record_ajax_event(
-            'atomic_wc_tasklist_clicked',
+            'atomic_wc_tasklist_click',
             'click',
             { 
                 title: taskTitle, 
@@ -29,7 +29,7 @@
         var total = progressNumber[1];
         var percentage = parseFloat( complete / total ).toFixed( 2 ) * 100;
         window.jpTracksAJAX.record_ajax_event(
-            'atomic_wc_tasklist_finished',
+            'atomic_wc_tasklist_finish',
             'click',
             { 
                 complete: complete,

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -14,7 +14,7 @@
             'atomic_wc_tasklist_click',
             'click',
             {
-                id: parseInt( taskId ),
+                id: taskId,
                 title: taskTitle, 
                 status: status,
             }

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -1,0 +1,22 @@
+( function( $ ) {
+    'use strict';
+
+    /**
+     * Record checklist task click
+     */
+    $( '.checklist__task-title a, .checklist__task-secondary a' ).click( function() {
+        var $task = $( this ).closest( '.checklist__task' )
+        var status = $task.hasClass( 'is-completed' ) ? 'complete' : 'incomplete';
+        var taskTitle = $task.data('title');
+
+        window.jpTracksAJAX.record_ajax_event(
+            'atomic_wc_tasklist_clicked',
+            'click',
+            { 
+                title: taskTitle, 
+                status: status,
+            }
+        );
+    } );
+
+} )( jQuery );

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -30,15 +30,17 @@
         var complete = progressNumber[0];
         var total = progressNumber[1];
         var percentage = parseFloat( complete / total ).toFixed( 2 ) * 100;
-        window.jpTracksAJAX.record_ajax_event(
-            'atomic_wc_tasklist_finish',
-            'click',
-            { 
-                complete: complete,
-                total: total,
-                percentage: percentage
-            }
-        );
+        if (window.jpTracksAJAX) {
+            window.jpTracksAJAX.record_ajax_event(
+                'atomic_wc_tasklist_finish',
+                'click',
+                { 
+                    complete: complete,
+                    total: total,
+                    percentage: percentage
+                }
+            );
+        }
     } );
 
 } )( jQuery );

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -92,6 +92,7 @@ class WC_Calypso_Bridge {
 	public function enqueue_calypsoify_styles() {
 		$asset_path = self::$plugin_asset_path ? self::$plugin_asset_path : self::MU_PLUGIN_ASSET_PATH;
 		wp_enqueue_style( 'wc-calypso-bridge-calypsoify', $asset_path . 'assets/css/calypsoify.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION, 'all' );
+		wp_enqueue_script( 'wc-calypso-bridge-calypsoify', $asset_path . 'assets/js/calypsoify.js', array( 'jquery' ), WC_CALYPSO_BRIDGE_CURRENT_VERSION, true );
 		add_filter( 'woocommerce_display_admin_footer_text', '__return_false' );
 	}
 

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -124,7 +124,8 @@ class WC_Calypso_Bridge {
 					$current_user,
 					'atomic_wc_calypsoify_toggle',
 					array(
-						'status' => intval( $_GET['calypsoify'] ) ? 'on' : 'off', // WPCS: CSRF ok.
+						'blog_id' => Jetpack_Options::get_option( 'id' ),
+						'status'  => intval( $_GET['calypsoify'] ) ? 'on' : 'off', // WPCS: CSRF ok.
 					)
 				);
 			}

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -44,6 +44,7 @@ class WC_Calypso_Bridge {
 	 * Load calypsoify plugins if query param / user setting is set
 	 */
 	public function possibly_load_calypsoify() {
+		add_action( 'admin_init', array( $this, 'track_calypsoify_toggle' ) );
 		if ( 1 === (int) get_user_meta( get_current_user_id(), 'calypsoify', true ) ) {
 			$this->includes();
 			// Hook on `admin_print_styles`, after some WC CSS is hooked, so we can override a few '!important' styles.
@@ -105,6 +106,27 @@ class WC_Calypso_Bridge {
 				update_user_meta( get_current_user_id(), 'calypsoify', 1 );
 				wp_safe_redirect( admin_url( 'admin.php?page=wc-setup-checklist' ) );
 				exit;
+			}
+		}
+	}
+
+	/**
+	 * Track Calypsoify events when turned on or off
+	 */
+	public function track_calypsoify_toggle() {
+		if ( isset( $_GET['calypsoify'] ) ) { // WPCS: CSRF ok.
+			$current_user      = wp_get_current_user();
+			$calypsoify_status = (int) get_user_meta( $current_user->ID, 'calypsoify', true );
+			if ( 1 === $calypsoify_status && 0 === (int) $_GET['calypsoify'] ) { // WPCS: CSRF ok.
+				jetpack_tracks_record_event(
+					$current_user,
+					'atomic_wc_calypsoify_off'
+				);
+			} elseif ( 0 === $calypsoify_status && 1 === (int) $_GET['calypsoify'] ) { // WPCS: CSRF ok.
+				jetpack_tracks_record_event(
+					$current_user,
+					'atomic_wc_calypsoify_on'
+				);
 			}
 		}
 	}

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -117,15 +117,15 @@ class WC_Calypso_Bridge {
 		if ( isset( $_GET['calypsoify'] ) ) { // WPCS: CSRF ok.
 			$current_user      = wp_get_current_user();
 			$calypsoify_status = (int) get_user_meta( $current_user->ID, 'calypsoify', true );
-			if ( 1 === $calypsoify_status && 0 === (int) $_GET['calypsoify'] ) { // WPCS: CSRF ok.
+			if ( 1 === $calypsoify_status && 0 === (int) $_GET['calypsoify'] // WPCS: CSRF ok.
+				|| 0 === $calypsoify_status && 1 === (int) $_GET['calypsoify'] // WPCS: CSRF ok.
+			) {
 				jetpack_tracks_record_event(
 					$current_user,
-					'atomic_wc_calypsoify_off'
-				);
-			} elseif ( 0 === $calypsoify_status && 1 === (int) $_GET['calypsoify'] ) { // WPCS: CSRF ok.
-				jetpack_tracks_record_event(
-					$current_user,
-					'atomic_wc_calypsoify_on'
+					'atomic_wc_calypsoify_toggle',
+					array(
+						'status' => intval( $_GET['calypsoify'] ) ? 'on' : 'off', // WPCS: CSRF ok.
+					)
 				);
 			}
 		}

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -115,20 +115,34 @@ class WC_Calypso_Bridge {
 	 */
 	public function track_calypsoify_toggle() {
 		if ( isset( $_GET['calypsoify'] ) ) { // WPCS: CSRF ok.
-			$current_user      = wp_get_current_user();
 			$calypsoify_status = (int) get_user_meta( $current_user->ID, 'calypsoify', true );
 			if ( 1 === $calypsoify_status && 0 === (int) $_GET['calypsoify'] // WPCS: CSRF ok.
 				|| 0 === $calypsoify_status && 1 === (int) $_GET['calypsoify'] // WPCS: CSRF ok.
 			) {
-				jetpack_tracks_record_event(
-					$current_user,
+				$this->record_event(
 					'atomic_wc_calypsoify_toggle',
-					array(
-						'blog_id' => Jetpack_Options::get_option( 'id' ),
-						'status'  => intval( $_GET['calypsoify'] ) ? 'on' : 'off', // WPCS: CSRF ok.
-					)
+					array( 'status' => intval( $_GET['calypsoify'] ) ? 'on' : 'off' ) // WPCS: CSRF ok.
 				);
 			}
+		}
+	}
+
+	/**
+	 * Record event using JetPack if enabled
+	 *
+	 * @param string $event_name Name of the event.
+	 * @param array  $event_params Custom event params to capture.
+	 */
+	public static function record_event( $event_name, $event_params ) {
+		if ( function_exists( 'jetpack_tracks_record_event' ) ) {
+			$current_user         = wp_get_current_user();
+			$default_event_params = array( 'blog_id' => Jetpack_Options::get_option( 'id' ) );
+			$event_params         = array_merge( $default_event_params, $event_params );
+			jetpack_tracks_record_event(
+				$current_user,
+				$event_name,
+				$event_params
+			);
 		}
 	}
 

--- a/includes/class-wc-calypso-bridge-admin-setup-checklist.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-checklist.php
@@ -187,12 +187,12 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 		}
 
 		$whitelist = array( 'customize', 'shipping', 'product' );
-		$step = $_GET['wc-setup-step']; // WPCS: CSRF ok, sanitization ok.
+		$step      = $_GET['wc-setup-step']; // WPCS: CSRF ok, sanitization ok.
 		if ( ! in_array( $step, $whitelist ) ) {
 			return;
 		}
 
-		$click_settings = get_option( 'woocommerce_setup_checklist_clicks', array() );
+		$click_settings          = get_option( 'woocommerce_setup_checklist_clicks', array() );
 		$click_settings[ $step ] = true;
 
 		update_option( 'woocommerce_setup_checklist_clicks', $click_settings );
@@ -204,10 +204,10 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 	public function menu_order_count() {
 		global $submenu;
 		if ( isset( $submenu['woocommerce'] ) ) {
-			$cache_key = 'woocommerce_setup_checklist_uncompleted_steps';
+			$cache_key   = 'woocommerce_setup_checklist_uncompleted_steps';
 			$setup_count = get_transient( $cache_key );
 			if ( false === $setup_count ) {
-				$data = $this->get_task_data();
+				$data        = $this->get_task_data();
 				$setup_count = $data['uncompleted'];
 				set_transient( $cache_key, $setup_count, 12 * HOUR_IN_SECONDS );
 			}
@@ -257,171 +257,186 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 
 		$all_tasks = array(
 			array(
-				'title' => __( 'Add a product', 'wc-calypso-bridge' ),
+				'id'              => 1,
+				'title'           => __( 'Add a product', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'Add another product', 'wc-calypso-bridge' ),
-				'description' => __( 'Start by adding your first product to your store.', 'wc-calypso-bridge' ),
-				'estimate' => '2',
-				'link' => 'post-new.php?post_type=product&wc-setup-step=product',
-				'condition' => isset( $click_settings['product'] ) && true === (bool) $click_settings['product'],
+				'description'     => __( 'Start by adding your first product to your store.', 'wc-calypso-bridge' ),
+				'estimate'        => '2',
+				'link'            => 'post-new.php?post_type=product&wc-setup-step=product',
+				'condition'       => isset( $click_settings['product'] ) && true === (bool) $click_settings['product'],
 			),
 
 			array(
-				'title' => __( 'View and customize', 'wc-calypso-bridge' ),
+				'id'              => 2,
+				'title'           => __( 'View and customize', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'Open customizer', 'wc-calypso-bridge' ),
-				'description' => __( 'You have access to a few themes with your plan. See the options, chose the right one for you and customize your store.', 'wc-calypso-bridge' ),
-				'estimate' => '2',
-				'link' => 'customize.php?return=%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-setup-checklist&wc-setup-step=customize',
-				'condition' => isset( $click_settings['customize'] ) && true === (bool) $click_settings['customize'],
+				'description'     => __( 'You have access to a few themes with your plan. See the options, chose the right one for you and customize your store.', 'wc-calypso-bridge' ),
+				'estimate'        => '2',
+				'link'            => 'customize.php?return=%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-setup-checklist&wc-setup-step=customize',
+				'condition'       => isset( $click_settings['customize'] ) && true === (bool) $click_settings['customize'],
 			),
 
 			array(
-				'title' => __( 'Review shipping', 'wc-calypso-bridge' ),
+				'id'              => 3,
+				'title'           => __( 'Review shipping', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
-				'description' => __( "We've set up a few shipping options based on your store location. Check them out to see if they're right for you.", 'wc-calypso-bridge' ),
-				'estimate' => '2',
-				'link' => 'admin.php?page=wc-settings&tab=shipping&wc-setup-step=shipping',
-				'condition' => isset( $click_settings['shipping'] ) && true === (bool) $click_settings['shipping'],
+				'description'     => __( "We've set up a few shipping options based on your store location. Check them out to see if they're right for you.", 'wc-calypso-bridge' ),
+				'estimate'        => '2',
+				'link'            => 'admin.php?page=wc-settings&tab=shipping&wc-setup-step=shipping',
+				'condition'       => isset( $click_settings['shipping'] ) && true === (bool) $click_settings['shipping'],
 			),
 
 			array(
-				'title' => __( 'Add live rates with UPS', 'wc-calypso-bridge' ),
+				'id'              => 4,
+				'title'           => __( 'Add live rates with UPS', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
-				'description' => __( "Showing shipping rates directly from UPS during checkout ensures you're charging customers the right amount for shipping.", 'wc-calypso-bridge' ),
-				'estimate' => '2',
-				'link' => 'admin.php?page=wc-settings&tab=shipping&section=ups',
-				'condition' => ! empty( $ups_settings['user_id'] ) &&
+				'description'     => __( "Showing shipping rates directly from UPS during checkout ensures you're charging customers the right amount for shipping.", 'wc-calypso-bridge' ),
+				'estimate'        => '2',
+				'link'            => 'admin.php?page=wc-settings&tab=shipping&section=ups',
+				'condition'       => ! empty( $ups_settings['user_id'] ) &&
 							   ! empty( $ups_settings['password'] ) &&
 							   ! empty( $ups_settings['access_key'] ) &&
 							   ! empty( $ups_settings['shipper_number'] ),
-				'extension' => 'woocommerce-shipping-ups/woocommerce-shipping-ups.php',
+				'extension'       => 'woocommerce-shipping-ups/woocommerce-shipping-ups.php',
 			),
 
 			array(
-				'title' => __( 'Add live rates with Canada Post', 'wc-calypso-bridge' ),
+				'id'              => 5,
+				'title'           => __( 'Add live rates with Canada Post', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
-				'description' => __( 'Get shipping rates for domestic and international parcels.', 'wc-calypso-bridge' ),
-				'estimate' => '2',
-				'link' => 'https://woocommerce.com/wc-api/canada_post_registration?return_url=' . WC()->api_request_url( 'canada_post_return' ),
-				'condition' => ! empty( $wc_canada_post_merchant_username ) &&
+				'description'     => __( 'Get shipping rates for domestic and international parcels.', 'wc-calypso-bridge' ),
+				'estimate'        => '2',
+				'link'            => 'https://woocommerce.com/wc-api/canada_post_registration?return_url=' . WC()->api_request_url( 'canada_post_return' ),
+				'condition'       => ! empty( $wc_canada_post_merchant_username ) &&
 							   ! empty( $wc_canada_post_merchant_password ),
-				'extension' => 'woocommerce-shipping-canada-post/woocommerce-shipping-canada-post.php',
+				'extension'       => 'woocommerce-shipping-canada-post/woocommerce-shipping-canada-post.php',
 			),
 
 			array(
-				'title' => __( 'Setup payments with Square', 'wc-calypso-bridge' ),
+				'id'              => 6,
+				'title'           => __( 'Setup payments with Square', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
-				'description' => __( 'Connect your Square account to accept credit and debit card, to track sales and sync inventory.', 'wc-calypso-bridge' ),
-				'estimate' => '2',
-				'link' => 'admin.php?page=wc-settings&tab=integration&section=squareconnect',
-				'learn_more' => 'https://woocommerce.com/products/square/',
-				'condition' => ! empty( $square_merchant_access_token ),
-				'extension' => 'woocommerce-square/woocommerce-square.php',
+				'description'     => __( 'Connect your Square account to accept credit and debit card, to track sales and sync inventory.', 'wc-calypso-bridge' ),
+				'estimate'        => '2',
+				'link'            => 'admin.php?page=wc-settings&tab=integration&section=squareconnect',
+				'learn_more'      => 'https://woocommerce.com/products/square/',
+				'condition'       => ! empty( $square_merchant_access_token ),
+				'extension'       => 'woocommerce-square/woocommerce-square.php',
 			),
 
 			array(
-				'title' => __( 'Setup payments with PayPal', 'wc-calypso-bridge' ),
+				'id'              => 7,
+				'title'           => __( 'Setup payments with PayPal', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
-				'description' => __( 'Connect your PayPal account to let customers to conveniently checkout directly with PayPal.', 'wc-calypso-bridge' ),
-				'estimate' => '2',
-				'link' => 'admin.php?page=wc-settings&tab=checkout&section=ppec_paypal',
-				'learn_more' => 'https://woocommerce.com/products/woocommerce-gateway-paypal-checkout/',
-				'condition' => ! empty( $paypal_settings['api_username'] ) &&
+				'description'     => __( 'Connect your PayPal account to let customers to conveniently checkout directly with PayPal.', 'wc-calypso-bridge' ),
+				'estimate'        => '2',
+				'link'            => 'admin.php?page=wc-settings&tab=checkout&section=ppec_paypal',
+				'learn_more'      => 'https://woocommerce.com/products/woocommerce-gateway-paypal-checkout/',
+				'condition'       => ! empty( $paypal_settings['api_username'] ) &&
 							   ! empty( $paypal_settings['api_password'] ) &&
 							   ! empty( $paypal_settings['api_signature'] ) &&
 							   'yes' === $paypal_settings['enabled'],
-				'extension' => 'woocommerce-gateway-paypal-express-checkout/woocommerce-gateway-paypal-express-checkout.php',
+				'extension'       => 'woocommerce-gateway-paypal-express-checkout/woocommerce-gateway-paypal-express-checkout.php',
 			),
 
 			array(
-				'title' => __( 'Setup payments with Stripe', 'wc-calypso-bridge' ),
+				'id'              => 8,
+				'title'           => __( 'Setup payments with Stripe', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
-				'description' => __( 'Connect your Stripe account to accept credit and debit card payments.', 'wc-calypso-bridge' ),
-				'estimate' => '2',
-				'link' => 'admin.php?page=wc-settings&tab=checkout&section=stripe',
-				'learn_more' => 'https://woocommerce.com/products/stripe/',
-				'condition' => ! empty( $stripe_settings['publishable_key'] ) &&
+				'description'     => __( 'Connect your Stripe account to accept credit and debit card payments.', 'wc-calypso-bridge' ),
+				'estimate'        => '2',
+				'link'            => 'admin.php?page=wc-settings&tab=checkout&section=stripe',
+				'learn_more'      => 'https://woocommerce.com/products/stripe/',
+				'condition'       => ! empty( $stripe_settings['publishable_key'] ) &&
 							   ! empty( $stripe_settings['secret_key'] ) &&
 							   'yes' === $stripe_settings['enabled'],
-				'extension' => 'woocommerce-gateway-stripe/woocommerce-gateway-stripe.php',
+				'extension'       => 'woocommerce-gateway-stripe/woocommerce-gateway-stripe.php',
 			),
 
 			array(
-				'title' => __( 'Setup payments with Klarna', 'wc-calypso-bridge' ),
+				'id'              => 9,
+				'title'           => __( 'Setup payments with Klarna', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
-				'description' => __( 'Connect your Klarna account to take payments with pay now, pay later and slice it.', 'wc-calypso-bridge' ),
-				'estimate' => '2',
-				'link' => 'admin.php?page=wc-settings&tab=checkout&section=klarna_payments',
-				'learn_more' => 'https://woocommerce.com/products/klarna-payments/',
-				'condition' => 'yes' === $klarna_payments_settings['enabled'],
-				'extension' => 'klarna-payments-for-woocommerce/klarna-payments-for-woocommerce.php',
+				'description'     => __( 'Connect your Klarna account to take payments with pay now, pay later and slice it.', 'wc-calypso-bridge' ),
+				'estimate'        => '2',
+				'link'            => 'admin.php?page=wc-settings&tab=checkout&section=klarna_payments',
+				'learn_more'      => 'https://woocommerce.com/products/klarna-payments/',
+				'condition'       => 'yes' === $klarna_payments_settings['enabled'],
+				'extension'       => 'klarna-payments-for-woocommerce/klarna-payments-for-woocommerce.php',
 			),
 
 			array(
-				'title' => __( 'Setup checkout with Klarna', 'wc-calypso-bridge' ),
+				'id'              => 10,
+				'title'           => __( 'Setup checkout with Klarna', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
-				'description' => __( 'Setup to provide a full checkout experience with pay now, pay later and slice it.', 'wc-calypso-bridge' ),
-				'estimate' => '2',
-				'link' => 'admin.php?page=wc-settings&tab=checkout&section=kco',
-				'learn_more' => 'https://woocommerce.com/products/klarna-checkout/',
-				'condition' => 'yes' === $kco_settings['enabled'],
-				'extension' => 'klarna-checkout-for-woocommerce/klarna-checkout-for-woocommerce.php',
+				'description'     => __( 'Setup to provide a full checkout experience with pay now, pay later and slice it.', 'wc-calypso-bridge' ),
+				'estimate'        => '2',
+				'link'            => 'admin.php?page=wc-settings&tab=checkout&section=kco',
+				'learn_more'      => 'https://woocommerce.com/products/klarna-checkout/',
+				'condition'       => 'yes' === $kco_settings['enabled'],
+				'extension'       => 'klarna-checkout-for-woocommerce/klarna-checkout-for-woocommerce.php',
 			),
 
 			array(
-				'title' => __( 'Setup payments with eWAY', 'wc-calypso-bridge' ),
+				'id'              => 11,
+				'title'           => __( 'Setup payments with eWAY', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
-				'description' => __( 'Connect your eWay account to take credit card payments directly on your store.', 'wc-calypso-bridge' ),
-				'estimate' => '2',
-				'link' => 'admin.php?page=wc-settings&tab=checkout&section=eway',
-				'condition' => ! empty( $eway_settings['customer_api'] ) &&
+				'description'     => __( 'Connect your eWay account to take credit card payments directly on your store.', 'wc-calypso-bridge' ),
+				'estimate'        => '2',
+				'link'            => 'admin.php?page=wc-settings&tab=checkout&section=eway',
+				'condition'       => ! empty( $eway_settings['customer_api'] ) &&
 							   ! empty( $eway_settings['customer_password'] ) &&
 							   'yes' === $eway_settings['enabled'],
-				'extension' => 'woocommerce-gateway-eway/woocommerce-gateway-eway.php',
+				'extension'       => 'woocommerce-gateway-eway/woocommerce-gateway-eway.php',
 			),
 
 			array(
-				'title' => __( 'Setup payments with PayFast', 'wc-calypso-bridge' ),
+				'id'              => 12,
+				'title'           => __( 'Setup payments with PayFast', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
-				'description' => __( 'Connect your PayFast account to accept payments by credit card and Electronic Fund Transfer.', 'wc-calypso-bridge' ),
-				'estimate' => '2',
-				'link' => 'admin.php?page=wc-settings&tab=checkout&section=payfast',
-				'condition' => ! empty( $payfast_settings['merchant_id'] ) &&
+				'description'     => __( 'Connect your PayFast account to accept payments by credit card and Electronic Fund Transfer.', 'wc-calypso-bridge' ),
+				'estimate'        => '2',
+				'link'            => 'admin.php?page=wc-settings&tab=checkout&section=payfast',
+				'condition'       => ! empty( $payfast_settings['merchant_id'] ) &&
 							   ! empty( $payfast_settings['merchant_key'] ) &&
 							   ! empty( $payfast_settings['pass_phrase'] ) &&
 							   'yes' === $payfast_settings['enabled'],
-				'extension' => 'woocommerce-payfast-gateway/gateway-payfast.php',
+				'extension'       => 'woocommerce-payfast-gateway/gateway-payfast.php',
 			),
 
 			array(
-				'title' => __( 'Enable automatic tax rates with TaxJar', 'wc-calypso-bridge' ),
+				'id'              => 13,
+				'title'           => __( 'Enable automatic tax rates with TaxJar', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
-				'description' => __( 'Automatically collect sales tax at checkout by connecting with TaxJar.', 'wc-calypso-bridge' ),
-				'estimate' => '2',
-				'link' => 'admin.php?page=wc-settings&tab=integration&section=taxjar-integration',
-				'condition' => ! empty( $taxjar_settings['api_token'] ),
-				'extension' => 'taxjar-simplified-taxes-for-woocommerce/taxjar-woocommerce.php',
+				'description'     => __( 'Automatically collect sales tax at checkout by connecting with TaxJar.', 'wc-calypso-bridge' ),
+				'estimate'        => '2',
+				'link'            => 'admin.php?page=wc-settings&tab=integration&section=taxjar-integration',
+				'condition'       => ! empty( $taxjar_settings['api_token'] ),
+				'extension'       => 'taxjar-simplified-taxes-for-woocommerce/taxjar-woocommerce.php',
 			),
 
 			array(
-				'title' => __( 'Integrate with Facebook', 'wc-calypso-bridge' ),
+				'id'              => 14,
+				'title'           => __( 'Integrate with Facebook', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
-				'description' => __( 'Integrating Facebook with your store and drive sales.', 'wc-calypso-bridge' ),
-				'estimate' => '20',
-				'link' => 'admin.php?page=wc-settings&tab=integration&section=facebookcommerce',
-				'learn_more' => 'https://www.facebook.com/business/help/900699293402826',
-				'condition' => ! empty( $facebook_settings['fb_api_key'] ),
-				'extension' => 'facebook-for-woocommerce/facebook-for-woocommerce.php',
+				'description'     => __( 'Integrating Facebook with your store and drive sales.', 'wc-calypso-bridge' ),
+				'estimate'        => '20',
+				'link'            => 'admin.php?page=wc-settings&tab=integration&section=facebookcommerce',
+				'learn_more'      => 'https://www.facebook.com/business/help/900699293402826',
+				'condition'       => ! empty( $facebook_settings['fb_api_key'] ),
+				'extension'       => 'facebook-for-woocommerce/facebook-for-woocommerce.php',
 			),
 
 			array(
-				'title' => __( 'Integrate with Mailchimp', 'wc-calypso-bridge' ),
+				'id'              => 15,
+				'title'           => __( 'Integrate with Mailchimp', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
-				'description' => __( 'Connect your store to bring the power of email marketing to your business.', 'wc-calypso-bridge' ),
-				'estimate' => '20',
-				'link' => 'options-general.php?page=mailchimp-woocommerce',
-				'learn_more' => 'https://wordpress.org/plugins/mailchimp-for-woocommerce/',
-				'condition' => ! empty( $mailchimp_settings['mailchimp_api_key'] ),
-				'extension' => 'mailchimp-for-woocommerce/mailchimp-woocommerce.php',
+				'description'     => __( 'Connect your store to bring the power of email marketing to your business.', 'wc-calypso-bridge' ),
+				'estimate'        => '20',
+				'link'            => 'options-general.php?page=mailchimp-woocommerce',
+				'learn_more'      => 'https://wordpress.org/plugins/mailchimp-for-woocommerce/',
+				'condition'       => ! empty( $mailchimp_settings['mailchimp_api_key'] ),
+				'extension'       => 'mailchimp-for-woocommerce/mailchimp-woocommerce.php',
 			),
 		);
 
@@ -454,7 +469,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 	 * Renders the checklist display.
 	 */
 	public function checklist() {
-		$data = $this->get_task_data();
+		$data       = $this->get_task_data();
 		$percentage = floor( ( $data['completed'] / $data['total'] ) * 100 );
 
 		$asset_path = WC_Calypso_Bridge::$plugin_asset_path ? WC_Calypso_Bridge::$plugin_asset_path : WC_Calypso_Bridge::MU_PLUGIN_ASSET_PATH;
@@ -510,7 +525,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 			$task_url = admin_url( $task_url );
 		}
 		?>
-		<div class="checklist-card checklist__task has-actionlink is-compact <?php echo $task['condition'] ? 'is-completed' : ''; ?>" data-title="<?php echo esc_html( $task['title'] ); ?>">
+		<div class="checklist-card checklist__task has-actionlink is-compact <?php echo $task['condition'] ? 'is-completed' : ''; ?>" data-id="<?php echo intval( $task['id'] ); ?>" data-title="<?php echo esc_html( $task['title'] ); ?>">
 			<div class="checklist__task-primary">
 				<h3 class="checklist__task-title">
 					<?php
@@ -536,10 +551,10 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 				<?php
 				if ( true === $task['condition'] ) {
 					$action_link_secondary_class = 'checklist__task-action';
-					$title = $task['completed_title'];
+					$title                       = $task['completed_title'];
 				} else {
 					$action_link_secondary_class = 'button-primary';
-					$title = __( 'Do it', 'wc-calypso-bridge' );
+					$title                       = __( 'Do it', 'wc-calypso-bridge' );
 				}
 				echo '<a href="' . esc_url( $task_url ) . '" class=" ' . esc_html( $action_link_secondary_class ) . '">' . esc_html( $title ) . '</a>';
 				?>

--- a/includes/class-wc-calypso-bridge-admin-setup-checklist.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-checklist.php
@@ -510,7 +510,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 			$task_url = admin_url( $task_url );
 		}
 		?>
-		<div class="checklist-card checklist__task has-actionlink is-compact <?php echo $task['condition'] ? 'is-completed' : ''; ?>">
+		<div class="checklist-card checklist__task has-actionlink is-compact <?php echo $task['condition'] ? 'is-completed' : ''; ?>" data-title="<?php echo esc_html( $task['title'] ); ?>">
 			<div class="checklist__task-primary">
 				<h3 class="checklist__task-title">
 					<?php

--- a/includes/class-wc-calypso-bridge-admin-setup-checklist.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-checklist.php
@@ -257,7 +257,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 
 		$all_tasks = array(
 			array(
-				'id'              => 1,
+				'id'              => 'add-product',
 				'title'           => __( 'Add a product', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'Add another product', 'wc-calypso-bridge' ),
 				'description'     => __( 'Start by adding your first product to your store.', 'wc-calypso-bridge' ),
@@ -267,7 +267,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 			),
 
 			array(
-				'id'              => 2,
+				'id'              => 'customize',
 				'title'           => __( 'View and customize', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'Open customizer', 'wc-calypso-bridge' ),
 				'description'     => __( 'You have access to a few themes with your plan. See the options, chose the right one for you and customize your store.', 'wc-calypso-bridge' ),
@@ -277,7 +277,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 			),
 
 			array(
-				'id'              => 3,
+				'id'              => 'shipping',
 				'title'           => __( 'Review shipping', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
 				'description'     => __( "We've set up a few shipping options based on your store location. Check them out to see if they're right for you.", 'wc-calypso-bridge' ),
@@ -287,7 +287,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 			),
 
 			array(
-				'id'              => 4,
+				'id'              => 'ups',
 				'title'           => __( 'Add live rates with UPS', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
 				'description'     => __( "Showing shipping rates directly from UPS during checkout ensures you're charging customers the right amount for shipping.", 'wc-calypso-bridge' ),
@@ -301,7 +301,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 			),
 
 			array(
-				'id'              => 5,
+				'id'              => 'canada-post',
 				'title'           => __( 'Add live rates with Canada Post', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
 				'description'     => __( 'Get shipping rates for domestic and international parcels.', 'wc-calypso-bridge' ),
@@ -313,7 +313,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 			),
 
 			array(
-				'id'              => 6,
+				'id'              => 'square',
 				'title'           => __( 'Setup payments with Square', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
 				'description'     => __( 'Connect your Square account to accept credit and debit card, to track sales and sync inventory.', 'wc-calypso-bridge' ),
@@ -325,7 +325,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 			),
 
 			array(
-				'id'              => 7,
+				'id'              => 'paypal',
 				'title'           => __( 'Setup payments with PayPal', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
 				'description'     => __( 'Connect your PayPal account to let customers to conveniently checkout directly with PayPal.', 'wc-calypso-bridge' ),
@@ -340,7 +340,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 			),
 
 			array(
-				'id'              => 8,
+				'id'              => 'stripe',
 				'title'           => __( 'Setup payments with Stripe', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
 				'description'     => __( 'Connect your Stripe account to accept credit and debit card payments.', 'wc-calypso-bridge' ),
@@ -354,7 +354,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 			),
 
 			array(
-				'id'              => 9,
+				'id'              => 'klarna-payments',
 				'title'           => __( 'Setup payments with Klarna', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
 				'description'     => __( 'Connect your Klarna account to take payments with pay now, pay later and slice it.', 'wc-calypso-bridge' ),
@@ -366,7 +366,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 			),
 
 			array(
-				'id'              => 10,
+				'id'              => 'klarna-checkout',
 				'title'           => __( 'Setup checkout with Klarna', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
 				'description'     => __( 'Setup to provide a full checkout experience with pay now, pay later and slice it.', 'wc-calypso-bridge' ),
@@ -378,7 +378,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 			),
 
 			array(
-				'id'              => 11,
+				'id'              => 'eway',
 				'title'           => __( 'Setup payments with eWAY', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
 				'description'     => __( 'Connect your eWay account to take credit card payments directly on your store.', 'wc-calypso-bridge' ),
@@ -391,7 +391,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 			),
 
 			array(
-				'id'              => 12,
+				'id'              => 'payfast',
 				'title'           => __( 'Setup payments with PayFast', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
 				'description'     => __( 'Connect your PayFast account to accept payments by credit card and Electronic Fund Transfer.', 'wc-calypso-bridge' ),
@@ -405,7 +405,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 			),
 
 			array(
-				'id'              => 13,
+				'id'              => 'taxjar',
 				'title'           => __( 'Enable automatic tax rates with TaxJar', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
 				'description'     => __( 'Automatically collect sales tax at checkout by connecting with TaxJar.', 'wc-calypso-bridge' ),
@@ -416,7 +416,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 			),
 
 			array(
-				'id'              => 14,
+				'id'              => 'facebook',
 				'title'           => __( 'Integrate with Facebook', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
 				'description'     => __( 'Integrating Facebook with your store and drive sales.', 'wc-calypso-bridge' ),
@@ -428,7 +428,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 			),
 
 			array(
-				'id'              => 15,
+				'id'              => 'mailchimp',
 				'title'           => __( 'Integrate with Mailchimp', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
 				'description'     => __( 'Connect your store to bring the power of email marketing to your business.', 'wc-calypso-bridge' ),
@@ -525,7 +525,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 			$task_url = admin_url( $task_url );
 		}
 		?>
-		<div class="checklist-card checklist__task has-actionlink is-compact <?php echo $task['condition'] ? 'is-completed' : ''; ?>" data-id="<?php echo intval( $task['id'] ); ?>" data-title="<?php echo esc_html( $task['title'] ); ?>">
+		<div class="checklist-card checklist__task has-actionlink is-compact <?php echo $task['condition'] ? 'is-completed' : ''; ?>" data-id="<?php echo esc_html( $task['id'] ); ?>" data-title="<?php echo esc_html( $task['title'] ); ?>">
 			<div class="checklist__task-primary">
 				<h3 class="checklist__task-title">
 					<?php

--- a/includes/class-wc-calypso-bridge-admin-setup-wizard.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-wizard.php
@@ -107,6 +107,8 @@ class WC_Calypso_Bridge_Admin_Setup_Wizard extends WC_Admin_Setup_Wizard {
 
 		// @codingStandardsIgnoreStart
 		if ( ! empty( $_POST['save_step'] ) && isset( $this->steps[ $this->step ]['handler'] ) ) {
+			$current_user = wp_get_current_user();
+			jetpack_tracks_record_event( $current_user, 'atomic_wc_obw_step_complete', array( 'name' =>  $this->step ) );
 			call_user_func( $this->steps[ $this->step ]['handler'], $this );
 		}
 		// @codingStandardsIgnoreEnd

--- a/includes/class-wc-calypso-bridge-admin-setup-wizard.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-wizard.php
@@ -108,7 +108,14 @@ class WC_Calypso_Bridge_Admin_Setup_Wizard extends WC_Admin_Setup_Wizard {
 		// @codingStandardsIgnoreStart
 		if ( ! empty( $_POST['save_step'] ) && isset( $this->steps[ $this->step ]['handler'] ) ) {
 			$current_user = wp_get_current_user();
-			jetpack_tracks_record_event( $current_user, 'atomic_wc_obw_step_complete', array( 'name' =>  $this->step ) );
+			jetpack_tracks_record_event(
+				$current_user,
+				'atomic_wc_obw_step_complete',
+				array(
+					'blog_id' => Jetpack_Options::get_option( 'id' ),
+					'name'    =>  $this->step
+				)
+			);
 			call_user_func( $this->steps[ $this->step ]['handler'], $this );
 		}
 		// @codingStandardsIgnoreEnd

--- a/includes/class-wc-calypso-bridge-admin-setup-wizard.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-wizard.php
@@ -107,15 +107,7 @@ class WC_Calypso_Bridge_Admin_Setup_Wizard extends WC_Admin_Setup_Wizard {
 
 		// @codingStandardsIgnoreStart
 		if ( ! empty( $_POST['save_step'] ) && isset( $this->steps[ $this->step ]['handler'] ) ) {
-			$current_user = wp_get_current_user();
-			jetpack_tracks_record_event(
-				$current_user,
-				'atomic_wc_obw_step_complete',
-				array(
-					'blog_id' => Jetpack_Options::get_option( 'id' ),
-					'name'    =>  $this->step
-				)
-			);
+			WC_Calypso_Bridge::record_event( 'atomic_wc_obw_step_complete', array( 'name' => $this->step ) );
 			call_user_func( $this->steps[ $this->step ]['handler'], $this );
 		}
 		// @codingStandardsIgnoreEnd


### PR DESCRIPTION
Fixes #85 

This PR adds event tracking for the following events:
* OBW step completion
* Tasklist item clicked
* Tasklist finished (clicked "I'm done")
* Edit address in OBW clicked
* Calypsoify manually turned on/off

### Screenshots
<img width="809" alt="screen shot 2018-11-01 at 3 41 10 pm" src="https://user-images.githubusercontent.com/10561050/47878557-995f9a80-ddec-11e8-822e-0ff419a33514.png">

### Testing
1.  Make sure you have a Jetpack connected site with tracking enabled.
2.  Try the various above events to make sure they come through (may take a few minutes to show up) - https://mc.a8c.com/tracks/live/?eventname=%25atomic_%25&user=&useragent=

### Notes
* The javascript events are prefixed automatically with `jetpack_`
* The task list completion event is dependent on https://github.com/Automattic/wc-calypso-bridge/pull/130 