### PR TITLE
Add mobile styling to checklist page

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -112,7 +112,8 @@ div.woocommerce-message, .wc-helper .start-container {
 .wc_addons_wrap .addons-button-outline-green,
 .wc_addons_wrap .addons-button-outline-white,
 .edit-tag-actions .button-primary,
-.woocommerce-BlankState a.button {
+.woocommerce-BlankState a.button,
+.setup-footer a {
 	font-size: 14px !important;
 	padding: 7px 14px 9px !important;
 	line-height: 21px !important;

--- a/assets/css/setup-checklist.css
+++ b/assets/css/setup-checklist.css
@@ -11,11 +11,17 @@
 }
 
 .setup-header h2 {
-	font-size: 2.25em;
+    font-size: 32px;
+	font-weight: 500;
+	line-height: 40px;
+	margin-bottom: 14px;
 }
 
 .setup-header p {
-	line-height: 0;
+	line-height: 1.5;
+	color: #6a748e;
+	margin: 0;
+	font-size: 14px;
 }
 
 .setup-footer {
@@ -24,6 +30,20 @@
 
 .setup-footer a {
 	font-weight: bold;
+}
+
+@media screen and (max-width: 600px) {
+	.setup-header {
+		flex-direction: column;
+		text-align: center;
+	}
+	.setup-header h2 {
+		margin-top: 0;
+	}
+	.setup-header img {
+		max-width: 107px;
+		margin: 0 auto;
+	}
 }
 
 /** Checklist styles - copied from Calypso code generated on 10/29/2018 */
@@ -468,4 +488,62 @@
 
 #klarna-kp-banner, #klarna-banner {
 	display: none;
+}
+
+/* Checklist overrides */
+
+.checklist__header-action {
+    background: #fff;
+}
+.checklist__header-summary {
+    font-size: 13px;
+}
+.checklist__header-progress {
+    font-size: 15px;
+}
+.checklist__header-progress-text {
+    font-size: 15px;
+}
+.checklist__task-title {
+    margin-bottom: 5px;
+}
+.checklist__task-description {
+	line-height: 16px;
+}
+.checklist__task-duration {
+    font-size: 13px;
+}
+.checklist__task-icon {
+	left: 25px;
+	border-width: 1px;
+	cursor: default;
+}
+.checklist-card:not(.is-completed) .checklist__task-icon:hover,
+.checklist-card:not(.is-completed) .checklist__task-icon:focus {
+    background: #fff;
+	border-color: #c8d7e1;
+	cursor: default;
+}
+
+@media (max-width: 480px) {
+	.wp-core-ui .checklist__task-secondary .button-primary {
+		color: #2e4453 !important;
+		background: #fff !important;
+		border-color: #c8d7e1 !important;
+	}
+	.wp-core-ui .checklist__task-secondary .button-primary:hover,
+	.wp-core-ui .checklist__task-secondary .button-primary:focus {
+		color: #2e4453 !important;
+		border-color: #a8bece !important;
+		background: #fff !important;
+	}
+	.checklist__task-secondary {
+		justify-content: flex-start;
+	}
+}
+
+@media (max-width: 600px) {
+	.checklist {
+		margin: 20px 0px 25px -15px;
+	}
 }

--- a/assets/css/setup-checklist.css
+++ b/assets/css/setup-checklist.css
@@ -11,7 +11,7 @@
 }
 
 .setup-header h2 {
-    font-size: 32px;
+	font-size: 32px;
 	font-weight: 500;
 	line-height: 40px;
 	margin-bottom: 14px;
@@ -493,25 +493,25 @@
 /* Checklist overrides */
 
 .checklist__header-action {
-    background: #fff;
+	background: #fff;
 }
 .checklist__header-summary {
-    font-size: 13px;
+	font-size: 13px;
 }
 .checklist__header-progress {
-    font-size: 15px;
+	font-size: 15px;
 }
 .checklist__header-progress-text {
-    font-size: 15px;
+	font-size: 15px;
 }
 .checklist__task-title {
-    margin-bottom: 5px;
+	margin-bottom: 5px;
 }
 .checklist__task-description {
 	line-height: 16px;
 }
 .checklist__task-duration {
-    font-size: 13px;
+	font-size: 13px;
 }
 .checklist__task-icon {
 	left: 25px;
@@ -520,7 +520,7 @@
 }
 .checklist-card:not(.is-completed) .checklist__task-icon:hover,
 .checklist-card:not(.is-completed) .checklist__task-icon:focus {
-    background: #fff;
+	background: #fff;
 	border-color: #c8d7e1;
 	cursor: default;
 }

--- a/includes/class-wc-calypso-bridge-admin-setup-checklist.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-checklist.php
@@ -550,12 +550,10 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 					?>
 				</small>
 			</div>
-			<?php if ( true === $task['condition'] ) { ?>
-				<div class="checklist__task-icon">
-					<svg class="gridicon gridicons-checkmark" height="18" width="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"></path></g></svg>
-				</div>
-			<?php } ?>
+			<div class="checklist__task-icon">
+				<svg class="gridicon gridicons-checkmark" height="18" width="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"></path></g></svg>
 			</div>
+		</div>
 		<?php
 	}
 }


### PR DESCRIPTION
Fixes #137 

This PR adds in the mobile styling for the checklist page.

### Screenshots
<img width="323" alt="screen shot 2018-11-02 at 2 07 45 pm" src="https://user-images.githubusercontent.com/10561050/47935950-2ae11200-deaa-11e8-9d15-aa7e851960f6.png">
<img width="325" alt="screen shot 2018-11-02 at 2 07 55 pm" src="https://user-images.githubusercontent.com/10561050/47935951-2ae11200-deaa-11e8-8012-a66b5bd1cff6.png">

### Testing
1. Visit `/wp-admin/admin.php?page=wc-setup-checklist`
2. Check that styles match hifi designs for viewports <600px.