### PR TITLE
Add taxonomy form toggle

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1213,3 +1213,15 @@ TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10507
 		top: 32px;
 	}
 }
+
+/* Taxonomy page */
+.edit-tags-php #col-left {
+	width: 100%;
+	display: none;
+}
+.edit-tags-php #col-right {
+	width: 100%;
+}
+.wp-core-ui .button.taxonomy-form-cancel-button {
+	display: none;
+}

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1221,13 +1221,14 @@ TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10507
 /* Taxonomy page */
 .edit-tags-php #col-left {
 	width: 100%;
-	/* display: none; */
+	display: none;
 }
 .edit-tags-php #col-right {
 	width: 100%;
 }
 .wp-core-ui .button.taxonomy-form-cancel-button {
 	display: none;
+	margin-left: 10px;
 }
 /* @TODO: Remove the following selector if https://github.com/woocommerce/woocommerce/pull/21884 is merged into WC core. */
 .edit-tags-php #col-left > .col-wrap > p:first-child {

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -112,6 +112,10 @@ div.woocommerce-message, .wc-helper .start-container {
 	box-shadow: none;
 	outline: none;
 	opacity: 1;
+	font-size: 12px;
+	height: auto;
+	padding: 7px;
+	line-height: 1;
 }
 .wp-core-ui .button:active,
 .wp-core-ui .button-secondary:active,
@@ -134,7 +138,7 @@ div.woocommerce-message, .wc-helper .start-container {
 
 /* Primary Buttons */
 .wp-core-ui .button-primary,
-.wrap .page-title-action,
+.wrap .page-title-action:not(.button-secondary),
 .wc-helper .button,
 .wc_addons_wrap .addons-button-solid {
 	background: #00aadc !important;
@@ -156,8 +160,8 @@ div.woocommerce-message, .wc-helper .start-container {
 }
 .wp-core-ui .button-primary:hover,
 .wp-core-ui .button-primary:focus,
-.wrap .page-title-action:hover,
-.wrap .page-title-action:focus,
+.wrap .page-title-action:not(.button-secondary):hover,
+.wrap .page-title-action:not(.button-secondary):focus,
 .wc-helper .button:hover,
 .wc-helper .button:focus,
 .wc_addons_wrap .addons-button-solid:hover,

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1221,11 +1221,15 @@ TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10507
 /* Taxonomy page */
 .edit-tags-php #col-left {
 	width: 100%;
-	display: none;
+	/* display: none; */
 }
 .edit-tags-php #col-right {
 	width: 100%;
 }
 .wp-core-ui .button.taxonomy-form-cancel-button {
+	display: none;
+}
+/* @TODO: Remove the following selector if https://github.com/woocommerce/woocommerce/pull/21884 is merged into WC core. */
+.edit-tags-php #col-left > .col-wrap > p:first-child {
 	display: none;
 }

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -95,4 +95,14 @@
         }
     } );
 
+    /**
+     * Toggle taxonomy form
+     */
+    $( '.taxonomy-form-toggle' ).click( function(e) {
+        e.preventDefault();
+        $( '#col-container > #col-left' ).toggle();
+        $( '#col-container > #col-right' ).toggle();
+        $( '.taxonomy-form-toggle' ).toggle();
+    } );
+
 } )( jQuery );

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -105,4 +105,9 @@
         $( '.taxonomy-form-toggle' ).toggle();
     } );
 
+    /**
+     * Move cancel button
+     */
+    $( '.taxonomy-form-cancel-button' ).appendTo( '#addtag p.submit' );
+
 } )( jQuery );

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -87,6 +87,7 @@ class WC_Calypso_Bridge {
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-breadcrumbs.php';
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-hide-alerts.php';
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-pagination.php';
+		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-taxonomies.php';
 		include_once dirname( __FILE__ ) . '/includes/gutenberg.php';
 
 		$connect_files = glob( dirname( __FILE__ ) . '/includes/connect/*.php' );

--- a/includes/class-wc-calypso-bridge-taxonomies.php
+++ b/includes/class-wc-calypso-bridge-taxonomies.php
@@ -47,7 +47,7 @@ class WC_Calypso_Bridge_Taxonomies {
 		<button class="page-title-action button button-primary taxonomy-form-toggle">
 			<?php esc_html_e( 'Add New', 'wc-calypso-bridge' ); ?>
 		</button>
-		<button class="page-title-action button button-secondary taxonomy-form-toggle taxonomy-form-cancel-button">
+		<button class="button button-secondary taxonomy-form-toggle taxonomy-form-cancel-button">
 			<?php esc_html_e( 'Cancel', 'wc-calypso-bridge' ); ?>
 		</button>
 		<?php

--- a/includes/class-wc-calypso-bridge-taxonomies.php
+++ b/includes/class-wc-calypso-bridge-taxonomies.php
@@ -35,14 +35,14 @@ class WC_Calypso_Bridge_Taxonomies {
 	 * Constructor
 	 */
 	private function __construct() {
-		add_action( 'add_tag_form_pre', array( $this, 'add_new_button' ) );
+		add_action( 'add_tag_form_pre', array( $this, 'add_action_button' ) );
 		add_action( 'init', array( $this, 'remove_taxonomy_form_description' ), 100 );
 	}
 
 	/**
 	 * Add new button to toggle taxonomy form
 	 */
-	public function add_new_button() {
+	public function add_action_button() {
 		?>
 		<button class="page-title-action button button-primary taxonomy-form-toggle">
 			<?php esc_html_e( 'Add New', 'wc-calypso-bridge' ); ?>

--- a/includes/class-wc-calypso-bridge-taxonomies.php
+++ b/includes/class-wc-calypso-bridge-taxonomies.php
@@ -44,10 +44,10 @@ class WC_Calypso_Bridge_Taxonomies {
 	 */
 	public function add_new_button() {
 		?>
-		<button class="button button-primary taxonomy-form-toggle">
+		<button class="page-title-action button button-primary taxonomy-form-toggle">
 			<?php esc_html_e( 'Add New', 'wc-calypso-bridge' ); ?>
 		</button>
-		<button class="button button-secondary taxonomy-form-toggle taxonomy-form-cancel-button">
+		<button class="page-title-action button button-secondary taxonomy-form-toggle taxonomy-form-cancel-button">
 			<?php esc_html_e( 'Cancel', 'wc-calypso-bridge' ); ?>
 		</button>
 		<?php

--- a/includes/class-wc-calypso-bridge-taxonomies.php
+++ b/includes/class-wc-calypso-bridge-taxonomies.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Removes the back links and adds the taxonomies on settings pages.
+ *
+ * @package WC_Calypso_Bridge/Classes
+ * @since   1.0.0
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC Calypso Bridge Taxonomies
+ */
+class WC_Calypso_Bridge_Taxonomies {
+
+	/**
+	 * Class instance.
+	 *
+	 * @var WC_Calypso_Bridge_Taxonomies instance
+	 */
+	protected static $instance = false;
+
+	/**
+	 * Get class instance
+	 */
+	public static function get_instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor
+	 */
+	private function __construct() {
+		add_action( 'all_admin_notices', array( $this, 'add_new_button' ) );
+		add_action( 'init', array( $this, 'remove_taxonomy_form_description' ), 100 );
+	}
+
+	/**
+	 * Add new button to toggle taxonomy form
+	 */
+	public function add_new_button() {
+		?>
+		<button class="button button-primary taxonomy-form-toggle">
+			<?php esc_html_e( 'Add New', 'wc-calypso-bridge' ); ?>
+		</button>
+		<button class="button button-secondary taxonomy-form-toggle taxonomy-form-cancel-button">
+			<?php esc_html_e( 'Cancel', 'wc-calypso-bridge' ); ?>
+		</button>
+		<?php
+	}
+
+	/**
+	 * Remove taxonomy form description
+	 *
+	 * Description includes items that have been removed and are irrelevant
+	 * to WC Calypso Bridge.
+	 */
+	public function remove_taxonomy_form_description() {
+		remove_action( 'product_cat_pre_add_form', array( 'WC_Admin_Taxonomies', 'product_cat_description' ) );
+	}
+}
+$wc_calypso_bridge_taxonomies = WC_Calypso_Bridge_Taxonomies::get_instance();

--- a/includes/class-wc-calypso-bridge-taxonomies.php
+++ b/includes/class-wc-calypso-bridge-taxonomies.php
@@ -35,7 +35,7 @@ class WC_Calypso_Bridge_Taxonomies {
 	 * Constructor
 	 */
 	private function __construct() {
-		add_action( 'all_admin_notices', array( $this, 'add_new_button' ) );
+		add_action( 'add_tag_form_pre', array( $this, 'add_new_button' ) );
 		add_action( 'init', array( $this, 'remove_taxonomy_form_description' ), 100 );
 	}
 

--- a/includes/class-wc-calypso-bridge-taxonomies.php
+++ b/includes/class-wc-calypso-bridge-taxonomies.php
@@ -36,7 +36,7 @@ class WC_Calypso_Bridge_Taxonomies {
 	 */
 	private function __construct() {
 		add_action( 'add_tag_form_pre', array( $this, 'add_action_button' ) );
-		add_action( 'init', array( $this, 'remove_taxonomy_form_description' ), 100 );
+		add_action( 'wp_loaded', array( $this, 'remove_taxonomy_form_description' ) );
 	}
 
 	/**
@@ -60,7 +60,8 @@ class WC_Calypso_Bridge_Taxonomies {
 	 * to WC Calypso Bridge.
 	 */
 	public function remove_taxonomy_form_description() {
-		remove_action( 'product_cat_pre_add_form', array( 'WC_Admin_Taxonomies', 'product_cat_description' ) );
+		// @TODO: Uncomment the following line if https://github.com/woocommerce/woocommerce/pull/21884 is merged into WC core.
+		// remove_action( 'product_cat_pre_add_form', array( WC_Admin_Taxonomies::get_instance(), 'product_cat_description' ), 10 );
 	}
 }
 $wc_calypso_bridge_taxonomies = WC_Calypso_Bridge_Taxonomies::get_instance();


### PR DESCRIPTION
Adds a toggle to the header in all taxonomy pages that shows the form on click and shows the taxonomy list on cancel.

Fixes #147 

#### Screenshots
<img width="756" alt="screen shot 2018-11-12 at 10 04 05 am" src="https://user-images.githubusercontent.com/10561050/48322404-5a3e0e80-e662-11e8-85a9-7fdea0212059.png">
<img width="748" alt="screen shot 2018-11-12 at 10 04 01 am" src="https://user-images.githubusercontent.com/10561050/48322403-5a3e0e80-e662-11e8-8128-b0b16c51eecf.png">

#### Testing
1.  Visit any taxonomy page (e.g., `/wp-admin/edit-tags.php?taxonomy=product_cat&post_type=product`)
2. Check that the toggle form works using the "Add new" and "Cancel" buttons to the right of the page header.

@josemarques The "Cancel" button was also added to the header here.  There's no hook inside the form to add the cancel button, but it can be added after the submit button ("Add new category") in the form.  Let me know what you think and I'll modify accordingly.