### PR TITLE
Fix site logo size and alt text

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -635,6 +635,12 @@ li#wp-admin-bar-menu-toggle {
 	margin-right: 8px;
 	text-align: center;
 }
+
+.action-header__content .site-icon img {
+	height: 32px;
+	width: 32px;
+}
+
 .action-header__content .site-icon svg {
 	fill: #fff;
 }

--- a/includes/class-wc-calypso-bridge-action-header.php
+++ b/includes/class-wc-calypso-bridge-action-header.php
@@ -99,7 +99,7 @@ class WC_Calypso_Bridge_Action_Header {
 		<a href="<?php echo esc_url( $site_url ); ?>" aria-label="<?php echo esc_html( $site_name ); ?>">
 			<div class="site-icon <?php echo $site_icon ? '' : 'is-blank'; ?>">
 				<?php if ( $site_icon ) { ?>
-					<img src="<?php echo esc_url( $site_icon ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?>">
+					<img src="<?php echo esc_url( $site_icon ); ?>" alt="" />
 				<?php } else { ?>
 					<svg class="gridicon gridicons-globe" height="25" width="25" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm0 18l2-2 1-1v-2h-2v-1l-1-1H9v3l2 2v1.93c-3.94-.494-7-3.858-7-7.93l1 1h2v-2h2l3-3V6h-2L9 5v-.41C9.927 4.21 10.94 4 12 4s2.073.212 3 .59V6l-1 1v2l1 1 3.13-3.13c.752.897 1.304 1.964 1.606 3.13H18l-2 2v2l1 1h2l.286.286C18.03 18.06 15.24 20 12 20z"></path></g></svg>
 				<?php } ?>


### PR DESCRIPTION
This PR constrains the site logo to a smaller size. It also makes the alt text blank, since we already have the site title nearby.

Before:

![test](https://user-images.githubusercontent.com/689165/48576095-a480f300-e8e1-11e8-86cc-3a354ea5ade9.png)

After:

<img width="449" alt="screen shot 2018-11-15 at 2 21 17 pm" src="https://user-images.githubusercontent.com/689165/48576150-c11d2b00-e8e1-11e8-8412-cc00f79351e3.png">


