### PR TITLE
Calypso style search and subnav search

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -272,6 +272,15 @@ div.woocommerce-message, .wc-helper .start-container {
 }
 
 /* Navigation tabs */
+.subsubsub {
+	position: relative;
+	border: 0;
+	-webkit-box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
+    box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
+}
+.subsubsub a, .filter-links li>a {
+    padding: 11px 15px;
+}
 .woocommerce nav.woo-nav-tab-wrapper {
 	width: 100%;
 }
@@ -1236,18 +1245,100 @@ TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10507
 }
 
 /* Search box */
-.search-box {
+p.search-box {
 	height: 50px;
+	width: 100%;
     display: flex;
     background: #fff;
 	padding: 0;
     margin: 0 0 17px 0;
     -webkit-box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
-    box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
+	box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
+	align-items: center;
+	transition: all 0.15s ease-in-out;
+}
+.search-box.has-focus {
+	box-shadow: 0 0 0 1px #0087be, 0 0 0 4px #78dcfa;
 }
 .search-box input[name="s"] {
 	height: 100%;
 	border: none;
 	font-size: 16px;
 	color: #2e4453;
+	box-shadow: none;
+	flex: 1;
+}
+.search-box input[type="submit"] {
+	margin-right: 13px;
+}
+.search-box.is-expanded input[type="submit"] {
+	margin-right: 0;
+}
+.search-box__search-icon,
+.search-box__close-icon {
+	width: 50px;
+	height: 50px;
+	cursor: pointer;
+	background: none;
+	border: none;
+	box-shadow: none;
+	padding: 0;
+	display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.search-box__close-icon {
+	display: none;
+}
+.search-box__search-icon:focus,
+.search-box__close-icon:focus {
+	outline: none;
+	box-shadow: none;
+}
+.search-box svg {
+	fill: #3d596d;
+}
+.search-box input[name="s"]::-webkit-search-cancel-button {
+	display: none;
+}
+.search-box.is-expanded {
+	position: absolute;
+	height: 100%;
+    width: 100%;
+    top: 0;
+    right: 0;
+}
+.subsubsub .search-box {
+	margin-bottom: 0;
+	position: absolute;
+    right: 0;
+}
+.subsubsub .search-box {
+	margin-bottom: 0;
+	position: absolute;
+	right: 0;
+	top: 0;
+	width: auto;
+	width: 50px;
+	overflow: hidden;
+}
+.subsubsub .search-box:not(.is-expanded) {
+	box-shadow: none;
+}
+.subsubsub .search-box.is-expanded {
+	width: 100%;
+}
+.subsubsub .search-box input {
+	display: none;
+	margin: 0 !important;
+}
+.subsubsub .search-box:not(.is-expanded) .search-box__search-icon svg {
+	fill: #0087be;
+}
+.subsubsub .search-box:not(.is-expanded) .search-box__search-icon:hover svg {
+	fill: #3d596d;
+}
+.subsubsub .search-box.is-expanded .search-box__close-icon,
+.subsubsub .search-box.is-expanded input {
+	display: block;
 }

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1344,6 +1344,9 @@ p.search-box {
 .subsubsub .search-box:not(.is-expanded) .search-box__search-icon:hover svg {
 	fill: #3d596d;
 }
+.search-box.has-value .search-box__close-icon {
+	display: flex;
+}
 .subsubsub .search-box.is-expanded .search-box__close-icon,
 .subsubsub .search-box.is-expanded input[type="search"] {
 	display: flex;

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1234,3 +1234,20 @@ TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10507
 .edit-tags-php #col-left > .col-wrap > p:first-child {
 	display: none;
 }
+
+/* Search box */
+.search-box {
+	height: 50px;
+    display: flex;
+    background: #fff;
+	padding: 0;
+    margin: 0 0 17px 0;
+    -webkit-box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
+    box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
+}
+.search-box input[name="s"] {
+	height: 100%;
+	border: none;
+	font-size: 16px;
+	color: #2e4453;
+}

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1269,6 +1269,9 @@ p.search-box {
 	box-shadow: none;
 	flex: 1;
 }
+.search-box input[name="s"]:-webkit-autofill {
+	box-shadow: none;
+}
 .search-box input[type="submit"] {
 	margin-right: 13px;
 }

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -279,9 +279,6 @@ div.woocommerce-message, .wc-helper .start-container {
 	box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
 	box-sizing: border-box;	
 }
-.subsubsub.has-search {
-	padding-right: 50px;
-}
 .subsubsub a, .filter-links li>a {
 	padding: 11px 15px;
 }
@@ -1321,6 +1318,13 @@ p.search-box {
 	height: 100%;
 	overflow: hidden;
 }
+.subsubsub.has-search {
+	padding-right: 50px;
+}
+.search-box .button,
+.search-box input[type="submit"] {
+	display: none;
+}
 .subsubsub .search-box:not(.is-expanded) {
 	box-shadow: none;
 }
@@ -1338,6 +1342,6 @@ p.search-box {
 	fill: #3d596d;
 }
 .subsubsub .search-box.is-expanded .search-box__close-icon,
-.subsubsub .search-box.is-expanded input {
-	display: block;
+.subsubsub .search-box.is-expanded input[type="search"] {
+	display: flex;
 }

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -276,10 +276,14 @@ div.woocommerce-message, .wc-helper .start-container {
 	position: relative;
 	border: 0;
 	-webkit-box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
-    box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
+	box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
+	box-sizing: border-box;	
+}
+.subsubsub.has-search {
+	padding-right: 50px;
 }
 .subsubsub a, .filter-links li>a {
-    padding: 11px 15px;
+	padding: 11px 15px;
 }
 .woocommerce nav.woo-nav-tab-wrapper {
 	width: 100%;
@@ -1248,11 +1252,11 @@ TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10507
 p.search-box {
 	height: 50px;
 	width: 100%;
-    display: flex;
-    background: #fff;
+	display: flex;
+	background: #fff;
 	padding: 0;
-    margin: 0 0 17px 0;
-    -webkit-box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
+	margin: 0 0 17px 0;
+	-webkit-box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
 	box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
 	align-items: center;
 	transition: all 0.15s ease-in-out;
@@ -1284,8 +1288,8 @@ p.search-box {
 	box-shadow: none;
 	padding: 0;
 	display: flex;
-    align-items: center;
-    justify-content: center;
+	align-items: center;
+	justify-content: center;
 }
 .search-box__close-icon {
 	display: none;
@@ -1304,22 +1308,17 @@ p.search-box {
 .search-box.is-expanded {
 	position: absolute;
 	height: 100%;
-    width: 100%;
-    top: 0;
-    right: 0;
-}
-.subsubsub .search-box {
-	margin-bottom: 0;
-	position: absolute;
-    right: 0;
+	width: 100%;
+	top: 0;
+	right: 0;
 }
 .subsubsub .search-box {
 	margin-bottom: 0;
 	position: absolute;
 	right: 0;
 	top: 0;
-	width: auto;
 	width: 50px;
+	height: 100%;
 	overflow: hidden;
 }
 .subsubsub .search-box:not(.is-expanded) {

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -115,8 +115,56 @@
      */
     var $subNav = $( '.subsubsub' );
     if ( $subNav.length ) {
-        var $searchBoxListItem = $( '<li class="subsubsub-search"></li>').appendTo( $subNav );
+        var $searchBoxListItem = $( '<li class="subsubsub__search-item"></li>').appendTo( $subNav );
         $( '#posts-filter .search-box' ).appendTo( $searchBoxListItem );
     }
+
+    /**
+     * Add icons to search boxes
+     */
+    $( '.search-box' ).prepend( '<button class="search-box__search-icon" aria-label="' + wcb.openSearchText + '"><svg class="gridicon gridicons-search" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M21 19l-5.154-5.154C16.574 12.742 17 11.42 17 10c0-3.866-3.134-7-7-7s-7 3.134-7 7 3.134 7 7 7c1.42 0 2.742-.426 3.846-1.154L19 21l2-2zM5 10c0-2.757 2.243-5 5-5s5 2.243 5 5-2.243 5-5 5-5-2.243-5-5z"/></g></svg></button>' );
+    $( '.search-box' ).append( '<button class="search-box__close-icon" aria-label="' + wcb.closeSearchText + '"><svg class="gridicon gridicons-cross" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M18.36 19.78L12 13.41l-6.36 6.37-1.42-1.42L10.59 12 4.22 5.64l1.42-1.42L12 10.59l6.36-6.36 1.41 1.41L13.41 12l6.36 6.36z"/></g></svg></button>' );
+
+    /**
+     * Focus search input on open icon click
+     */
+    $( document ).on( 'click', '.search-box__search-icon', function(e) {
+        e.preventDefault();
+        $( this ).closest( '.search-box' ).addClass( 'has-focus' );
+        // Defer focus when expanding since input is not displayed
+        var $searchInput = $( this ).siblings( 'input[name="s"]' );
+        setTimeout( function() {
+            $searchInput.focus();
+        }, 0 );
+    } );
+
+    /**
+     * Open search when inside nav
+     */
+    $( document ).on( 'click', '.subsubsub .search-box__search-icon', function(e) {
+        $( this ).closest( '.search-box' ).addClass( 'is-expanded' );
+    } );
+
+    /**
+     * Close search when inside nav
+     */
+    $( document ).on( 'click', '.subsubsub .search-box__close-icon', function(e) {
+        e.preventDefault();
+        $( this ).closest( '.search-box' ).removeClass( 'is-expanded' );
+    } );
+
+    /**
+     * Add focus class to search box wrapper on focus
+     */
+    $( document ).on( 'focus', 'input[name="s"]', function() {
+        $( this ).closest( '.search-box' ).addClass( 'has-focus' );
+    } );
+
+    /**
+     * Remove focus on blur
+     */
+    $( document ).on( 'blur', 'input[name="s"]', function() {
+        $( this ).closest( '.search-box' ).removeClass( 'has-focus' );
+    } );
 
 } )( jQuery );

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -117,11 +117,16 @@
     if ( $subNav.length ) {
         var $searchBoxListItem = $( '<li class="subsubsub__search-item"></li>').appendTo( $subNav );
         var $searchBox = $( '#posts-filter .search-box' );
+        var $searchInput = $searchBox.find( 'input[type=search]' );
         var uniqueId = Math.floor(Math.random() * 26) + Date.now();
+
         $searchBox.closest( 'form' ).attr( 'data-form-id', uniqueId );
         $searchBox.attr( 'data-target-form-id', uniqueId );
         $searchBox.appendTo( $searchBoxListItem );
         $subNav.addClass( 'has-search' );
+        if ( $searchInput.val().length ) {
+            $searchBox.addClass( 'is-expanded' );
+        }
     }
 
     /**

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -217,4 +217,24 @@
         $( this ).attr( 'autocomplete', 'off' );
     } );
 
+    /**
+     * Clear the search query when clicking the close icon not inside subnav
+     */
+    $( document ).on( 'click', 'div:not(.subsubsub) .search-box__close-icon', function(e) {
+        e.preventDefault();
+        $( this ).closest( '.search-box' ).find( 'input[type=search]' ).val( '' );
+        $( this ).closest( '.search-box' ).removeClass( 'has-value' );
+    } );
+
+    /**
+     * Add has-value class on type
+     */
+    $( document ).on( 'keyup', '.search-box input[type="search"]', function(e) {
+        if ( $( this ).val() ) {
+            $( this ).closest( '.search-box' ).addClass( 'has-value' );
+        } else {
+            $( this ).closest( '.search-box' ).removeClass( 'has-value' );
+        }
+    } );
+
 } )( jQuery );

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -210,4 +210,11 @@
         }
     } );
 
+    /** 
+     * Disable autocomplete for search inputs
+     */
+    $( document ).on( 'focus', 'input[type=search]', function() {
+        $( this ).attr( 'autocomplete', 'off' );
+    } );
+
 } )( jQuery );

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -117,6 +117,7 @@
     if ( $subNav.length ) {
         var $searchBoxListItem = $( '<li class="subsubsub__search-item"></li>').appendTo( $subNav );
         $( '#posts-filter .search-box' ).appendTo( $searchBoxListItem );
+        $subNav.addClass( 'has-search' );
     }
 
     /**

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -116,7 +116,11 @@
     var $subNav = $( '.subsubsub' );
     if ( $subNav.length ) {
         var $searchBoxListItem = $( '<li class="subsubsub__search-item"></li>').appendTo( $subNav );
-        $( '#posts-filter .search-box' ).appendTo( $searchBoxListItem );
+        var $searchBox = $( '#posts-filter .search-box' );
+        var uniqueId = Math.floor(Math.random() * 26) + Date.now();
+        $searchBox.closest( 'form' ).attr( 'data-form-id', uniqueId );
+        $searchBox.attr( 'data-target-form-id', uniqueId );
+        $searchBox.appendTo( $searchBoxListItem );
         $subNav.addClass( 'has-search' );
     }
 
@@ -167,5 +171,28 @@
     $( document ).on( 'blur', 'input[name="s"]', function() {
         $( this ).closest( '.search-box' ).removeClass( 'has-focus' );
     } );
+
+    /**
+     * Fix search for inputs outside of forms by appending inputs on enter/click
+     */
+    function appendInputsToForm( e ) {
+        if ( e.type === 'click' || e.which === 13 ) {
+            e.preventDefault();
+            var formId = $( this ).closest( '.search-box' ).data( 'target-form-id' );
+            var $form = $( 'form[data-form-id="' + formId + '"' );
+            var $searchInput = $( this ).closest( '.search-box' ).find( 'input[type="search"]' );
+            $( '<input>' ).attr(
+                {
+                    type: 'hidden',
+                    id: $searchInput.attr( 'id' ),
+                    name: $searchInput.attr( 'name' ),
+                    value: $searchInput.val(),
+                }
+            ).appendTo( $form );
+            $form.submit();
+        }
+    }
+    $( document ).on( 'click', '.subsubsub .search-box input[type=submit]', appendInputsToForm );
+    $( document ).on( 'keypress', '.subsubsub .search-box input[type=search]', appendInputsToForm );
 
 } )( jQuery );

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -195,4 +195,14 @@
     $( document ).on( 'click', '.subsubsub .search-box input[type=submit]', appendInputsToForm );
     $( document ).on( 'keypress', '.subsubsub .search-box input[type=search]', appendInputsToForm );
 
+    /**
+     * Submit regular search forms on enter
+     */
+    $( document ).on( 'keypress', 'div:not(.subsubsub) .search-box input[type=search]', function( e ) {
+        if ( e.which === 13 ) {
+            e.preventDefault();
+            $( this ).closest( 'form' ).submit();
+        }
+    } );
+
 } )( jQuery );

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -110,4 +110,13 @@
      */
     $( '.taxonomy-form-cancel-button' ).appendTo( '#addtag p.submit' );
 
+    /**
+     * Move search box to subnav
+     */
+    var $subNav = $( '.subsubsub' );
+    if ( $subNav.length ) {
+        var $searchBoxListItem = $( '<li class="subsubsub-search"></li>').appendTo( $subNav );
+        $( '#posts-filter .search-box' ).appendTo( $searchBoxListItem );
+    }
+
 } )( jQuery );

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -122,7 +122,6 @@ class WC_Calypso_Bridge {
 		$asset_path = self::$plugin_asset_path ? self::$plugin_asset_path : self::MU_PLUGIN_ASSET_PATH;
 		wp_enqueue_style( 'wc-calypso-bridge-calypsoify', $asset_path . 'assets/css/calypsoify.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION, 'all' );
 		wp_enqueue_script( 'wc-calypso-bridge-calypsoify', $asset_path . 'assets/js/calypsoify.js', array( 'jquery' ), WC_CALYPSO_BRIDGE_CURRENT_VERSION, true );
-
 		$icons = array(
 			'info'      => get_gridicon( 'gridicons-info' ),
 			'checkmark' => get_gridicon( 'gridicons-checkmark' ),
@@ -134,6 +133,13 @@ class WC_Calypso_Bridge {
 			'icons',
 			$icons
 		);
+
+		$translations = array(
+			'openSearchText'  => __( 'Open Search', 'wc-calypso-bridge' ),
+			'closeSearchText' => __( 'Close Search', 'wc-calypso-bridge' ),
+		);
+		wp_localize_script( 'wc-calypso-bridge-calypsoify', 'wcb', $translations );
+
 	}
 
 	/**

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -122,6 +122,7 @@ class WC_Calypso_Bridge {
 		$asset_path = self::$plugin_asset_path ? self::$plugin_asset_path : self::MU_PLUGIN_ASSET_PATH;
 		wp_enqueue_style( 'wc-calypso-bridge-calypsoify', $asset_path . 'assets/css/calypsoify.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION, 'all' );
 		wp_enqueue_script( 'wc-calypso-bridge-calypsoify', $asset_path . 'assets/js/calypsoify.js', array( 'jquery' ), WC_CALYPSO_BRIDGE_CURRENT_VERSION, true );
+
 		$icons = array(
 			'info'      => get_gridicon( 'gridicons-info' ),
 			'checkmark' => get_gridicon( 'gridicons-checkmark' ),


### PR DESCRIPTION
This PR styles the search box to look like Calypso's and also moves it into the subnav if one exists on the page.

Fixes #151 

#### Screenshots
<img width="795" alt="screen shot 2018-11-12 at 2 31 37 pm" src="https://user-images.githubusercontent.com/10561050/48343532-99de1800-e6ad-11e8-9083-eaafafc3c92b.png">
<img width="786" alt="screen shot 2018-11-12 at 2 31 44 pm" src="https://user-images.githubusercontent.com/10561050/48343534-99de1800-e6ad-11e8-87fc-6b1d269c0caa.png">
<img width="802" alt="screen shot 2018-11-12 at 2 31 47 pm" src="https://user-images.githubusercontent.com/10561050/48343535-99de1800-e6ad-11e8-9c4d-555d605e622e.png">

#### Testing
1.  Visit pages with search boxes both with a subnav and without.  E.g., `/wp-admin/edit-tags.php?taxonomy=product_cat&post_type=product` and `/wp-admin/edit.php?post_type=product`
2.  Check that styling and functionality work for both types and match Calypso's - https://wordpress.com/store/products/

##### Some things to test for
* Search icon (magnifying glass) should open the input on products and focus the input.
* Close icon (x) should only be visible in subnav search bar and should close menu.
* Search should still work on both

#### Design
The Calypso style search runs on type, while the WP forms only run on submit.  I've kept the submit buttons inside the form for the time being, but should we change this?  /cc @josemarques 

We could also:
* Auto-submit when the user finishes typing
* Use a different icon for search?