### PR TITLE
Add gridicons as composer package

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 This repository houses various fixes and extensions for wp-admin to enhance the experience for users of the WordPress.com Store.
 
+## Getting Started
+
+To get started with development run `composer install` from the this repo's root directory.  This will:
+* Install all vendor dependencies
+* Create pre-commit hooks to catch lint and WPCS errors
+
+To check WPCS and lint errors via CLI, run the following from the root directory.
+`./vendor/bin/phpcs [filename]`
+To automatically fix errors and beautify files, run the following from the root directory.
+`./vendor/bin/phpcbf [filename]`
+
 ## Test Suite
 
 This repository does have a test suite, which depends upon `wc-api-dev`, and `woocommerce` both being present witin the same `wp-content/plugins` directory. Much like the test suite in `wc-api-dev` it borrows heavily from the base `woocommerce` API test suite to enable quick testing via all of the core helper methods.

--- a/assets/css/setup-checklist.css
+++ b/assets/css/setup-checklist.css
@@ -518,6 +518,10 @@
 	border-width: 1px;
 	cursor: default;
 }
+.checklist__task-icon svg {
+	max-width: 18px;
+	max-height: 18px;
+}
 .checklist-card:not(.is-completed) .checklist__task-icon:hover,
 .checklist-card:not(.is-completed) .checklist__task-icon:focus {
 	background: #fff;

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -47,11 +47,11 @@
      * Append icons to notices
      */
     $( 'div.notice, div.error, div.updated, div.warning' ).each( function() {
-        var icon = '<svg class="gridicon gridicons-info" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"/></g></svg>';
+        var icon = icons.info;
         if ( $( this ).hasClass( 'notice-success') ) {
-            icon = '<svg class="gridicon gridicons-checkmark" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"/></g></svg>';
+            icon = icons.checkmark;
         } else if ( $( this ).hasClass( 'error' ) || $( this ).hasClass( 'notice-warning' ) ) {
-            icon = '<svg class="gridicon gridicons-notice" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"/></g></svg>';
+            icon = icons.notice;
         }
         $( this ).prepend( '<span class="wc-calypso-bridge-notice-icon-wrapper">' + icon + '</span>' );
     } );
@@ -60,7 +60,7 @@
      * Replace dismissal buttons in notices
      */
     $( document ).ready( function() {
-        $( '.notice-dismiss' ).html( '<svg class="gridicon gridicons-cross" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M18.36 19.78L12 13.41l-6.36 6.37-1.42-1.42L10.59 12 4.22 5.64l1.42-1.42L12 10.59l6.36-6.36 1.41 1.41L13.41 12l6.36 6.36z"/></g></svg>' );
+        $( '.notice-dismiss' ).html( icons.cross );
     } );
 
     /**

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -87,6 +87,7 @@ class WC_Calypso_Bridge {
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-breadcrumbs.php';
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-hide-alerts.php';
 		include_once dirname( __FILE__ ) . '/includes/gutenberg.php';
+		include_once dirname( __FILE__ ) . '/vendor/automattic/gridicons/php/gridicons.php';
 
 		$connect_files = glob( dirname( __FILE__ ) . '/includes/connect/*.php' );
 		foreach ( $connect_files as $connect_file ) {
@@ -119,6 +120,18 @@ class WC_Calypso_Bridge {
 		$asset_path = self::$plugin_asset_path ? self::$plugin_asset_path : self::MU_PLUGIN_ASSET_PATH;
 		wp_enqueue_style( 'wc-calypso-bridge-calypsoify', $asset_path . 'assets/css/calypsoify.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION, 'all' );
 		wp_enqueue_script( 'wc-calypso-bridge-calypsoify', $asset_path . 'assets/js/calypsoify.js', array( 'jquery' ), WC_CALYPSO_BRIDGE_CURRENT_VERSION, true );
+
+		$icons = array(
+			'info'      => get_gridicon( 'gridicons-info' ),
+			'checkmark' => get_gridicon( 'gridicons-checkmark' ),
+			'notice'    => get_gridicon( 'gridicons-notice' ),
+			'cross'     => get_gridicon( 'gridicons-cross' ),
+		);
+		wp_localize_script(
+			'wc-calypso-bridge-calypsoify',
+			'icons',
+			$icons
+		);
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,23 @@
 			"wc-calypso-bridge.php"
 		]
 	},
+	"repositories": [
+		{
+			"type": "package",
+			"package": {
+				"name": "automattic/gridicons",
+				"version": "3.1.1",
+				"source": {
+					"url": "https://github.com/Automattic/gridicons",
+					"type": "git",
+					"reference": "master"
+				}
+			}
+		}
+	],
 	"require": {
-		"composer/installers": "~1.2"
+		"composer/installers": "~1.2",
+		"automattic/gridicons": "*"
 	},
 	"require-dev": {
 		"squizlabs/php_codesniffer": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,18 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "76cfed33e583a8dcd246def9c69b4eab",
+    "content-hash": "1e8ec4d93e03aae54eaf36f419829658",
     "packages": [
+        {
+            "name": "automattic/gridicons",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/gridicons",
+                "reference": "master"
+            },
+            "type": "library"
+        },
         {
             "name": "composer/installers",
             "version": "v1.6.0",

--- a/includes/class-wc-calypso-bridge-admin-setup-checklist.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-checklist.php
@@ -496,7 +496,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 						<label for="checklist__header-action" class="checklist__header-summary checklist__toggle checklist__header-complete-label">Hide completed</label>
 						<button id="checklist__header-action" class="checklist__header-action checklist__toggle">
 							<span class="screen-reader-text checklist__header-complete-label">Hide completed</span>
-							<svg class="gridicon gridicons-chevron-down" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M20 9l-8 8-8-8 1.414-1.414L12 14.172l6.586-6.586"></path></g></svg>
+							<?php echo get_gridicon( 'gridicons-chevron-down' ); // WPCS: XSS ok. ?>
 						</button>
 					</div>
 				</div>
@@ -566,7 +566,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 				</small>
 			</div>
 			<div class="checklist__task-icon">
-				<svg class="gridicon gridicons-checkmark" height="18" width="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"></path></g></svg>
+				<?php echo get_gridicon( 'gridicons-checkmark' ); // WPCS: XSS ok. ?>
 			</div>
 		</div>
 		<?php

--- a/includes/class-wc-calypso-bridge-menus.php
+++ b/includes/class-wc-calypso-bridge-menus.php
@@ -65,10 +65,10 @@ class WC_Calypso_Bridge_Menus {
 	 */
 	public function insert_sidebar_html() { ?>
 		<a href="<?php echo esc_url( 'https://wordpress.com/stats/day/' . Jetpack::build_raw_urls( home_url() ) ); ?>" id="calypso-sidebar-header">
-			<svg class="gridicon gridicons-chevron-left" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M14 20l-8-8 8-8 1.414 1.414L8.828 12l6.586 6.586"></path></g></svg>
+			<?php echo get_gridicon( 'gridicons-chevron-left' ); // WPCS: XSS ok. ?>
 			<ul>
-			<li id="calypso-sitename"><?php bloginfo( 'name' ); ?></li>
-			<li id="calypso-plugins"><?php esc_html_e( 'WooCommerce', 'wc-calypso-bridge' ); ?></li>
+				<li id="calypso-sitename"><?php bloginfo( 'name' ); ?></li>
+				<li id="calypso-plugins"><?php esc_html_e( 'WooCommerce', 'wc-calypso-bridge' ); ?></li>
 			</ul>
 		</a>
 		<?php


### PR DESCRIPTION
This PR pulls in Automattic/gridicons ( https://github.com/Automattic/gridicons/ ) so that we can insert SVG icons through `get_gridicon()` instead of inlining all of our SVGs.

Fixes #165 

#### Testing


1. Run `composer install`
2. Visit areas of the dashboard that we pull in icons and verify that no icons are broken.  Here are the areas we currently use grid icons:
* Checklist check on Setup page
* Checklist chevron arrow
* Admin notices
* Chevron arrow in sidebar
* Pagination (not yet merged)
* Expandable search bar (not yet merged)
