### PR TITLE
Add calypso styling to form inputs

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -170,6 +170,18 @@ textarea:focus {
 	-moz-outline: none;
 	-moz-user-focus: ignore;
 }
+input[type="text"]::placeholder,
+input[type="search"]::placeholder,
+input[type="email"]::placeholder,
+input[type="number"]::placeholder,
+input[type="password"]::placeholder,
+input[type=checkbox]::placeholder,
+input[type=radio]::placeholder,
+input[type="tel"]::placeholder,
+input[type="url"]::placeholder,
+textarea::placeholder {
+    color: #87a6bc;
+}
 .form-wrap {
 	display: block;
 	margin: 0 auto 10px auto;

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -116,6 +116,52 @@ textarea {
 	box-shadow: none;
 	height: auto;
 }
+input[type="text"]:focus,
+input[type="password"]:focus,
+input[type="checkbox"]:focus,
+input[type="color"]:focus,
+input[type="date"]:focus,
+input[type="datetime"]:focus,
+input[type="datetime-local"]:focus,
+input[type="email"]:focus,
+input[type="month"]:focus,
+input[type="number"]:focus,
+input[type="search"]:focus,
+input[type="radio"]:focus,
+input[type="tel"]:focus,
+input[type="text"]:focus,
+input[type="time"]:focus,
+input[type="url"]:focus,
+input[type="week"]:focus,
+textarea:focus {
+	box-shadow: none;
+	border: 1px solid #c8d7e1;
+	-webkit-box-shadow: 0 0 0 2px #78dcfa;
+	box-shadow: 0 0 0 2px #78dcfa;
+}
+.wp-admin select:focus {
+	background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiI…JvdyIgc2tldGNoOnR5cGU9Ik1TU2hhcGVHcm91cCI+PC9wYXRoPiA8L2c+IDwvZz48L3N2Zz4=);
+	border-color: #00aadc;
+	-webkit-box-shadow: 0 0 0 2px #78dcfa;
+	box-shadow: 0 0 0 2px #78dcfa;
+	outline: 0;
+	-moz-outline: none;
+	-moz-user-focus: ignore;
+}
+input[type="text"]::placeholder,
+input[type="search"]::placeholder,
+input[type="email"]::placeholder,
+input[type="number"]::placeholder,
+input[type="password"]::placeholder,
+input[type=checkbox]::placeholder,
+input[type=radio]::placeholder,
+input[type="tel"]::placeholder,
+input[type="url"]::placeholder,
+textarea::placeholder {
+	color: #87a6bc;
+}
+
+/* Checkboxes and radios */
 input[type=checkbox], input[type=radio] {
 	clear: none;
 	cursor: pointer;
@@ -162,6 +208,24 @@ input[type=radio]:checked:before {
 		transform: scale(1);
 	}
 }
+
+/* Form wraps */
+.form-wrap {
+	display: block;
+	margin: 0 auto 10px auto;
+	padding: 16px;
+	background: #fff;
+	-webkit-box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
+	box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
+}
+.form-wrap > h2:first-child {
+	font-size: 24px;
+	font-weight: 300;
+	margin: 0 0 20px 0;
+	line-height: 36px;
+}
+
+/* Select2 inputs */
 .wp-admin select, .select2-container .select2-selection--single {
 	background: #fff url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjQzhEN0UxIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg==) no-repeat right 10px center;
 	border-color: #c8d7e1;
@@ -207,64 +271,8 @@ input[type=radio]:checked:before {
 .select2-container--default .select2-selection--single .select2-selection__placeholder {
 	color: #2e4453;
 }
-input[type="text"]:focus,
-input[type="password"]:focus,
-input[type="checkbox"]:focus,
-input[type="color"]:focus,
-input[type="date"]:focus,
-input[type="datetime"]:focus,
-input[type="datetime-local"]:focus,
-input[type="email"]:focus,
-input[type="month"]:focus,
-input[type="number"]:focus,
-input[type="search"]:focus,
-input[type="radio"]:focus,
-input[type="tel"]:focus,
-input[type="text"]:focus,
-input[type="time"]:focus,
-input[type="url"]:focus,
-input[type="week"]:focus,
-textarea:focus {
-	box-shadow: none;
-	border: 1px solid #c8d7e1;
-	-webkit-box-shadow: 0 0 0 2px #78dcfa;
-	box-shadow: 0 0 0 2px #78dcfa;
-}
-.wp-admin select:focus {
-	background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiI…JvdyIgc2tldGNoOnR5cGU9Ik1TU2hhcGVHcm91cCI+PC9wYXRoPiA8L2c+IDwvZz48L3N2Zz4=);
-	border-color: #00aadc;
-	-webkit-box-shadow: 0 0 0 2px #78dcfa;
-	box-shadow: 0 0 0 2px #78dcfa;
-	outline: 0;
-	-moz-outline: none;
-	-moz-user-focus: ignore;
-}
-input[type="text"]::placeholder,
-input[type="search"]::placeholder,
-input[type="email"]::placeholder,
-input[type="number"]::placeholder,
-input[type="password"]::placeholder,
-input[type=checkbox]::placeholder,
-input[type=radio]::placeholder,
-input[type="tel"]::placeholder,
-input[type="url"]::placeholder,
-textarea::placeholder {
-	color: #87a6bc;
-}
-.form-wrap {
-	display: block;
-	margin: 0 auto 10px auto;
-	padding: 16px;
-	background: #fff;
-	-webkit-box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
-	box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
-}
-.form-wrap > h2:first-child {
-	font-size: 24px;
-	font-weight: 300;
-	margin: 0 0 20px 0;
-	line-height: 36px;
-}
+
+/* Fixes for button height next to select dropdowns */
 .post-type-product .tablenav input,
 .post-type-product .tablenav select,
 .post-type-shop_order .tablenav input,
@@ -277,12 +285,12 @@ textarea::placeholder {
 	height: 41px;
 	margin-top: 0px;
 }
+.button.wc-reload::after {
+	line-height: 38px;
+}
 #order_data .order_data_column .form-field .hour,
 #order_data .order_data_column .form-field .minute {
 	width: auto;
-}
-.button.wc-reload::after {
-	line-height: 38px;
 }
 
 /* Secondary Buttons */

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -80,6 +80,105 @@ div.woocommerce-message, .wc-helper .start-container {
 	fill: #e9eff3;
 }
 
+/* Inputs and forms */
+label {
+	font-size: 14px;
+	font-weight: 600;
+	margin-bottom: 5px;
+}
+input[type="text"],
+input[type="password"],
+input[type="checkbox"],
+input[type="color"],
+input[type="date"],
+input[type="datetime"],
+input[type="datetime-local"],
+input[type="email"],
+input[type="month"],
+input[type="number"],
+input[type="search"],
+input[type="radio"],
+input[type="tel"],
+input[type="text"],
+input[type="time"],
+input[type="url"],
+input[type="week"],
+textarea {
+	margin: 0;
+	padding: 7px 14px;
+	color: #2e4453;
+	font-size: 16px;
+	line-height: 1.5;
+	border: 1px solid #c8d7e1;
+	box-shadow: none;
+}
+.wp-admin select {
+	background: #fff url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjQzhEN0UxIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg==) no-repeat right 10px center;
+	border-color: #c8d7e1;
+	border-style: solid;
+	border-radius: 4px;
+	border-width: 1px 1px 2px;
+	box-sizing: border-box;
+	color: #2e4453;
+	cursor: pointer;
+	display: inline-block;
+	margin: 0;
+	outline: 0;
+	overflow: hidden;
+	font-size: 16px;
+	font-weight: 400;
+	line-height: 1.4em;
+	text-overflow: ellipsis;
+	text-decoration: none;
+	vertical-align: top;
+	white-space: nowrap;
+	-webkit-box-sizing: border-box;
+	box-sizing: border-box;
+	padding: 7px 32px 9px 14px;
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	appearance: none;
+	height: auto;
+}
+input[type="text"]:focus,
+input[type="password"]:focus,
+input[type="checkbox"]:focus,
+input[type="color"]:focus,
+input[type="date"]:focus,
+input[type="datetime"]:focus,
+input[type="datetime-local"]:focus,
+input[type="email"]:focus,
+input[type="month"]:focus,
+input[type="number"]:focus,
+input[type="search"]:focus,
+input[type="radio"]:focus,
+input[type="tel"]:focus,
+input[type="text"]:focus,
+input[type="time"]:focus,
+input[type="url"]:focus,
+input[type="week"]:focus,
+textarea:focus {
+	box-shadow: none;
+	border: 1px solid #c8d7e1;
+}
+.wp-admin select:focus {
+	background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiI…JvdyIgc2tldGNoOnR5cGU9Ik1TU2hhcGVHcm91cCI+PC9wYXRoPiA8L2c+IDwvZz48L3N2Zz4=);
+	border-color: #00aadc;
+	-webkit-box-shadow: 0 0 0 2px #78dcfa;
+	box-shadow: 0 0 0 2px #78dcfa;
+	outline: 0;
+	-moz-outline: none;
+	-moz-user-focus: ignore;
+}
+.post-type-product .tablenav input,
+.post-type-product .tablenav select,
+.post-type-shop_order .tablenav input,
+.post-type-shop_order .tablenav select {
+	line-height: 1.4em;
+	height: 40px;
+	margin-top: 1px;
+}
+
 /* Secondary Buttons */
 .wp-core-ui .button,
 .wp-core-ui .button-secondary,

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -8,6 +8,9 @@ div.woocommerce-message, .wc-helper .start-container {
 }
 
 /* Pagination */
+.tablenav {
+	height: auto;
+}
 .tablenav.bottom .actions, .tablenav .tablenav-pages {
 	display: none;
 }
@@ -111,6 +114,7 @@ textarea {
 	line-height: 1.5;
 	border: 1px solid #c8d7e1;
 	box-shadow: none;
+	height: auto;
 }
 .wp-admin select {
 	background: #fff url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjQzhEN0UxIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg==) no-repeat right 10px center;
@@ -199,10 +203,21 @@ textarea::placeholder {
 .post-type-product .tablenav input,
 .post-type-product .tablenav select,
 .post-type-shop_order .tablenav input,
-.post-type-shop_order .tablenav select {
+.post-type-shop_order .tablenav select,
+#doaction,
+#doaction2,
+#post-query-submit,
+.wp-admin select + .button {
 	line-height: 1.4em;
-	height: 40px;
-	margin-top: 1px;
+	height: 41px;
+	margin-top: 0px;
+}
+#order_data .order_data_column .form-field .hour,
+#order_data .order_data_column .form-field .minute {
+    width: auto;
+}
+.button.wc-reload::after {
+    line-height: 38px;
 }
 
 /* Secondary Buttons */

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -116,6 +116,52 @@ textarea {
 	box-shadow: none;
 	height: auto;
 }
+input[type=checkbox], input[type=radio] {
+	clear: none;
+	cursor: pointer;
+	display: inline-block;
+	line-height: 0;
+	height: 16px;
+	margin: 2px 0 0;
+	outline: 0;
+	padding: 0;
+	text-align: center;
+	vertical-align: middle;
+	width: 16px;
+	min-width: 16px;
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	appearance: none;
+}
+input[type=checkbox] {
+	border-radius: 2px;
+}
+input[type=radio]:checked:before {
+	display: inline-block;
+	content: '\2022';
+	margin: 3px;
+	width: 8px;
+	height: 8px;
+	text-indent: -9999px;
+	background: #00aadc;
+	vertical-align: middle;
+	border-radius: 50%;
+	-webkit-animation: grow .2s ease-in-out;
+	animation: grow .2s ease-in-out;
+}
+@keyframes grow {
+	0% {
+		transform: scale(0.3);
+	}
+	
+	60% {
+		transform: scale(1.15);
+	}
+	
+	100% {
+		transform: scale(1);
+	}
+}
 .wp-admin select, .select2-container .select2-selection--single {
 	background: #fff url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjQzhEN0UxIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg==) no-repeat right 10px center;
 	border-color: #c8d7e1;
@@ -181,6 +227,8 @@ input[type="week"]:focus,
 textarea:focus {
 	box-shadow: none;
 	border: 1px solid #c8d7e1;
+	-webkit-box-shadow: 0 0 0 2px #78dcfa;
+	box-shadow: 0 0 0 2px #78dcfa;
 }
 .wp-admin select:focus {
 	background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiI…JvdyIgc2tldGNoOnR5cGU9Ik1TU2hhcGVHcm91cCI+PC9wYXRoPiA8L2c+IDwvZz48L3N2Zz4=);

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -116,7 +116,7 @@ textarea {
 	box-shadow: none;
 	height: auto;
 }
-.wp-admin select {
+.wp-admin select, .select2-container .select2-selection--single {
 	background: #fff url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjQzhEN0UxIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg==) no-repeat right 10px center;
 	border-color: #c8d7e1;
 	border-style: solid;
@@ -143,6 +143,23 @@ textarea {
 	-moz-appearance: none;
 	appearance: none;
 	height: auto;
+}
+.post-type-shop_order .tablenav .select2-container {
+	width: auto !important;
+	margin: 0 6px 0 0;
+}
+.select2-dropdown {
+	border-color: #c8d7e1;
+}
+.select2-container .select2-selection--single .select2-selection__rendered {
+	line-height: 1.4;
+	padding: 0;
+}
+.select2-container .select2-selection--single .select2-selection__arrow {
+	display: none;
+}
+.select2-container--default .select2-selection--single .select2-selection__placeholder {
+	color: #2e4453;
 }
 input[type="text"]:focus,
 input[type="password"]:focus,
@@ -184,7 +201,7 @@ input[type=radio]::placeholder,
 input[type="tel"]::placeholder,
 input[type="url"]::placeholder,
 textarea::placeholder {
-    color: #87a6bc;
+	color: #87a6bc;
 }
 .form-wrap {
 	display: block;
@@ -214,10 +231,10 @@ textarea::placeholder {
 }
 #order_data .order_data_column .form-field .hour,
 #order_data .order_data_column .form-field .minute {
-    width: auto;
+	width: auto;
 }
 .button.wc-reload::after {
-    line-height: 38px;
+	line-height: 38px;
 }
 
 /* Secondary Buttons */

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -170,6 +170,20 @@ textarea:focus {
 	-moz-outline: none;
 	-moz-user-focus: ignore;
 }
+.form-wrap {
+	display: block;
+	margin: 0 auto 10px auto;
+	padding: 16px;
+	background: #fff;
+	-webkit-box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
+	box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
+}
+.form-wrap > h2:first-child {
+	font-size: 24px;
+	font-weight: 300;
+	margin: 0 0 20px 0;
+	line-height: 36px;
+}
 .post-type-product .tablenav input,
 .post-type-product .tablenav select,
 .post-type-shop_order .tablenav input,


### PR DESCRIPTION
This PR adds Calypso styling to all form inputs.

Fixes #148 

#### Screenshots
<img width="439" alt="screen shot 2018-11-12 at 9 23 25 am" src="https://user-images.githubusercontent.com/10561050/48321411-2ad8d300-e65d-11e8-862e-02405403ef9b.png">
<img width="1045" alt="screen shot 2018-11-12 at 9 23 15 am" src="https://user-images.githubusercontent.com/10561050/48321410-2ad8d300-e65d-11e8-95f5-1aef93efdec4.png">

#### Testing
1. Visit pages with form inputs (e.g. Product edit, and Categories pages).
2. Check that input styling is correct and doesn’t break existing form fields.

@josemarques Since the inputs are 40px tall and this PR increases the height of all select boxes to 40px, I also adjusted the buttons in bulk actions to 40px in height (see the bulk action select options screenshot above).  Can you let me know if this looks okay or if we should make both the buttons and inputs back to the previous height of 28px?