### PR TITLE
Remove page titles and move page actions to action header

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1200,6 +1200,10 @@ TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10497
 }
 
 /* Fix title padding */
+.wp-admin .wrap > h1:first-child,
+.wp-admin .wrap > h2:first-child  {
+	display: none;
+}
 .wp-admin .wrap h1, .wp-admin .wrap h2 {
 	padding-left: 0;
 }

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -138,13 +138,14 @@ div.woocommerce-message, .wc-helper .start-container {
 
 /* Primary Buttons */
 .wp-core-ui .button-primary,
-.wrap .page-title-action:not(.button-secondary),
+.action-header .page-title-action,
 .wc-helper .button,
 .wc_addons_wrap .addons-button-solid {
 	background: #00aadc !important;
 	border-color: #008ab3 !important;
 	border-width: 1px 1px 2px !important;
 	border-style: solid;
+	border-radius: 4px;
 	text-shadow: none !important;
 	box-shadow: none !important;
 	padding: 7px !important;
@@ -160,8 +161,8 @@ div.woocommerce-message, .wc-helper .start-container {
 }
 .wp-core-ui .button-primary:hover,
 .wp-core-ui .button-primary:focus,
-.wrap .page-title-action:not(.button-secondary):hover,
-.wrap .page-title-action:not(.button-secondary):focus,
+.action-header .page-title-action:hover,
+.action-header .page-title-action:focus,
 .wc-helper .button:hover,
 .wc-helper .button:focus,
 .wc_addons_wrap .addons-button-solid:hover,
@@ -185,7 +186,8 @@ div.woocommerce-message, .wc-helper .start-container {
 .wc_addons_wrap .addons-button-outline-white,
 .edit-tag-actions .button-primary,
 .woocommerce-BlankState a.button,
-.setup-footer a {
+.setup-footer a,
+.action-header .page-title-action {
 	font-size: 14px !important;
 	padding: 7px 14px 9px !important;
 	line-height: 21px !important;
@@ -211,7 +213,7 @@ div.woocommerce-message, .wc-helper .start-container {
 
 /* Specific Buttons */
 .wp-core-ui .button-primary:active,
-.wrap .page-title-action:active,
+.action-header .page-title-action:active,
 .wc-helper .button:active,
 .wc_addons_wrap .addons-button-solid:active {
 	border-width: 2px 1px 1px !important;
@@ -403,8 +405,12 @@ html.wp-toolbar {
 .action-header__actions {
 	flex-grow: 1;
 	flex-shrink: 2;
-	overflow: hidden;
 	text-align: right;
+	margin-top: -3px;
+}
+.action-header__actions a {
+	margin-left: 12px;
+	text-decoration: none;
 }
 @media screen and ( min-width: 661px ) {
 	.action-header__actions {
@@ -445,12 +451,6 @@ html.wp-toolbar {
 
 .wc-helper .subscription-filter .count {
 	border: 0;
-}
-
-/* Page title actions */
-.page-title-actions {
-	float: right;
-	padding-top: 12px;
 }
 
 /* Navigation tabs */

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -75,11 +75,9 @@
     } );
 
     /**
-     * Wrap page title actions to align right
+     * Move page actions to action header
      */
-    var $pageTitleActionsContainer = $( '<div class="page-title-actions"></div>' );
-    $pageTitleActionsContainer.insertAfter( 'h1.wp-heading-inline' );
-    $( '.page-title-action' ).appendTo( $pageTitleActionsContainer );
+    $( '.page-title-action' ).appendTo( '#action-header .action-header__actions' );
 
 
     /** 

--- a/includes/class-wc-calypso-bridge-action-header.php
+++ b/includes/class-wc-calypso-bridge-action-header.php
@@ -44,7 +44,7 @@ class WC_Calypso_Bridge_Action_Header {
 	 */
 	public function render() {
 		?>
-		<div class="action-header">
+		<div class="action-header" id="action-header">
 			<?php $this->back_button(); ?>
 			<div class="action-header__content">
 				<?php $this->site_icon(); ?>


### PR DESCRIPTION
Removes the page titles since they are already added to the action header and also moves page title actions to the action bar.

Fixes #170 

#### Screenshots
<img width="423" alt="screen shot 2018-11-14 at 2 12 01 pm" src="https://user-images.githubusercontent.com/10561050/48463546-60292080-e817-11e8-9244-c0a3fb26f6e9.png">
<img width="1680" alt="screen shot 2018-11-14 at 2 12 19 pm" src="https://user-images.githubusercontent.com/10561050/48463547-60c1b700-e817-11e8-835a-31b41533efe8.png">

#### Testing
Visit various pages in the dashboard and check that:
* Page titles have been removed
* Page actions have been moved to the action header bar.
* Page actions are styled correctly

@josemarques Do we also want to try and move the "Publish" actions to the header?  If so, do we need to do anything else to that meta box?

<img width="295" alt="screen shot 2018-11-14 at 2 11 51 pm" src="https://user-images.githubusercontent.com/10561050/48463539-5c959980-e817-11e8-9d89-3057ce90a11c.png">
