### PR TITLE
Update version to 1.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "automattic/wc-calypso-bridge",
-	"version": "v1.0.0",
+	"version": "v1.0.1",
 	"autoload": {
 		"files": [
 			"wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 1.0.0
+Stable tag: 1.0.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ This section describes how to install the plugin and get it working.
 1. Activate the plugin through the 'Plugins' screen in WordPress
 
 == Changelog ==
+
+= 1.0.1 =
+* Calypsoify + WooCommerce: UI and CSS updates to make WooCommerce match Calypso.
 
 = 1.0.0 =
 * Renames `product/reviews` to `product/calypso-reviews` now that there is a core endpoint with the same name. There are differences between the two, so it needs to stick around until Calypso has been updated.

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -30,7 +30,7 @@ if ( file_exists( WP_PLUGIN_DIR . '/wc-calypso-bridge/wc-calypso-bridge.php' ) )
 	}
 }
 
-define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.0.0' );
+define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.0.1' );
 define( 'WC_MIN_VERSION', '3.0.0' );
 
 /**


### PR DESCRIPTION
This PR bumps the Calypso Bridge version to `1.0.1` in preparation of a wpcomsh release.

I kept the change-log simple since there are lots of smaller changes that are just fixing the UI.
