### PR TITLE
Remove add new product menu item

### DIFF
--- a/includes/class-wc-calypso-bridge-page-controller.php
+++ b/includes/class-wc-calypso-bridge-page-controller.php
@@ -160,6 +160,13 @@ class WC_Calypso_Bridge_Page_Controller {
 	private $pages = array();
 
 	/**
+	 * Constructor
+	 */
+	private function __construct() {
+		add_action( 'admin_menu', array( $this, 'remove_menu_items' ), 100 );
+	}
+
+	/**
 	 * We want a single instance of this class so we can accurately track registered menus and pages.
 	 */
 	public static function get_instance() {
@@ -201,6 +208,13 @@ class WC_Calypso_Bridge_Page_Controller {
 	 */
 	public function get_registered_menus() {
 		return $this->menus;
+	}
+
+	/**
+	 * Remove unneeded menu items
+	 */
+	public function remove_menu_items() {
+		remove_submenu_page( 'edit.php?post_type=product', 'post-new.php?post_type=product' );
 	}
 }
 


### PR DESCRIPTION
This PR removes "Add new product" from the "Products" submenu in the sidebar.

Fixes #146 

#### Screenshots
<img width="294" alt="screen shot 2018-11-12 at 6 44 47 am" src="https://user-images.githubusercontent.com/10561050/48319235-7a5fd480-e646-11e8-9d84-598e7cb43bec.png">

#### Testing
1.  Fire up that dashboard 🔥 💻 
2.  Confirm that "Add new product" isn't under the "Products" submenu.