### PR TITLE
Add Calypsoify pagination

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -12,18 +12,22 @@ div.woocommerce-message, .wc-helper .start-container {
 	display: none;
 }
 .tablenav.bottom .wc-calypso-brdige-pagination.tablenav-pages {
-	display: block;
+	float: none;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	margin-top: 16px;
 }
 .tablenav .tablenav-pages a,
 .tablenav-pages-navspan,
 .tablenav-pages span.current,
 .tablenav .dots {
 	padding: 8px 12px;
-    background-color: #fff;
-    border: solid 1px #c8d7e1;
-    border-right: none;
-    font-size: 14px;
-    line-height: 18px;
+	background-color: #fff;
+	border: solid 1px #c8d7e1;
+	border-right: none;
+	font-size: 14px;
+	line-height: 18px;
 	color: #537994;
 	float: left;
 	font-weight: 500;
@@ -49,7 +53,7 @@ div.woocommerce-message, .wc-helper .start-container {
 .tablenav .gridicon,
 .tablenav .gridicon {
 	vertical-align: middle;
-    width: 18px;
+	width: 18px;
 	height: 18px;
 	fill: #537994;
 }
@@ -70,7 +74,7 @@ div.woocommerce-message, .wc-helper .start-container {
 }
 .tablenav-pages-navspan.disabled {
 	color: #e9eff3;
-    cursor: default;
+	cursor: default;
 }
 .tablenav-pages-navspan.disabled svg {
 	fill: #e9eff3;

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -7,9 +7,73 @@ div.woocommerce-message, .wc-helper .start-container {
 	border-left-color: #00a0d2 !important;
 }
 
-/* Adds padding between pagination and the table of items on management screens */
-.tablenav .tablenav-pages {
-	margin-bottom: 8px;
+/* Pagination */
+.tablenav.bottom .actions, .tablenav .tablenav-pages {
+	display: none;
+}
+.tablenav.bottom .wc-calypso-brdige-pagination.tablenav-pages {
+	display: block;
+}
+.tablenav .tablenav-pages a,
+.tablenav-pages-navspan,
+.tablenav-pages span.current,
+.tablenav .dots {
+	padding: 8px 12px;
+    background-color: #fff;
+    border: solid 1px #c8d7e1;
+    border-right: none;
+    font-size: 14px;
+    line-height: 18px;
+	color: #537994;
+	float: left;
+	font-weight: 500;
+	min-width: 0;
+	display: flex;
+	align-content: center;
+	height: auto;
+}
+.tablenav .tablenav-pages a:hover,
+.tablenav .tablenav-pages a:focus {
+	color: #2e4453;
+	background: #fff;
+	border-color: #C8D7E1
+}
+.tablenav .tablenav-pages a:hover .gridicon {
+	fill: #2e4453;
+}
+.tablenav-pages span.current {
+	border-color: #00aadc;
+	background-color: #00aadc;
+	color: #fff;
+}
+.tablenav .gridicon,
+.tablenav .gridicon {
+	vertical-align: middle;
+    width: 18px;
+	height: 18px;
+	fill: #537994;
+}
+.tablenav .tablenav-pages > *:first-child {
+	border-top-left-radius: 4px;
+	border-bottom-left-radius: 4px;
+}
+.tablenav .tablenav-pages > *:first-child .gridicon {
+	margin-right: 2px;
+}
+.tablenav .tablenav-pages > *:last-child {
+	border-top-right-radius: 4px;
+	border-bottom-right-radius: 4px;
+	border-right: 1px solid #c8d7e1;
+}
+.tablenav .tablenav-pages > *:last-child .gridicon {
+	margin-left: 2px;
+}
+.tablenav-pages-navspan.disabled {
+	color: #e9eff3;
+    cursor: default;
+}
+.tablenav-pages-navspan.disabled svg {
+	fill: #e9eff3;
 }
 
 /* Secondary Buttons */
@@ -337,11 +401,6 @@ table.wp-list-table td.column-thumb img {
 table.widefat {
 	border-color: #c8d7e1;
 	box-shadow: none;
-}
-
-/* Removes table footer actions */
-.tablenav.bottom .actions, .tablenav.bottom .tablenav-pages {
-	display: none;
 }
 
 /* Onboarding wizard */

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -86,6 +86,7 @@ class WC_Calypso_Bridge {
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-admin-setup-checklist.php';
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-breadcrumbs.php';
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-hide-alerts.php';
+		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-pagination.php';
 		include_once dirname( __FILE__ ) . '/includes/gutenberg.php';
 
 		$connect_files = glob( dirname( __FILE__ ) . '/includes/connect/*.php' );

--- a/includes/class-wc-calypso-bridge-pagination.php
+++ b/includes/class-wc-calypso-bridge-pagination.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Removes the back links and adds the pagination on settings pages.
+ *
+ * @package WC_Calypso_Bridge/Classes
+ * @since   1.0.0
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC Calypso Bridge Pagination
+ */
+class WC_Calypso_Bridge_Pagination {
+
+	/**
+	 * Class instance.
+	 *
+	 * @var WC_Calypso_Bridge_Pagination instance
+	 */
+	protected static $instance = false;
+
+	/**
+	 * Current page
+	 *
+	 * @var int
+	 */
+	private $current_page = null;
+
+	/**
+	 * Max pages
+	 *
+	 * @var int
+	 */
+	private $max_pages = null;
+
+	/**
+	 * Get class instance
+	 */
+	public static function get_instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor
+	 */
+	private function __construct() {
+		add_action( 'wp', array( $this, 'set_page_vars' ) );
+		add_action( 'manage_posts_extra_tablenav', array( $this, 'render_pagination' ) );
+	}
+
+
+	/**
+	 * Set pagination vars after wp is ready
+	 */
+	public function set_page_vars() {
+		global $wp_query;
+		$this->current_page = ( get_query_var( 'paged' ) ) ? absint( get_query_var( 'paged' ) ) : 1;
+		$this->max_pages    = $wp_query->max_num_pages;
+	}
+
+	/**
+	 * Render pagination
+	 */
+	public function render_pagination() {
+		$page_links = paginate_links(
+			array(
+				'base'      => add_query_arg( 'paged', '%#%' ),
+				'format'    => '',
+				'prev_text' => $this->prev_link(),
+				'next_text' => $this->next_link(),
+				'prev_next' => true,
+				'total'     => $this->max_pages,
+				'current'   => $this->current_page,
+			)
+		);
+		$page_links = $this->add_prev_next_disabled_links( $page_links );
+		echo '<div class="tablenav-pages wc-calypso-brdige-pagination">' . $page_links . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput
+	}
+
+	/**
+	 * Get the previous page link
+	 */
+	public function prev_link() {
+		// translators: Add in the Gridicons previous svg icon.
+		return sprintf( __( '%s Previous', 'wc-calypso-bridge' ), '<svg class="gridicon gridicons-arrow-left" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/></g></svg>' );
+	}
+
+	/**
+	 * Get the next page link
+	 */
+	public function next_link() {
+		// translators: Add in the Gridicons next svg icon.
+		return sprintf( __( 'Next %s', 'wc-calypso-bridge' ), '<svg class="gridicon gridicons-arrow-right" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8-8-8z"/></g></svg>' );
+	}
+
+	/**
+	 * Add next and previous links even if we're on the first or last page
+	 *
+	 * @param string $page_links Pagination html to append to.
+	 */
+	public function add_prev_next_disabled_links( $page_links ) {
+		if ( $this->max_pages > 1 ) {
+			if ( 1 === $this->current_page ) {
+				$prev_link  = '<span class="tablenav-pages-navspan disabled">' . $this->prev_link() . '</span>';
+				$page_links = $prev_link . $page_links;
+			}
+			if ( (int) $this->current_page === (int) $this->max_pages ) {
+				$next_link  = '<span class="tablenav-pages-navspan disabled">' . $this->next_link() . '</span>';
+				$page_links = $page_links . $next_link;
+			}
+		}
+		return $page_links;
+	}
+
+}
+$wc_calypso_bridge_pagination = WC_Calypso_Bridge_Pagination::get_instance();


### PR DESCRIPTION
This PR adds in a custom Calypsoify pagination with page numbers as links beneath the table.

Fixes #143 

#### Screenshots
<img width="1013" alt="screen shot 2018-11-12 at 6 13 50 am" src="https://user-images.githubusercontent.com/10561050/48318955-569a8f80-e642-11e8-9b38-6f76ea3fd491.png">

#### Testing
1.  Visit various pages with pagination/tables with calypsoify enabled.  (e.g., `/wp-admin/edit.php?post_type=shop_order`)
2. Note that the styles show up correctly for the pagination and previous pagination does not show.