### PR TITLE
Hide manual payments in OBW.

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -365,6 +365,10 @@ table.widefat {
 	color: #2E4453;
 }
 
+.wc-wizard-services.manual {
+	display: none;
+}
+
 /* Forms */
 
 #post-body-content {


### PR DESCRIPTION
There isn't a way to filter off `get_wizard_manual_payment_gateways()` in the core [obw code](https://github.com/woocommerce/woocommerce/blob/e343f4def7ff11e01b3c31d35997c7a68001c6fb/includes/admin/class-wc-admin-setup-wizard.php#L1546) so instead of that I implemented a display none to hide them in the OBW 🍹 

__Before__
<img width="510" alt="woocommerce setup wizard 2018-11-07 09-15-36" src="https://user-images.githubusercontent.com/22080/48148056-bf15f500-e26d-11e8-9951-a7567e1ddf6f.png">

__After__
![image](https://user-images.githubusercontent.com/22080/48164068-55f6a780-e296-11e8-8c6a-1776d0092a3f.png)

__To Test__
Visit `/wp-admin/admin.php?page=wc-setup&step=payment` and verify the manual payments are not shown.
