### PR TITLE
Hide Woo OBW admin alert.

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -61,6 +61,7 @@ class WC_Calypso_Bridge {
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-setup.php';
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-admin-setup-checklist.php';
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-breadcrumbs.php';
+		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-hide-alerts.php';
 		include_once dirname( __FILE__ ) . '/includes/gutenberg.php';
 
 		$connect_files = glob( dirname( __FILE__ ) . '/includes/connect/*.php' );

--- a/includes/class-wc-calypso-bridge-hide-alerts.php
+++ b/includes/class-wc-calypso-bridge-hide-alerts.php
@@ -14,38 +14,38 @@ defined( 'ABSPATH' ) || exit;
  */
 class WC_Calypso_Bridge_Hide_Alerts {
 
-    /**
-     * Class instance.
-     *
-     * @var WC_Calypso_Bridge_Hide_Alerts instance
-     */
-    protected static $instance = false;
+	/**
+	 * Class instance.
+	 *
+	 * @var WC_Calypso_Bridge_Hide_Alerts instance
+	 */
+	protected static $instance = false;
 
-    /**
-     * Get class instance
-     */
-    public static function get_instance() {
-        if ( ! self::$instance ) {
-            self::$instance = new self();
-        }
-        return self::$instance;
-    }
+	/**
+	 * Get class instance
+	 */
+	public static function get_instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
 
-    /**
-     * Constructor
-     */
-    private function __construct() {
-        add_action( 'admin_init', array( $this, 'hide_woo_obw_alert' ) );
-    }
-    
-    /**
-     * Prevents the OBW admin alert from Woo Core from being shown
-     */
-    function hide_woo_obw_alert() {
-        if ( class_exists( 'WC_Admin_Notices' ) ) {
-            WC_Admin_Notices::remove_notice( 'install' );
-        }
-    }
+	/**
+	 * Constructor
+	 */
+	private function __construct() {
+		add_action( 'admin_init', array( $this, 'hide_woo_obw_alert' ) );
+	}
+
+	/**
+	 * Prevents the OBW admin alert from Woo Core from being shown
+	 */
+	function hide_woo_obw_alert() {
+		if ( class_exists( 'WC_Admin_Notices' ) ) {
+			WC_Admin_Notices::remove_notice( 'install' );
+		}
+	}
 
 }
 $wc_calypso_bridge_hide_alerts = WC_Calypso_Bridge_Hide_Alerts::get_instance();

--- a/includes/class-wc-calypso-bridge-hide-alerts.php
+++ b/includes/class-wc-calypso-bridge-hide-alerts.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Removes various admin alerts that should not be there
+ *
+ * @package WC_Calypso_Bridge/Classes
+ * @since   1.0.0
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC Calypso Bridge Hide Alerts
+ */
+class WC_Calypso_Bridge_Hide_Alerts {
+
+    /**
+     * Class instance.
+     *
+     * @var WC_Calypso_Bridge_Hide_Alerts instance
+     */
+    protected static $instance = false;
+
+    /**
+     * Get class instance
+     */
+    public static function get_instance() {
+        if ( ! self::$instance ) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * Constructor
+     */
+    private function __construct() {
+        add_action( 'admin_init', array( $this, 'hide_woo_obw_alert' ) );
+    }
+    
+    /**
+     * Prevents the OBW admin alert from Woo Core from being shown
+     */
+    function hide_woo_obw_alert() {
+        if ( class_exists( 'WC_Admin_Notices' ) ) {
+            WC_Admin_Notices::remove_notice( 'install' );
+        }
+    }
+
+}
+$wc_calypso_bridge_hide_alerts = WC_Calypso_Bridge_Hide_Alerts::get_instance();


### PR DESCRIPTION
Fixes #144 

This PR adds in a new class where we can keep any random logic needed to filter off admin alerts from being shown in the ecomm plan. The first of which is the OBW alert that is added by Woo Core to freshly installed Woo sites.

__Before__
<img width="1057" alt="notice-before" src="https://user-images.githubusercontent.com/22080/48095235-0b5b2980-e1c9-11e8-8d50-f60df553d24a.png">

__After__
<img width="1057" alt="notice-after" src="https://user-images.githubusercontent.com/22080/48095246-144bfb00-e1c9-11e8-97c6-783652d84148.png">

__To Test__
You can force the alert to be shown on any site by adding the following code somewhere:

`WC_Admin_Notices::add_notice( 'install' );`

And refreshing a calypsoified woo page to verify you see the alert as pictured in the "Before" grab above. Then checkout this branch and verify it is no longer shown.