### PR TITLE
Hide payment settings config in OBW

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -858,6 +858,10 @@ table.widefat {
 .wc-wizard-service-item.klarna-logo .wc-wizard-service-name img {
 	display: none;
 }
+.wc-wizard-service-item.checked .wc-wizard-service-settings,
+.wc-wizard-services-list-toggle.checked .wc-wizard-service-settings {
+	display: none;
+}
 @media screen and (max-width:600px) {
 	.wc-wizard-service-item, .wc-wizard-services-list-toggle {
 		flex-flow: row wrap;


### PR DESCRIPTION
This PR hides the settings for the payment gateways since these settings do not fully configure the payment gateway.

We use CSS to `display: none` since there aren't any filtering options for the payment gateways.

Fixes #154 

#### Screenshots
<img width="516" alt="screen shot 2018-11-12 at 12 00 15 pm" src="https://user-images.githubusercontent.com/10561050/48326077-8a8da900-e672-11e8-8c98-9fd759ab556a.png">

#### Testing
1. Visit `/wp-admin/admin.php?page=wc-setup&step=payment`
2. Confirm that the settings for each payment gateway are hidden when a payment gateway is toggled to enabled.
