### PR TITLE
Remove create new submenu items for all post types

### DIFF
--- a/includes/class-wc-calypso-bridge-menus.php
+++ b/includes/class-wc-calypso-bridge-menus.php
@@ -36,6 +36,7 @@ class WC_Calypso_Bridge_Menus {
 	 */
 	private function __construct() {
 		add_action( 'current_screen', array( $this, 'setup_menu_hooks' ) );
+		add_action( 'admin_menu', array( $this, 'remove_create_new_menu_items' ), 100 );
 	}
 
 	// TODO If any extensions add new pages to wp-admin's settings section, we will want to copy those over,
@@ -69,7 +70,6 @@ class WC_Calypso_Bridge_Menus {
 				unset( $menu[ $menu_key ] );
 			}
 		}
-
 	}
 
 	/**
@@ -84,6 +84,26 @@ class WC_Calypso_Bridge_Menus {
 			if ( in_array( $menu_item[2], $wc_menus, true ) ) {
 				unset( $menu[ $menu_key ] );
 			}
+		}
+	}
+
+	/**
+	 * Remove all create new pages for custom post types
+	 */
+	public function remove_create_new_menu_items() {
+		$post_types = (array) get_post_types(
+			array(
+				'show_ui'      => true,
+				'_builtin'     => false,
+				'show_in_menu' => true,
+			)
+		);
+
+		foreach ( $post_types as $post_type ) {
+			$post_type_object = get_post_type_object( $post_type );
+			$singular_name    = strtolower( $post_type_object->labels->singular_name );
+			remove_submenu_page( 'edit.php?post_type=' . $post_type, 'post-new.php?post_type=' . $singular_name );
+			remove_submenu_page( 'edit.php?post_type=' . $post_type, 'create_' . $singular_name );
 		}
 	}
 }

--- a/includes/class-wc-calypso-bridge-page-controller.php
+++ b/includes/class-wc-calypso-bridge-page-controller.php
@@ -160,13 +160,6 @@ class WC_Calypso_Bridge_Page_Controller {
 	private $pages = array();
 
 	/**
-	 * Constructor
-	 */
-	private function __construct() {
-		add_action( 'admin_menu', array( $this, 'remove_menu_items' ), 100 );
-	}
-
-	/**
 	 * We want a single instance of this class so we can accurately track registered menus and pages.
 	 */
 	public static function get_instance() {
@@ -210,12 +203,6 @@ class WC_Calypso_Bridge_Page_Controller {
 		return $this->menus;
 	}
 
-	/**
-	 * Remove unneeded menu items
-	 */
-	public function remove_menu_items() {
-		remove_submenu_page( 'edit.php?post_type=product', 'post-new.php?post_type=product' );
-	}
 }
 
 $wc_calypso_bridge_page_controller = WC_Calypso_Bridge_Page_Controller::get_instance();


### PR DESCRIPTION
This PR removes all the create/add new submenu items for post types.  

It does this by getting a list of post types and removing submenu items matching the usual patterns for these pages.  It's possible that plugins not following conventions will slip by this, but it should capture most.

Fixes #173 

#### Screenshots
<img width="281" alt="screen shot 2018-11-15 at 12 16 08 pm" src="https://user-images.githubusercontent.com/10561050/48529898-40a1fe80-e8d0-11e8-9a94-3e34e4823a27.png">

#### Testing
1.  Visit the Calypsoified dashboard.
2.  Check various plugins and look for "Add new" pages (e.g., "Create Booking").