### PR TITLE
Update loading order so our updates only apply on WC pages

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -69,32 +69,35 @@ class WC_Calypso_Bridge {
 	public function possibly_load_calypsoify() {
 		add_action( 'admin_init', array( $this, 'track_calypsoify_toggle' ) );
 		if ( 1 === (int) get_user_meta( get_current_user_id(), 'calypsoify', true ) ) {
-			$this->includes();
-			// Hook on `admin_print_styles`, after some WC CSS is hooked, so we can override a few '!important' styles.
-			add_action( 'admin_print_styles', array( $this, 'enqueue_calypsoify_scripts' ), 11 );
+
+			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-setup.php';
+			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-admin-setup-checklist.php';
+			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-page-controller.php';
+			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-menus.php';
+			$connect_files = glob( dirname( __FILE__ ) . '/includes/connect/*.php' );
+			foreach ( $connect_files as $connect_file ) {
+				include_once $connect_file;
+			}
+
 			add_action( 'admin_init', array( $this, 'remove_woocommerce_footer_text' ) );
+			add_action( 'current_screen', array( $this, 'load_ui_elements' ) );
 		}
 	}
 
 	/**
-	 * Loads required functionality, classes, and API endpoints.
+	 * Updates required UI elements for calypso bridge pages only.
 	 */
-	private function includes() {
-		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-page-controller.php';
-		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-menus.php';
-		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-setup.php';
-		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-admin-setup-checklist.php';
-		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-breadcrumbs.php';
-		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-hide-alerts.php';
-		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-pagination.php';
-		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-taxonomies.php';
-		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-action-header.php';
-		include_once dirname( __FILE__ ) . '/includes/gutenberg.php';
-		include_once dirname( __FILE__ ) . '/vendor/automattic/gridicons/php/gridicons.php';
+	public function load_ui_elements() {
+		if ( is_wc_calypso_bridge_page() || ( isset( $_GET['page'] ) && 'wc-setup' === $_GET['page'] ) ) {
+			add_action( 'admin_print_styles', array( $this, 'enqueue_calypsoify_scripts' ), 11 );
 
-		$connect_files = glob( dirname( __FILE__ ) . '/includes/connect/*.php' );
-		foreach ( $connect_files as $connect_file ) {
-			include_once $connect_file;
+			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-breadcrumbs.php';
+			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-hide-alerts.php';
+			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-pagination.php';
+			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-taxonomies.php';
+			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-action-header.php';
+			include_once dirname( __FILE__ ) . '/includes/gutenberg.php';
+			include_once dirname( __FILE__ ) . '/vendor/automattic/gridicons/php/gridicons.php';
 		}
 	}
 

--- a/includes/class-wc-calypso-bridge-action-header.php
+++ b/includes/class-wc-calypso-bridge-action-header.php
@@ -129,6 +129,7 @@ class WC_Calypso_Bridge_Action_Header {
 		$crumbs      = array( array( 'name' => get_admin_page_title() ) );
 		$page_parent = get_admin_page_parent();
 
+		$parent = false;
 		foreach ( $menu as $top_level_menu_item ) {
 			if ( $top_level_menu_item[2] === $page_parent && $crumbs[0]['name'] !== $top_level_menu_item[0] ) {
 				$parent = $top_level_menu_item;

--- a/includes/class-wc-calypso-bridge-menus.php
+++ b/includes/class-wc-calypso-bridge-menus.php
@@ -46,8 +46,6 @@ class WC_Calypso_Bridge_Menus {
 	 * Hooks into WordPress to overtake the menu system on WooCommerce pages.
 	 */
 	public function setup_menu_hooks() {
-		// We want the menu handler hooks to run late, so that other plugins hooking in here can make changes first.
-		$late_priority = 1000;
 		if ( is_wc_calypso_bridge_page() ) {
 			remove_action( 'in_admin_header', array( Jetpack_Calypsoify::getInstance(), 'insert_sidebar_html' ) );
 


### PR DESCRIPTION
Right now, with the way files and scripts are loaded, we are applying the action bar, form styles, etc to all plugin pages and not just WooCommerce pages.

These updates also only happen on eCommerce plan sites, so normal business members will have a slightly different plugin management UI which could be confusing.

I propose, for this initial launch, only implementing our UI changes on WC pages. This PR pulls out some includes to always load (setup, checklist, page controller) and others (action bar, scripts, etc) to only load on WooCommerce pages.

Long term, I think a number of our improvements should be brought over into main Calypsoify for all sites (like the form styles, notice styles, etc @joshuatf has been working on) -- but they should be pulled out into Jetpack and tested with other plugins.

Before:

<img width="1229" alt="screen shot 2018-11-15 at 10 30 55 am" src="https://user-images.githubusercontent.com/689165/48564766-0b43e380-e8c5-11e8-84f4-9c7e83670f8d.png">

After:

<img width="562" alt="screen shot 2018-11-15 at 10 37 32 am" src="https://user-images.githubusercontent.com/689165/48564781-1139c480-e8c5-11e8-9b15-4277e235c533.png">

To Test:
* Before applying this branch, note that the plugin screen has the action bar, etc.
* Apply this branch and verify the plugin screen matches the normal Calypsoified plugin screen.
* Spot check some of the WC updates, like action bar updates, and the setup wizard.
