### PR TITLE
Add action header actions

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -328,6 +328,9 @@ li#wp-admin-bar-menu-toggle {
 	padding: 0;
 	text-align: center;
 }
+.action-header .action-header__ground-control-back:focus {
+	box-shadow: none;
+}
 @media screen and ( max-width: 660px ) {
 	.action-header .action-header__ground-control-back {
 		padding-top: 11px;
@@ -1450,17 +1453,6 @@ TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10507
 .wrap div.updated + br.clear,
 .wrap div.error + br.clear {
 	display: none;
-}
-
-/* Admin menu */
-/* Can be removed pending merge of https://github.com/Automattic/jetpack/pull/10552 */
-@media screen and (max-width: 600px) {
-	#calypso-sidebar-header {
-		top: 32px;
-	}
-	.auto-fold #adminmenu {
-		top: 32px;
-	}
 }
 
 /* Taxonomy page */

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -259,6 +259,22 @@ html.wp-toolbar {
 .auto-fold #adminmenu {
 	top: 0;
 }
+@media screen and ( max-width: 660px ) {
+	.auto-fold #adminmenu,
+	.auto-fold #adminmenuback,
+	.auto-fold #adminmenuwrap {
+		width: 100%;
+	}
+	.auto-fold #adminmenuwrap {
+		display: block;
+		transform: translateX(-100%);
+		transition: transform 0.15s ease-in-out;
+	}
+	.auto-fold .wp-responsive-open #adminmenuwrap {
+		display: block;
+		transform: translateX(0%);
+	}
+}
 @media screen and ( min-width: 661px ) {
 	html.wp-toolbar {
 		padding-top: 93px;
@@ -314,6 +330,9 @@ html.wp-toolbar {
 	.action-header .gridicons-cross {
 		display: flex;
 	}
+}
+li#wp-admin-bar-menu-toggle {
+	display: none;
 }
 .action-header .action-header__ground-control-back {
 	align-items: center;

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -241,7 +241,7 @@ div.woocommerce-message, .wc-helper .start-container {
 
 /* Layout */
 html.wp-toolbar {
-	padding-top: 95px;
+	padding-top: 106px;
 }
 #wpcontent {
 	height: 100%;
@@ -255,25 +255,6 @@ html.wp-toolbar {
 }
 #adminmenu {
 	margin-top: 0;
-}
-.auto-fold #adminmenu {
-	top: 0;
-}
-@media screen and ( max-width: 660px ) {
-	.auto-fold #adminmenu,
-	.auto-fold #adminmenuback,
-	.auto-fold #adminmenuwrap {
-		width: 100%;
-	}
-	.auto-fold #adminmenuwrap {
-		display: block;
-		transform: translateX(-100%);
-		transition: transform 0.15s ease-in-out;
-	}
-	.auto-fold .wp-responsive-open #adminmenuwrap {
-		display: block;
-		transform: translateX(0%);
-	}
 }
 @media screen and ( min-width: 661px ) {
 	html.wp-toolbar {
@@ -346,6 +327,13 @@ li#wp-admin-bar-menu-toggle {
 	min-width: 40px;
 	padding: 0;
 	text-align: center;
+}
+@media screen and ( max-width: 660px ) {
+	.action-header .action-header__ground-control-back {
+		padding-top: 11px;
+		padding-bottom: 8px;
+		margin-left: 0;
+	}
 }
 .action-header__ground-control-back svg {
 	fill: #537994;
@@ -438,6 +426,49 @@ li#wp-admin-bar-menu-toggle {
 }
 .action-header__actions-list .button {
 	flex-basis: auto;
+}
+
+/* Sidebar header */
+.auto-fold #adminmenu {
+	top: 0;
+}
+.action-header.action-header-sidebar {
+	display: none;
+}
+.action-header.action-header-sidebar .action-header__site-title {
+	margin-top: 8px;
+	color: #2e4453;
+	font-size: 13px;
+	font-weight: 400;
+	line-height: 1.4;
+}
+.action-header.action-header-sidebar .gridicons-chevron-left {
+	display: none;
+}
+.action-header.action-header-sidebar .gridicons-cross {
+	display: block;
+}
+@media screen and ( max-width: 660px ) {
+	.auto-fold #adminmenu,
+	.auto-fold #adminmenuback,
+	.auto-fold #adminmenuwrap {
+		width: 100%;
+	}
+	.auto-fold #adminmenuwrap {
+		display: block;
+	}
+	.action-header.action-header-sidebar {
+		display: flex;
+	}
+	.auto-fold #adminmenuwrap,
+	.action-header.action-header-sidebar {
+		transform: translateX(-100%);
+		transition: transform 0.15s ease-in-out;
+	}
+	.auto-fold .wp-responsive-open #adminmenuwrap,
+	.wp-responsive-open .action-header.action-header-sidebar {
+		transform: translateX(0%);
+	}
 }
 
 /* White background behind the WooCommerce helper extensions navigation */

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -2,6 +2,16 @@
     'use strict';
 
     /**
+     * Action header mobile navigation
+     */
+    $( document ).on( 'click', '.action-header__ground-control-back', function( e ) {
+        if ( $( window ).width() < 661 ) {
+            e.preventDefault();
+            $( '#wp-admin-bar-menu-toggle .ab-item' ).click();
+        }
+    } );
+
+    /**
      * Record checklist task click
      */
     $( '.checklist__task-title a, .checklist__task-secondary a' ).click( function() {

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -4,7 +4,7 @@
     /**
      * Action header mobile navigation
      */
-    $( document ).on( 'click', '.action-header__ground-control-back', function( e ) {
+    $( document ).on( 'click', '.action-header:not(.action-header-sidebar) .action-header__ground-control-back', function( e ) {
         if ( $( window ).width() < 661 ) {
             e.preventDefault();
             $( '#wp-admin-bar-menu-toggle .ab-item' ).click();

--- a/includes/class-wc-calypso-bridge-action-header.php
+++ b/includes/class-wc-calypso-bridge-action-header.php
@@ -63,7 +63,7 @@ class WC_Calypso_Bridge_Action_Header {
 	 */
 	public function back_button() {
 		?>
-		<a class="button action-header__ground-control-back" aria-label="<?php esc_html_e( 'Close Store', 'wc-calypso-bridge' ); ?>">
+		<a class="button action-header__ground-control-back" aria-label="<?php esc_html_e( 'Close Store', 'wc-calypso-bridge' ); ?>" href="<?php echo esc_url( 'https://wordpress.com/stats/day/' . Jetpack::build_raw_urls( home_url() ) ); ?>">
 			<svg class="gridicon gridicons-cross" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M18.36 19.78L12 13.41l-6.36 6.37-1.42-1.42L10.59 12 4.22 5.64l1.42-1.42L12 10.59l6.36-6.36 1.41 1.41L13.41 12l6.36 6.36z"></path></g></svg>
 			<svg class="gridicon gridicons-chevron-left" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M14 20l-8-8 8-8 1.414 1.414L8.828 12l6.586 6.586"></path></g></svg>
 		</a>

--- a/includes/class-wc-calypso-bridge-action-header.php
+++ b/includes/class-wc-calypso-bridge-action-header.php
@@ -35,14 +35,15 @@ class WC_Calypso_Bridge_Action_Header {
 	 * Constructor
 	 */
 	private function __construct() {
-		add_action( 'wp_after_admin_bar_render', array( $this, 'render' ) );
+		add_action( 'wp_after_admin_bar_render', array( $this, 'render_action_header' ) );
+		add_action( 'in_admin_header', array( $this, 'render_sidebar_header' ) );
 		add_action( 'wp_loaded', array( $this, 'remove_calypso_sidebar_header' ) );
 	}
 
 	/**
 	 * Render action header
 	 */
-	public function render() {
+	public function render_action_header() {
 		?>
 		<div class="action-header">
 			<?php $this->back_button(); ?>
@@ -54,6 +55,23 @@ class WC_Calypso_Bridge_Action_Header {
 				</div>
 			</div>
 			<div class="action-header__actions"></div>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Render sidebar header
+	 */
+	public function render_sidebar_header() {
+		?>
+		<div class="action-header action-header-sidebar">
+			<?php $this->back_button(); ?>
+			<div class="action-header__content">
+				<?php $this->site_icon(); ?>
+				<div class="action-header__details">
+					<?php $this->site_title(); ?>
+				</div>
+			</div>
 		</div>
 		<?php
 	}

--- a/includes/class-wc-calypso-bridge-action-header.php
+++ b/includes/class-wc-calypso-bridge-action-header.php
@@ -81,7 +81,7 @@ class WC_Calypso_Bridge_Action_Header {
 	 */
 	public function back_button() {
 		?>
-		<a class="button action-header__ground-control-back" aria-label="<?php esc_html_e( 'Close Store', 'wc-calypso-bridge' ); ?>" href="<?php echo esc_url( 'https://wordpress.com/stats/day/' . Jetpack::build_raw_urls( home_url() ) ); ?>">
+		<a class="action-header__ground-control-back" aria-label="<?php esc_html_e( 'Close Store', 'wc-calypso-bridge' ); ?>" href="<?php echo esc_url( 'https://wordpress.com/stats/day/' . Jetpack::build_raw_urls( home_url() ) ); ?>">
 			<svg class="gridicon gridicons-cross" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M18.36 19.78L12 13.41l-6.36 6.37-1.42-1.42L10.59 12 4.22 5.64l1.42-1.42L12 10.59l6.36-6.36 1.41 1.41L13.41 12l6.36 6.36z"></path></g></svg>
 			<svg class="gridicon gridicons-chevron-left" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M14 20l-8-8 8-8 1.414 1.414L8.828 12l6.586 6.586"></path></g></svg>
 		</a>


### PR DESCRIPTION
Add in actions to the action-header to link to site stats on desktop and open the sidebar menu on mobile.

Fixes #169 

#### Screenshots
<img width="486" alt="screen shot 2018-11-14 at 1 25 23 pm" src="https://user-images.githubusercontent.com/10561050/48461874-d6765480-e810-11e8-9467-64b99e1d2115.png">
<img width="598" alt="screen shot 2018-11-14 at 1 25 38 pm" src="https://user-images.githubusercontent.com/10561050/48461875-d6765480-e810-11e8-878f-92803ace31cc.png">

#### Testing
1.  Open an page in the dashboard using Calypsoify
2.  Click the "x" on desktop in the action bar and confirm that this takes you to Calypso's site stats.
3.  Click the "<" on mobile in the action bar and confirm that this slides out the sidebar.
4.  Click the "x" in the sidebar's action header to confirm that you are taken to Calypso's site stats.
