### PR TITLE
Align page title actions to the right

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -193,6 +193,12 @@ div.woocommerce-message, .wc-helper .start-container {
 	border: 0;
 }
 
+/* Page title actions */
+.page-title-actions {
+	float: right;
+	padding-top: 12px;
+}
+
 /* Navigation tabs */
 .woocommerce nav.woo-nav-tab-wrapper {
 	width: 100%;

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -74,4 +74,11 @@
         $( this ).find( 'p:not(.submit)' ).appendTo( $noticeContent );
     } );
 
+    /**
+     * Wrap page title actions to align right
+     */
+    var $pageTitleActionsContainer = $( '<div class="page-title-actions"></div>' );
+    $pageTitleActionsContainer.insertAfter( 'h1.wp-heading-inline' );
+    $( '.page-title-action' ).appendTo( $pageTitleActionsContainer );
+
 } )( jQuery );


### PR DESCRIPTION
This PR wraps the page title actions and aligns them to the right.

Fixes #145 

### Screenshots
<img width="1366" alt="screen shot 2018-11-07 at 3 13 44 pm" src="https://user-images.githubusercontent.com/10561050/48158155-bdfdbb80-e29f-11e8-9010-8c83d153342a.png">

### Testing
1. Enable calypsoify and visit various pages (e.g., `/wp-admin/edit.php?post_type=product`)
2. Make sure that page actions are aligned right and no styling issues exist.