### PR TITLE
Add table wrappers and horizontal scrolling

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -8,12 +8,29 @@ div.woocommerce-message, .wc-helper .start-container {
 }
 
 /* Tables */
-.wp-list-table__wrapper {
+.wp-list-table-wrapper {
+	position: relative;
+}
+.wp-list-table-wrapper:after {
+	content: '';
+	position: absolute;
+	top: 0;
+	right: 0;
+	width: 41px;
+	height: 100%;
+	background: linear-gradient(90deg, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.2));
+	visibility: hidden;
+}
+.wp-list-table-wrapper__inner {
 	overflow-x: auto;
 	width: 100%;
 	border: 1px solid #c8d7e1;
+	box-sizing: border-box;
 }
-.wp-list-table__wrapper table {
+.wp-list-table-wrapper.is-scrollable:after {
+	visibility: visible;
+}
+.wp-list-table-wrapper table {
 	table-layout: initial;
 	border: none;
 }

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -7,12 +7,34 @@ div.woocommerce-message, .wc-helper .start-container {
 	border-left-color: #00a0d2 !important;
 }
 
+/* Tables */
+.wp-list-table__wrapper {
+	overflow-x: auto;
+	width: 100%;
+	border: 1px solid #c8d7e1;
+}
+.wp-list-table__wrapper table {
+	table-layout: initial;
+	border: none;
+}
+.wp-list-table-wrapper__fake-inner {
+	height: 0;
+}
+
 /* Pagination */
 .tablenav {
 	height: auto;
+	display: inline-block;
+	width: 100%;
 }
-.tablenav.bottom .actions, .tablenav .tablenav-pages {
+.tablenav-pages {
 	display: none;
+}
+.tablenav.bottom {
+	display: none;
+}
+.tablenav.bottom.secondary {
+	display: inline-block;
 }
 .tablenav.bottom .wc-calypso-brdige-pagination.tablenav-pages {
 	float: none;

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -190,9 +190,9 @@
     function appendInputsToForm( e ) {
         if ( e.type === 'click' || e.which === 13 ) {
             e.preventDefault();
-            var formId = $( this ).closest( '.search-box' ).data( 'target-form-id' );
-            var $form = $( 'form[data-form-id="' + formId + '"' );
-            var $searchInput = $( this ).closest( '.search-box' ).find( 'input[type="search"]' );
+            const formId = $( this ).closest( '.search-box' ).data( 'target-form-id' );
+            const $form = $( 'form[data-form-id="' + formId + '"' );
+            const $searchInput = $( this ).closest( '.search-box' ).find( 'input[type="search"]' );
             $( '<input>' ).attr(
                 {
                     type: 'hidden',
@@ -256,5 +256,23 @@
     }
     $( window ).on( 'resize', removeAutoFold );
     $( document ).on( 'ready', removeAutoFold );
+
+    /**
+     * Table scrolling shadow
+     */
+    function checkTableScroll() {
+        const scrolledToEnd = $( this )[0].scrollWidth - $( this )[0].scrollLeft <= $( this )[0].offsetWidth;
+        if ( ! scrolledToEnd ) {
+            $( this ).parent().addClass( 'is-scrollable' )
+        } else {
+            $( this ).parent().removeClass( 'is-scrollable' );
+        }
+    }
+    $( '.wp-list-table-wrapper__inner' ).scroll( checkTableScroll );
+    $( '.wp-list-table-wrapper__inner' ).scroll();
+    $( window ).resize( function() {
+        $( '.wp-list-table-wrapper__inner' ).scroll();
+    } );
+
 
 } )( jQuery );

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -96,6 +96,7 @@ class WC_Calypso_Bridge {
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-pagination.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-taxonomies.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-action-header.php';
+			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-tables.php';
 			include_once dirname( __FILE__ ) . '/includes/gutenberg.php';
 			include_once dirname( __FILE__ ) . '/vendor/automattic/gridicons/php/gridicons.php';
 		}

--- a/includes/class-wc-calypso-bridge-pagination.php
+++ b/includes/class-wc-calypso-bridge-pagination.php
@@ -50,7 +50,7 @@ class WC_Calypso_Bridge_Pagination {
 	 */
 	private function __construct() {
 		add_action( 'wp', array( $this, 'set_page_vars' ) );
-		add_action( 'manage_posts_extra_tablenav', array( $this, 'render_pagination' ) );
+		add_action( 'manage_posts_extra_tablenav', array( $this, 'render_pagination' ), PHP_INT_MAX - 1 );
 	}
 
 

--- a/includes/class-wc-calypso-bridge-tables.php
+++ b/includes/class-wc-calypso-bridge-tables.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Adds a wrapper to tables to allow scrolling long tables
+ *
+ * @package WC_Calypso_Bridge/Classes
+ * @since   1.0.0
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC Calypso Bridge Tables
+ */
+class WC_Calypso_Bridge_Tables {
+
+	/**
+	 * Class instance.
+	 *
+	 * @var WC_Calypso_Bridge_Tables instance
+	 */
+	protected static $instance = false;
+
+	/**
+	 * Get class instance
+	 */
+	public static function get_instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor
+	 */
+	private function __construct() {
+		add_action( 'manage_posts_extra_tablenav', array( $this, 'wrap_before_table' ), PHP_INT_MAX );
+		add_action( 'manage_posts_extra_tablenav', array( $this, 'wrap_after_table' ), 0 );
+	}
+
+	/**
+	 * Open the wrapper and create a fake div that's closed by the previous tablenav top
+	 *
+	 * @param string $which Top or bottom.
+	 */
+	public function wrap_before_table( $which ) {
+		if ( 'top' === $which ) {
+			echo '</div><div class="wp-list-table__wrapper"><div class="wp-list-table-wrapper__fake-inner">';
+		}
+	}
+
+	/**
+	 * Close the wrapper and reopen the bottom tablenav
+	 *
+	 * @param string $which Top or bottom.
+	 */
+	public function wrap_after_table( $which ) {
+		if ( 'bottom' === $which ) {
+			echo '</div></div><div class="tablenav bottom secondary">';
+		}
+	}
+
+}
+$wc_calypso_bridge_table = WC_Calypso_Bridge_Tables::get_instance();

--- a/includes/class-wc-calypso-bridge-tables.php
+++ b/includes/class-wc-calypso-bridge-tables.php
@@ -46,7 +46,7 @@ class WC_Calypso_Bridge_Tables {
 	 */
 	public function wrap_before_table( $which ) {
 		if ( 'top' === $which ) {
-			echo '</div><div class="wp-list-table__wrapper"><div class="wp-list-table-wrapper__fake-inner">';
+			echo '</div><div class="wp-list-table-wrapper"><div class="wp-list-table-wrapper__inner"><div class="wp-list-table-wrapper__fake-inner">';
 		}
 	}
 
@@ -57,7 +57,7 @@ class WC_Calypso_Bridge_Tables {
 	 */
 	public function wrap_after_table( $which ) {
 		if ( 'bottom' === $which ) {
-			echo '</div></div><div class="tablenav bottom secondary">';
+			echo '</div></div></div><div class="tablenav bottom secondary">';
 		}
 	}
 


### PR DESCRIPTION
Adds in a table wrapper and horizontal scrolling for tables with many columns added by third party plugins.

Fixes #152 

#### Screenshots
<img width="694" alt="screen shot 2018-11-15 at 5 54 43 pm" src="https://user-images.githubusercontent.com/10561050/48544918-aeb1ea00-e8ff-11e8-90b1-195b34a2d081.png">
<img width="715" alt="screen shot 2018-11-15 at 5 54 52 pm" src="https://user-images.githubusercontent.com/10561050/48544919-aeb1ea00-e8ff-11e8-99bb-8a3b0a52fe55.png">

#### Testing
1.  Visit any page with a WP_List_Table (products, orders, etc).
2.  Add extra columns via plugins that utilize them (e.g., WC vendors) or resize screen to make table scrollable.
3.  Check that table is scrollable and that shadow is added if scrollable and removed when scrolled to the end.

@josemarques I added a shadow to the table if it's scrollable which I thought was a great idea by @LevinMedia that we used in WC admin.  Let me know if this looks okay to you or if we need to remove/modify to match Calypso.