### PR TITLE
Remove folded menu on tablet viewport

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -247,6 +247,9 @@ html.wp-toolbar {
 	height: 100%;
 	padding: 30px;
 }
+#wpbody {
+	padding-top: 0;
+}
 #wpwrap {
 	top: 0;
 }
@@ -1434,17 +1437,6 @@ TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10507
 .wrap div.updated + br.clear,
 .wrap div.error + br.clear {
 	display: none;
-}
-
-/* Admin menu */
-/* Can be removed pending merge of https://github.com/Automattic/jetpack/pull/10552 */
-@media screen and (max-width: 600px) {
-	#calypso-sidebar-header {
-		top: 32px;
-	}
-	.auto-fold #adminmenu {
-		top: 32px;
-	}
 }
 
 /* Taxonomy page */

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1169,6 +1169,39 @@ table.widefat {
 	}
 }
 
+/* Admin menu */
+@media only screen and (min-width: 661px) and (max-width: 960px) {
+	.autofold .adminmenuwrap,
+	#wpadminbar li#wp-admin-bar-menu-toggle {
+		display: none;
+	}
+	#calypso-sidebar-header {
+		width: 190px;
+		display: block;
+		position: absolute;
+		top: 0;
+	}
+	#calypso-sidebar-header ul {
+		display: block;
+	}
+	#adminmenu,
+	#adminmenuwrap,
+	#adminmenuback,
+	#adminmenu
+	.wp-submenu {
+		width: 190px;
+		position: relative !important;
+	}
+	#wpcontent, #wpfooter {
+		margin-left: 190px;
+	}
+}
+@media only screen and (min-width: 661px) and (max-width: 783px) {
+	#calypso-sidebar-header {
+		left: -190px;
+	}
+}
+
 /* Breadcrumbs */
 .wc-calypso-bridge-breadcrumbs + h2 {
 	display: none;
@@ -1227,9 +1260,10 @@ TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10507
 	width: 225px;
 }
 
-@media screen and (max-width:782px) {
+@media screen and (max-width:960px) {
 	#calypso-sidebar-header ul li#calypso-sitename {
 		width: 150px;
+		overflow: hidden;
 	}
 }
 

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -81,7 +81,6 @@
     $pageTitleActionsContainer.insertAfter( 'h1.wp-heading-inline' );
     $( '.page-title-action' ).appendTo( $pageTitleActionsContainer );
 
-
     /** 
      * Move notices on pages with sub navigation
      * 
@@ -236,5 +235,18 @@
             $( this ).closest( '.search-box' ).removeClass( 'has-value' );
         }
     } );
+
+    /**
+     * Remove auto-fold for admin sidebar menu
+     */
+    function removeAutoFold() {
+        if ( $(this).width() > 660 && $(this).width() <= 960 ) {
+            $( 'body' ).removeClass('auto-fold');
+        } else {
+            $( 'body' ).addClass('auto-fold');
+        }
+    }
+    $( window ).on( 'resize', removeAutoFold );
+    $( document ).on( 'ready', removeAutoFold );
 
 } )( jQuery );


### PR DESCRIPTION
This removes the folded/collapsed menu seen on tablet viewports.

Fixes #149 

#### Screenshots
##### Before
<img width="194" alt="screen shot 2018-11-13 at 2 28 40 pm 1" src="https://user-images.githubusercontent.com/10561050/48394949-70c29380-e750-11e8-8d3e-9d686be19ce0.png">

##### After
<img width="540" alt="screen shot 2018-11-13 at 2 23 45 pm" src="https://user-images.githubusercontent.com/10561050/48394831-0578c180-e750-11e8-977d-fee536664e87.png">

#### Testing
1.  Test any admin page in Calypsoify on a viewport >782px  and <960px to confirm that the non-folded menu is seen.
2.  Also check on smaller screen sizes to make sure no regressions have occurred.
