### PR TITLE
Move notices beneath subnavigation

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -203,6 +203,9 @@ div.woocommerce-message, .wc-helper .start-container {
 .woocommerce nav.woo-nav-tab-wrapper {
 	width: 100%;
 }
+.wrap .subsubsub {
+	margin-bottom: 1em;
+}
 .nav-tab, .subsubsub a, .filter-links li>a {
 	color: #00aadc;
 }
@@ -1123,6 +1126,12 @@ TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10507
 		font-size: 12px !important;
 	}
 }
+.wrap div.notice + br.clear,
+.wrap div.updated + br.clear,
+.wrap div.error + br.clear {
+	display: none;
+}
+
 /* Admin menu */
 /* Can be removed pending merge of https://github.com/Automattic/jetpack/pull/10552 */
 @media screen and (max-width: 600px) {

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -81,4 +81,18 @@
     $pageTitleActionsContainer.insertAfter( 'h1.wp-heading-inline' );
     $( '.page-title-action' ).appendTo( $pageTitleActionsContainer );
 
+
+    /** 
+     * Move notices on pages with sub navigation
+     * 
+     * WP Core moves notices with jQuery so this is needed to move them again since
+     * we can't control their position.
+     */
+    $( document ).ready(function() {
+        var $subNavigation = $( '.wrap > form > .subsubsub' );
+        if ( $subNavigation.length ) {
+            $( 'div.notice, div.error, div.updated, div.warning' ).insertAfter( $subNavigation );
+        }
+    } );
+
 } )( jQuery );


### PR DESCRIPTION
This PR fixes the problem where notices are added between the navigation and subnavigation if one exists on the page.

Fixes #122 

#### Screenshots
<img width="1254" alt="screen shot 2018-11-12 at 6 32 44 am" src="https://user-images.githubusercontent.com/10561050/48319140-fe18c180-e644-11e8-913b-686d0db70724.png">

#### Testing
1.  Visit `/wp-admin/admin.php?page=wc-settings&tab=shipping`
2. Confirm that notices are moved beneath the sub navigation and padding/margin relative to navigation/content looks okay.