### PR TITLE
Fix masterbar to top of screen and fix gap

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -894,6 +894,12 @@ table.widefat {
 	display: none;
 }
 
+/* Masterbar */
+/* @TODO: can be removed if https://github.com/Automattic/jetpack/pull/10523 is merged*/
+#wpadminbar {
+	position: fixed;
+}
+
 /* Masterbar hover styles.
 TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10497/ is released */
 

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -159,11 +159,11 @@ div.woocommerce-message, .wc-helper .start-container {
 	color: #d94f4f;
 }
 #delete-link {
-    line-height: 38px;
-    margin-left: 12px;
-    font-size: 14px;
-    font-weight: 500;
-    color: #d94f4f;
+	line-height: 38px;
+	margin-left: 12px;
+	font-size: 14px;
+	font-weight: 500;
+	color: #d94f4f;
 }
 
 /* White background behind the WooCommerce helper extensions navigation */
@@ -908,13 +908,13 @@ TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10497
 	background: #0099d8 !important;
 	color: #fff;
 }
- #wpadminbar ul li#wp-admin-bar-ab-new-post:hover,
+#wpadminbar ul li#wp-admin-bar-ab-new-post:hover,
 #wpadminbar ul li#wp-admin-bar-ab-new-post:hover > .ab-item {
 	background: #fff !important;
 	opacity: 1;
 	border-radius: 5px;
 }
- #wpadminbar ul li#wp-admin-bar-notes.active,
+#wpadminbar ul li#wp-admin-bar-notes.active,
 #wpadminbar ul li#wp-admin-bar-notes.active > .ab-item {
 	background: #004967 !important;
 }
@@ -1109,5 +1109,15 @@ TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10507
 	.wrap div.updated a.button,
 	.wrap div.updated a.button-primary {
 		font-size: 12px !important;
+	}
+}
+/* Admin menu */
+/* Can be removed pending merge of https://github.com/Automattic/jetpack/pull/10552 */
+@media screen and (max-width: 600px) {
+	#calypso-sidebar-header {
+		top: 32px;
+	}
+	.auto-fold #adminmenu {
+		top: 32px;
 	}
 }


### PR DESCRIPTION
Fixes #134 

This PR fixes the masterbar to the top of the screen in mobile which resolves the gap issue as well as the admin menu gap issue.  I've also opened an issue with Jetpack here - https://github.com/Automattic/jetpack/pull/10523

### Screenshots
<img width="380" alt="screen shot 2018-11-02 at 10 56 57 am" src="https://user-images.githubusercontent.com/10561050/47926642-104d6f80-de8f-11e8-9d60-79bc478d4a12.png">
<img width="355" alt="screen shot 2018-11-02 at 11 19 39 am" src="https://user-images.githubusercontent.com/10561050/47927451-599ebe80-de91-11e8-8b8a-9ec54940ba17.png">

### Testing
1. Visit any page in your dashboard with Calypsoify enabled &calypsoify=1
2. Narrow viewport to 480px or less for the masterbar.  Adjust the viewport between 480px and 600px to see view the admin menu fixes.
3. Note the masterbar fixed to the top of the screen on scroll and no gaps present.