### PR TITLE
Fix publishing button and action alignment

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -439,6 +439,18 @@ input[type=radio]:checked:before {
 .wc-helper .button-update .dashicons, .wc-helper .button-update:hover .dashicons {
 	height: 13px;
 }
+#publishing-action {
+	position: absolute;
+	top: 10px;
+	right: 10px;
+}
+#major-publishing-actions {
+	position: relative;
+	min-height: 40px;
+}
+#major-publishing-actions > div {
+	max-width: 130px;
+}
 
 /* Delete buttons */
 #all-plugins-table .plugins a.delete, #delete-link a.delete, #media-items a.delete, #media-items a.delete-permanently, #nav-menu-footer .menu-delete, #search-plugins-table .plugins a.delete, .plugins a.delete, .row-actions span.delete a, .row-actions span.spam a, .row-actions span.trash a, .submitbox .submitdelete {


### PR DESCRIPTION
Sets the publishing button alignment to the absolute top right of the publishing actions box.

Fixes #178 

#### Screenshots
<img width="296" alt="screen shot 2018-11-15 at 11 21 25 am" src="https://user-images.githubusercontent.com/10561050/48528153-b5713a80-e8c8-11e8-9949-774c7025361d.png">
<img width="294" alt="screen shot 2018-11-15 at 11 21 47 am" src="https://user-images.githubusercontent.com/10561050/48528154-b5713a80-e8c8-11e8-84d9-e8f433bc0845.png">

#### Testing
1.  Visit various individual post pages (products, orders, coupons, third party posts, etc.)
2.  Check that button and action alignment looks okay and no overlapping occurs.