### PR TITLE
Adds Theme defaults

### DIFF
--- a/class-wc-calypso-bridge-frontend.php
+++ b/class-wc-calypso-bridge-frontend.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Frontend functions for Calypso Bridge
+ * 
+ * Mostly related to the Customizer, Storefront, and its extensions
+ *
+ * @package WC_Calypso_Bridge_Frontend/Classes
+ * @since   1.0.0
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC Calypso Bridge Frontend
+ */
+class WC_Calypso_Bridge_Frontend {
+	/**
+	 * Paths to assets act oddly in production
+	 */
+	const MU_PLUGIN_ASSET_PATH = '/wp-content/mu-plugins/wpcomsh/vendor/automattic/wc-calypso-bridge/';
+
+	/**
+	 * Plugin asset path
+	 *
+	 * @var string
+	 */
+	public static $plugin_asset_path = null;
+
+	/**
+	 * Class Instance.
+	 *
+	 * @var WC_Calypso_Bridge_Frontend instance
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'init', array( $this, 'remove_storefront_default_footer_credit' ), 10 );	
+    }
+    
+    /**
+	 * Unhooks Storefront footer credit
+	 *
+	 */
+	public function remove_storefront_default_footer_credit() {
+		remove_action( 'storefront_footer', 'storefront_credit', 20 );
+		add_action( 'storefront_footer', array( $this, 'wpcom_ecommerce_plan_storefront_credit' ), 20 );
+	}
+
+	/**
+	 * Display the new WordPress.com like theme credit
+	 *
+	 * @since  1.0.0
+	 * @return void
+	 */
+	public function wpcom_ecommerce_plan_storefront_credit() {
+		?>
+		<div class="site-info">
+			<?php echo esc_html( apply_filters( 'storefront_copyright_text', '&copy; ' . get_bloginfo( 'name' ) . ' ' . date( 'Y' ) ) ); ?>
+			<?php if ( apply_filters( 'storefront_credit_link', true ) ) { ?>
+			<br />
+				<?php
+				if ( apply_filters( 'storefront_privacy_policy_link', true ) && function_exists( 'the_privacy_policy_link' ) ) {
+					the_privacy_policy_link( '', '<span role="separator" aria-hidden="true"></span>' );
+				}
+				?>
+				<?php echo '<a href="https://wordpress.com/?ref=footer_website" target="_blank" title="' . esc_attr__( 'WordPress.com - The Best eCommerce Platform for WordPress', 'wc-calypso-bridge' ) . '" rel="author">' . esc_html__( 'Built with Storefront &amp; WordPress.com', 'wc-calypso-bridge' ) . '</a>.'; ?>
+			<?php } ?>
+		</div><!-- .site-info -->
+		<?php
+	}
+
+	/**
+	 * Class instance.
+	 */
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			// If this is a traditionally installed plugin, set plugin_url for the proper asset path.
+			if ( file_exists( WP_PLUGIN_DIR . '/wc-calypso-bridge/wc-calypso-bridge.php' ) ) {
+				if ( WP_PLUGIN_DIR . '/wc-calypso-bridge/' == plugin_dir_path( __FILE__ ) ) {
+					self::$plugin_asset_path = plugin_dir_url( __FILE__ );
+				}
+			}
+
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+
+
+}
+
+WC_Calypso_Bridge_Frontend::instance();

--- a/class-wc-calypso-bridge-frontend.php
+++ b/class-wc-calypso-bridge-frontend.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Frontend functions for Calypso Bridge
- * 
+ *
  * Mostly related to the Customizer, Storefront, and its extensions
  *
  * @package WC_Calypso_Bridge_Frontend/Classes
@@ -38,12 +38,11 @@ class WC_Calypso_Bridge_Frontend {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( 'init', array( $this, 'remove_storefront_default_footer_credit' ), 10 );	
-    }
-    
-    /**
+		add_action( 'init', array( $this, 'remove_storefront_default_footer_credit' ), 10 );
+	}
+
+	/**
 	 * Unhooks Storefront footer credit
-	 *
 	 */
 	public function remove_storefront_default_footer_credit() {
 		remove_action( 'storefront_footer', 'storefront_credit', 20 );
@@ -76,7 +75,7 @@ class WC_Calypso_Bridge_Frontend {
 	/**
 	 * Class instance.
 	 */
-	public static function instance() {
+	public static function get_instance() {
 		if ( is_null( self::$instance ) ) {
 			// If this is a traditionally installed plugin, set plugin_url for the proper asset path.
 			if ( file_exists( WP_PLUGIN_DIR . '/wc-calypso-bridge/wc-calypso-bridge.php' ) ) {
@@ -95,4 +94,4 @@ class WC_Calypso_Bridge_Frontend {
 
 }
 
-WC_Calypso_Bridge_Frontend::instance();
+WC_Calypso_Bridge_Frontend::get_instance();

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -39,6 +39,49 @@ class WC_Calypso_Bridge {
 		add_action( 'init', array( $this, 'check_calyposify_param' ), 1 );
 		add_action( 'init', array( $this, 'check_setup_param' ) );
 		add_action( 'init', array( $this, 'possibly_load_calypsoify' ), 2 );
+		if ( class_exists( 'Storefront_Powerpack' ) ) {
+			$this->disable_powerpack_features();
+		}	
+	}
+	
+	/**
+	 * 
+	 * Disables Specific Features within the Powerpack extension for Storefront.
+	 * 
+	 */
+	public function disable_powerpack_features() {
+		/**
+         * List of Powerpack features able to disable
+         * 
+         * 'storefront_powerpack_helpers_enabled'
+         * 'storefront_powerpack_admin_enabled'
+         * 'storefront_powerpack_frontend_enabled'
+         * 'storefront_powerpack_customizer_enabled'
+         * 'storefront_powerpack_header_enabled'
+         * 'storefront_powerpack_footer_enabled'
+         * 'storefront_powerpack_designer_enabled'
+         * 'storefront_powerpack_layout_enabled'
+         * 'storefront_powerpack_integrations_enabled'
+         * 'storefront_powerpack_mega_menus_enabled'
+         * 'storefront_powerpack_parallax_hero_enabled'
+         * 'storefront_powerpack_checkout_enabled'
+         * 'storefront_powerpack_homepage_enabled'
+         * 'storefront_powerpack_messages_enabled'
+         * 'storefront_powerpack_product_details_enabled'
+         * 'storefront_powerpack_shop_enabled'
+         * 'storefront_powerpack_pricing_tables_enabled'
+         * 'storefront_powerpack_reviews_enabled'
+         * 'storefront_powerpack_product_hero_enabled'
+         * 'storefront_powerpack_blog_customizer_enabled'
+         * 
+         */
+        $disabled_powerpack_features = array(	'storefront_powerpack_designer_enabled',
+                                                'storefront_powerpack_mega_menus_enabled',
+                                                'storefront_powerpack_pricing_tables_enabled',
+                                            );
+        foreach ( $disabled_powerpack_features as $feature_filter_name ) {
+            add_filter( $feature_filter_name, '__return_false' );
+        }
 	}
 
 	/**

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -72,6 +72,7 @@ class WC_Calypso_Bridge {
 
 			include_once( dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-helper-functions.php' );
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-setup.php';
+			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-themes-setup.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-admin-setup-checklist.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-page-controller.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-menus.php';

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -41,47 +41,46 @@ class WC_Calypso_Bridge {
 		add_action( 'init', array( $this, 'possibly_load_calypsoify' ), 2 );
 		if ( class_exists( 'Storefront_Powerpack' ) ) {
 			$this->disable_powerpack_features();
-		}	
+		}
 	}
-	
+
 	/**
-	 * 
 	 * Disables Specific Features within the Powerpack extension for Storefront.
-	 * 
 	 */
 	public function disable_powerpack_features() {
 		/**
-         * List of Powerpack features able to disable
-         * 
-         * 'storefront_powerpack_helpers_enabled'
-         * 'storefront_powerpack_admin_enabled'
-         * 'storefront_powerpack_frontend_enabled'
-         * 'storefront_powerpack_customizer_enabled'
-         * 'storefront_powerpack_header_enabled'
-         * 'storefront_powerpack_footer_enabled'
-         * 'storefront_powerpack_designer_enabled'
-         * 'storefront_powerpack_layout_enabled'
-         * 'storefront_powerpack_integrations_enabled'
-         * 'storefront_powerpack_mega_menus_enabled'
-         * 'storefront_powerpack_parallax_hero_enabled'
-         * 'storefront_powerpack_checkout_enabled'
-         * 'storefront_powerpack_homepage_enabled'
-         * 'storefront_powerpack_messages_enabled'
-         * 'storefront_powerpack_product_details_enabled'
-         * 'storefront_powerpack_shop_enabled'
-         * 'storefront_powerpack_pricing_tables_enabled'
-         * 'storefront_powerpack_reviews_enabled'
-         * 'storefront_powerpack_product_hero_enabled'
-         * 'storefront_powerpack_blog_customizer_enabled'
-         * 
-         */
-        $disabled_powerpack_features = array(	'storefront_powerpack_designer_enabled',
-                                                'storefront_powerpack_mega_menus_enabled',
-                                                'storefront_powerpack_pricing_tables_enabled',
-                                            );
-        foreach ( $disabled_powerpack_features as $feature_filter_name ) {
-            add_filter( $feature_filter_name, '__return_false' );
-        }
+		 * List of Powerpack features able to disable
+		 *
+		 * 'storefront_powerpack_helpers_enabled'
+		 * 'storefront_powerpack_admin_enabled'
+		 * 'storefront_powerpack_frontend_enabled'
+		 * 'storefront_powerpack_customizer_enabled'
+		 * 'storefront_powerpack_header_enabled'
+		 * 'storefront_powerpack_footer_enabled'
+		 * 'storefront_powerpack_designer_enabled'
+		 * 'storefront_powerpack_layout_enabled'
+		 * 'storefront_powerpack_integrations_enabled'
+		 * 'storefront_powerpack_mega_menus_enabled'
+		 * 'storefront_powerpack_parallax_hero_enabled'
+		 * 'storefront_powerpack_checkout_enabled'
+		 * 'storefront_powerpack_homepage_enabled'
+		 * 'storefront_powerpack_messages_enabled'
+		 * 'storefront_powerpack_product_details_enabled'
+		 * 'storefront_powerpack_shop_enabled'
+		 * 'storefront_powerpack_pricing_tables_enabled'
+		 * 'storefront_powerpack_reviews_enabled'
+		 * 'storefront_powerpack_product_hero_enabled'
+		 * 'storefront_powerpack_blog_customizer_enabled'
+		 */
+		$disabled_powerpack_features = array(
+			'storefront_powerpack_designer_enabled',
+			'storefront_powerpack_mega_menus_enabled',
+			'storefront_powerpack_pricing_tables_enabled',
+		);
+
+		foreach ( $disabled_powerpack_features as $feature_filter_name ) {
+			add_filter( $feature_filter_name, '__return_false' );
+		}
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-admin-setup-checklist.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-checklist.php
@@ -255,6 +255,13 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 		$wc_canada_post_merchant_username = get_option( 'wc_canada_post_merchant_username' );
 		$wc_canada_post_merchant_password = get_option( 'wc_canada_post_merchant_password' );
 
+		$count_wc_product_posts = wp_count_posts( 'product' );
+		$wc_published_products_count = $count_wc_product_posts->publish;
+		$customize_extra_params = '';
+		if ( 0 === absint( $wc_published_products_count ) ) {
+			$customize_extra_params = esc_attr( '&sf_starter_content=1&sf_tasks=homepage,products&action=storefront_starter_content' );
+		}
+
 		$all_tasks = array(
 			array(
 				'id'              => 'add-product',
@@ -272,7 +279,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 				'completed_title' => __( 'Open customizer', 'wc-calypso-bridge' ),
 				'description'     => __( 'You have access to a few themes with your plan. See the options, chose the right one for you and customize your store.', 'wc-calypso-bridge' ),
 				'estimate'        => '2',
-				'link'            => 'customize.php?return=%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-setup-checklist&wc-setup-step=customize',
+				'link'            => 'customize.php?return=%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-setup-checklist&wc-setup-step=customize' . $customize_extra_params,
 				'condition'       => isset( $click_settings['customize'] ) && true === (bool) $click_settings['customize'],
 			),
 

--- a/includes/class-wc-calypso-bridge-themes-setup.php
+++ b/includes/class-wc-calypso-bridge-themes-setup.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Adds the functionality needed to streamline the themes experience for Storefront and suppressing WC admin notices
+ *
+ * @package WC_Calypso_Bridge/Classes
+ * @since   1.0.0
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC Calypso Bridge Themes Setup
+ */
+class WC_Calypso_Bridge_Themes_Setup {
+
+	/**
+	 * Class instance.
+	 *
+	 * @var WC_Calypso_Bridge_Themes_Setup instance
+	 */
+	protected static $instance = false;
+
+	/**
+	 * Get class instance
+	 */
+	public static function get_instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	private function __construct() {
+        $this->includes();
+
+        // Suppress WC Admin Notices
+		add_action( 'admin_head', array( $this, 'suppress_admin_notices' ) );
+        add_filter( 'woocommerce_helper_suppress_connect_notice', '__return_true' ); 
+        
+	}
+
+    /**
+	 * Loads required functionality, classes, and API endpoints.
+	 */
+	private function includes() {
+		include_once( dirname( __FILE__ ) . '/class-wc-calypso-bridge-helper-functions.php' );
+    }
+    
+	/**
+	 * Suppresses admin notifications in wp-admin
+	 *
+	 * @return void
+	 */
+	public function suppress_admin_notices() {
+		/**
+		 * List of extension specific and themes class level functions to suppress
+		 * 'CLASS_NAME' => array( 'FUNCTION_PRIORITY' => 'FUNCTION_NAME' )
+		 */ 
+		$extension_admin_notices_to_suppress = array(	'WC_Shipping_Australia_Post_Init' 	=> array( '10' => 'environment_check' ),
+														'WC_Facebookcommerce_Integration' 	=> array( '10' => 'checks' ),	
+														'WC_USPS' 							=> array( '10' => 'environment_check' ),
+														'SP_Admin' 							=> array( '10' => 'activation_notice' ),
+														'Woocommerce_Square' 				=> array( '10' => 'is_connected_to_square' ),
+														'WC_Taxjar' 						=> array( '10' => 'maybe_display_admin_notices' ),
+														'WC_Klarna_Payments' 				=> array( '10' => 'order_management_check' ),
+														'Klarna_Checkout_For_WooCommerce' 	=> array( '10' => 'order_management_check' ),
+														'WC_Gateway_PayFast'				=> array( '10' => 'admin_notices' ),
+														'WC_Connect_Nux'					=> array( '9' => 'show_banner_before_connection' ),
+                                                        'Storefront_NUX_Admin' 				=> array( '99' => 'admin_notices' ),
+                                                        'WC_Gateway_PPEC_Plugin'            => array( '10' => 'show_bootstrap_warning' ),
+                                                        'WC_RoyalMail'                      => array( '10' => 'environment_check' )
+                                                );
+		foreach ( $extension_admin_notices_to_suppress as $class_name => $function_to_suppress ) {
+			WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', $class_name, current( $function_to_suppress ), key( $function_to_suppress ) );
+        }
+        // Canada Post Specific - refactor after launch to be included in the above loop
+        WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', 'WC_Shipping_Canada_Post_Init', 'connect_canada_post', 10 );
+        WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', 'WC_Shipping_Canada_Post_Init', 'environment_check', 10 );
+        // Square Specific - refactor after launch to be included in the above loop
+        WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', 'Woocommerce_Square', 'check_environment', 10 );
+        WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', 'Woocommerce_Square', 'is_connected_to_square', 10 );        
+		// List of extensions that do not use class level functions for admin notices.
+		$other_admin_notices = array( 'woocommerce_gateway_paypal_express_upgrade_notice', 'woocommerce_gateway_klarna_welcome_notice' );
+		foreach ( $other_admin_notices as $function_to_suppress ) {
+			remove_action( 'admin_notices', $function_to_suppress );
+		}
+        // Suppress: Looking for the store notice setting? It can now be found in the Customizer.
+        $user_id = get_current_user_id();
+        $user_meta_key = 'dismissed_store_notice_setting_moved_notice';
+        $current_user_meta_value = get_user_meta( $user_id, $user_meta_key, true);
+        if ( ! $current_user_meta_value ) {
+            $updated_user_meta_value = update_user_meta( $user_id, $user_meta_key, true );    
+        }
+		// Suppress: Product Add Ons Activation Notice
+		$deleted = delete_option( 'wpa_activation_notice' );
+        // Suppress all other WC Admin Notices not specified above
+        WC_Admin_Notices::remove_notice( 'wootenberg' );
+		WC_Admin_Notices::remove_all_notices();
+    }
+
+}
+
+$wc_calypso_bridge_themes_setup = WC_Calypso_Bridge_Themes_Setup::get_instance();

--- a/includes/class-wc-calypso-bridge-themes-setup.php
+++ b/includes/class-wc-calypso-bridge-themes-setup.php
@@ -40,7 +40,8 @@ class WC_Calypso_Bridge_Themes_Setup {
         // Suppress WC Admin Notices
 		add_action( 'admin_head', array( $this, 'suppress_admin_notices' ) );
         add_filter( 'woocommerce_helper_suppress_connect_notice', '__return_true' ); 
-        
+        // Set default theme values
+        add_action( 'init', array( $this, 'set_theme_default_values' ) );
 	}
 
     /**
@@ -100,8 +101,41 @@ class WC_Calypso_Bridge_Themes_Setup {
         // Suppress all other WC Admin Notices not specified above
         WC_Admin_Notices::remove_notice( 'wootenberg' );
 		WC_Admin_Notices::remove_all_notices();
+	}
+	
+	/**
+	 * Test if defaults are set.
+	 *
+	 * @return void
+	 */
+	public function check_if_defaults_already_setup() {
+        $wpcom_ec_plan_theme_defaults = get_option( 'wpcom_ec_plan_theme_defaults', false );
+        return $wpcom_ec_plan_theme_defaults;
     }
 
+	public function set_theme_default_values() {
+        // Should either be on theme activation or set to have been saved
+        if ( ! $this->check_if_defaults_already_setup() ) {
+            set_theme_mod( 'sp_product_layout', 'full-width' ); // enables Full width single product page.
+            set_theme_mod( 'sp_shop_layout', 'full-width' ); // enables Full width shop archive pages.
+            set_theme_mod( 'sph_hero_enable', 'enable' ); // enables Parallax Hero on homepage.
+            set_theme_mod( 'sph_hero_heading_text', esc_attr__( 'Welcome', 'wc-calypso-bridge' ) ); // Heading Text for Parallax Hero.
+            set_theme_mod( 'sph_hero_text', sprintf( esc_attr__( 'This is your homepage which is what most visitors will see when they first visit your shop.%sYou can change this text by editing the "Parallax Hero" Section via the "Powerpack" settings in the Customizer on the left hand side of your screen.', 'wc-calypso-bridge' ), PHP_EOL . PHP_EOL ) ); // Content for Parallax Hero.
+            if ( 0 < wc_get_page_id( 'shop' ) ) {
+                set_theme_mod( 'sph_hero_button_url', get_permalink( wc_get_page_id( 'shop' ) ) ); // Set button url to the shop page instead of home if the shop page exists.
+            }
+            set_theme_mod( 'sp_homepage_content', false ); // Removes default Welcome banner from starter content.
+            set_theme_mod( 'sp_homepage_top_rated', false ); // Removes Top Rated Products area from starter content.
+            set_theme_mod( 'sp_homepage_on_sale', false ); // Removes On Sale Products area from starter content.
+            set_theme_mod( 'sp_homepage_best_sellers', false ); // Removes Best Sellers Products area from starter content.
+            update_option( 'woocommerce_demo_store', 'yes' ); // enables demo store notice.
+			// Force Fresh Site
+			update_option( 'fresh_site', true );
+            // Save option that says the setup has been run already.
+            update_option( 'wpcom_ec_plan_theme_defaults', true );
+        }
+	}
+	
 }
 
 $wc_calypso_bridge_themes_setup = WC_Calypso_Bridge_Themes_Setup::get_instance();

--- a/includes/class-wc-calypso-bridge-themes-setup.php
+++ b/includes/class-wc-calypso-bridge-themes-setup.php
@@ -35,22 +35,22 @@ class WC_Calypso_Bridge_Themes_Setup {
 	 * Constructor.
 	 */
 	private function __construct() {
-        $this->includes();
+		$this->includes();
 
-        // Suppress WC Admin Notices
+		// Suppress WC Admin Notices.
 		add_action( 'admin_head', array( $this, 'suppress_admin_notices' ) );
-        add_filter( 'woocommerce_helper_suppress_connect_notice', '__return_true' ); 
-        // Set default theme values
-        add_action( 'init', array( $this, 'set_theme_default_values' ) );
+		add_filter( 'woocommerce_helper_suppress_connect_notice', '__return_true' );
+		// Set default theme values.
+		add_action( 'init', array( $this, 'set_theme_default_values' ) );
 	}
 
-    /**
+	/**
 	 * Loads required functionality, classes, and API endpoints.
 	 */
 	private function includes() {
-		include_once( dirname( __FILE__ ) . '/class-wc-calypso-bridge-helper-functions.php' );
-    }
-    
+		include_once dirname( __FILE__ ) . '/class-wc-calypso-bridge-helper-functions.php';
+	}
+
 	/**
 	 * Suppresses admin notifications in wp-admin
 	 *
@@ -60,82 +60,88 @@ class WC_Calypso_Bridge_Themes_Setup {
 		/**
 		 * List of extension specific and themes class level functions to suppress
 		 * 'CLASS_NAME' => array( 'FUNCTION_PRIORITY' => 'FUNCTION_NAME' )
-		 */ 
-		$extension_admin_notices_to_suppress = array(	'WC_Shipping_Australia_Post_Init' 	=> array( '10' => 'environment_check' ),
-														'WC_Facebookcommerce_Integration' 	=> array( '10' => 'checks' ),	
-														'WC_USPS' 							=> array( '10' => 'environment_check' ),
-														'SP_Admin' 							=> array( '10' => 'activation_notice' ),
-														'Woocommerce_Square' 				=> array( '10' => 'is_connected_to_square' ),
-														'WC_Taxjar' 						=> array( '10' => 'maybe_display_admin_notices' ),
-														'WC_Klarna_Payments' 				=> array( '10' => 'order_management_check' ),
-														'Klarna_Checkout_For_WooCommerce' 	=> array( '10' => 'order_management_check' ),
-														'WC_Gateway_PayFast'				=> array( '10' => 'admin_notices' ),
-														'WC_Connect_Nux'					=> array( '9' => 'show_banner_before_connection' ),
-                                                        'Storefront_NUX_Admin' 				=> array( '99' => 'admin_notices' ),
-                                                        'WC_Gateway_PPEC_Plugin'            => array( '10' => 'show_bootstrap_warning' ),
-                                                        'WC_RoyalMail'                      => array( '10' => 'environment_check' )
-                                                );
+		 */
+		$extension_admin_notices_to_suppress = array(
+			'WC_Shipping_Australia_Post_Init' => array( '10' => 'environment_check' ),
+			'WC_Facebookcommerce_Integration' => array( '10' => 'checks' ),
+			'WC_USPS'                         => array( '10' => 'environment_check' ),
+			'SP_Admin'                        => array( '10' => 'activation_notice' ),
+			'Woocommerce_Square'              => array( '10' => 'is_connected_to_square' ),
+			'WC_Taxjar'                       => array( '10' => 'maybe_display_admin_notices' ),
+			'WC_Klarna_Payments'              => array( '10' => 'order_management_check' ),
+			'Klarna_Checkout_For_WooCommerce' => array( '10' => 'order_management_check' ),
+			'WC_Gateway_PayFast'              => array( '10' => 'admin_notices' ),
+			'WC_Connect_Nux'                  => array( '9' => 'show_banner_before_connection' ),
+			'Storefront_NUX_Admin'            => array( '99' => 'admin_notices' ),
+			'WC_Gateway_PPEC_Plugin'          => array( '10' => 'show_bootstrap_warning' ),
+			'WC_RoyalMail'                    => array( '10' => 'environment_check' ),
+		);
 		foreach ( $extension_admin_notices_to_suppress as $class_name => $function_to_suppress ) {
 			WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', $class_name, current( $function_to_suppress ), key( $function_to_suppress ) );
-        }
-        // Canada Post Specific - refactor after launch to be included in the above loop
-        WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', 'WC_Shipping_Canada_Post_Init', 'connect_canada_post', 10 );
-        WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', 'WC_Shipping_Canada_Post_Init', 'environment_check', 10 );
-        // Square Specific - refactor after launch to be included in the above loop
-        WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', 'Woocommerce_Square', 'check_environment', 10 );
-        WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', 'Woocommerce_Square', 'is_connected_to_square', 10 );        
+		}
+		// Canada Post Specific - refactor after launch to be included in the above loop.
+		WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', 'WC_Shipping_Canada_Post_Init', 'connect_canada_post', 10 );
+		WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', 'WC_Shipping_Canada_Post_Init', 'environment_check', 10 );
+		// Square Specific - refactor after launch to be included in the above loop.
+		WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', 'Woocommerce_Square', 'check_environment', 10 );
+		WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', 'Woocommerce_Square', 'is_connected_to_square', 10 );
 		// List of extensions that do not use class level functions for admin notices.
 		$other_admin_notices = array( 'woocommerce_gateway_paypal_express_upgrade_notice', 'woocommerce_gateway_klarna_welcome_notice' );
 		foreach ( $other_admin_notices as $function_to_suppress ) {
 			remove_action( 'admin_notices', $function_to_suppress );
 		}
-        // Suppress: Looking for the store notice setting? It can now be found in the Customizer.
-        $user_id = get_current_user_id();
-        $user_meta_key = 'dismissed_store_notice_setting_moved_notice';
-        $current_user_meta_value = get_user_meta( $user_id, $user_meta_key, true);
-        if ( ! $current_user_meta_value ) {
-            $updated_user_meta_value = update_user_meta( $user_id, $user_meta_key, true );    
-        }
-		// Suppress: Product Add Ons Activation Notice
+		// Suppress: Looking for the store notice setting? It can now be found in the Customizer.
+		$user_id                 = get_current_user_id();
+		$user_meta_key           = 'dismissed_store_notice_setting_moved_notice';
+		$current_user_meta_value = get_user_meta( $user_id, $user_meta_key, true );
+		if ( ! $current_user_meta_value ) {
+			$updated_user_meta_value = update_user_meta( $user_id, $user_meta_key, true );
+		}
+		// Suppress: Product Add Ons Activation Notice.
 		$deleted = delete_option( 'wpa_activation_notice' );
-        // Suppress all other WC Admin Notices not specified above
-        WC_Admin_Notices::remove_notice( 'wootenberg' );
+		// Suppress all other WC Admin Notices not specified above.
+		WC_Admin_Notices::remove_notice( 'wootenberg' );
 		WC_Admin_Notices::remove_all_notices();
 	}
-	
+
 	/**
 	 * Test if defaults are set.
 	 *
-	 * @return void
+	 * @return boolean
 	 */
 	public function check_if_defaults_already_setup() {
-        $wpcom_ec_plan_theme_defaults = get_option( 'wpcom_ec_plan_theme_defaults', false );
-        return $wpcom_ec_plan_theme_defaults;
-    }
-
-	public function set_theme_default_values() {
-        // Should either be on theme activation or set to have been saved
-        if ( ! $this->check_if_defaults_already_setup() ) {
-            set_theme_mod( 'sp_product_layout', 'full-width' ); // enables Full width single product page.
-            set_theme_mod( 'sp_shop_layout', 'full-width' ); // enables Full width shop archive pages.
-            set_theme_mod( 'sph_hero_enable', 'enable' ); // enables Parallax Hero on homepage.
-            set_theme_mod( 'sph_hero_heading_text', esc_attr__( 'Welcome', 'wc-calypso-bridge' ) ); // Heading Text for Parallax Hero.
-            set_theme_mod( 'sph_hero_text', sprintf( esc_attr__( 'This is your homepage which is what most visitors will see when they first visit your shop.%sYou can change this text by editing the "Parallax Hero" Section via the "Powerpack" settings in the Customizer on the left hand side of your screen.', 'wc-calypso-bridge' ), PHP_EOL . PHP_EOL ) ); // Content for Parallax Hero.
-            if ( 0 < wc_get_page_id( 'shop' ) ) {
-                set_theme_mod( 'sph_hero_button_url', get_permalink( wc_get_page_id( 'shop' ) ) ); // Set button url to the shop page instead of home if the shop page exists.
-            }
-            set_theme_mod( 'sp_homepage_content', false ); // Removes default Welcome banner from starter content.
-            set_theme_mod( 'sp_homepage_top_rated', false ); // Removes Top Rated Products area from starter content.
-            set_theme_mod( 'sp_homepage_on_sale', false ); // Removes On Sale Products area from starter content.
-            set_theme_mod( 'sp_homepage_best_sellers', false ); // Removes Best Sellers Products area from starter content.
-            update_option( 'woocommerce_demo_store', 'yes' ); // enables demo store notice.
-			// Force Fresh Site
-			update_option( 'fresh_site', true );
-            // Save option that says the setup has been run already.
-            update_option( 'wpcom_ec_plan_theme_defaults', true );
-        }
+		$wpcom_ec_plan_theme_defaults = get_option( 'wpcom_ec_plan_theme_defaults', false );
+		return $wpcom_ec_plan_theme_defaults;
 	}
-	
+
+	/**
+	 * Sets default values for Storefront powered themes and Powerpack.
+	 *
+	 * @return void
+	 */
+	public function set_theme_default_values() {
+		// Should either be on theme activation or set to have been saved.
+		if ( ! $this->check_if_defaults_already_setup() ) {
+			set_theme_mod( 'sp_product_layout', 'full-width' ); // enables Full width single product page.
+			set_theme_mod( 'sp_shop_layout', 'full-width' ); // enables Full width shop archive pages.
+			set_theme_mod( 'sph_hero_enable', 'enable' ); // enables Parallax Hero on homepage.
+			set_theme_mod( 'sph_hero_heading_text', esc_attr__( 'Welcome', 'wc-calypso-bridge' ) ); // Heading Text for Parallax Hero.
+			set_theme_mod( 'sph_hero_text', sprintf( '%1$s <br/><br/> %2$s', esc_attr__( 'This is your homepage which is what most visitors will see when they first visit your shop.', 'wc-calypso-bridge' ), esc_attr__( 'You can change this text by editing the "Parallax Hero" Section via the "Powerpack" settings in the Customizer on the left hand side of your screen.', 'wc-calypso-bridge' ) ) ); // Content for Parallax Hero.
+			if ( 0 < wc_get_page_id( 'shop' ) ) {
+				set_theme_mod( 'sph_hero_button_url', get_permalink( wc_get_page_id( 'shop' ) ) ); // Set button url to the shop page instead of home if the shop page exists.
+			}
+			set_theme_mod( 'sp_homepage_content', false ); // Removes default Welcome banner from starter content.
+			set_theme_mod( 'sp_homepage_top_rated', false ); // Removes Top Rated Products area from starter content.
+			set_theme_mod( 'sp_homepage_on_sale', false ); // Removes On Sale Products area from starter content.
+			set_theme_mod( 'sp_homepage_best_sellers', false ); // Removes Best Sellers Products area from starter content.
+			update_option( 'woocommerce_demo_store', 'yes' ); // enables demo store notice.
+			// Force Fresh Site.
+			update_option( 'fresh_site', true );
+			// Save option that says the setup has been run already.
+			update_option( 'wpcom_ec_plan_theme_defaults', true );
+		}
+	}
+
 }
 
 $wc_calypso_bridge_themes_setup = WC_Calypso_Bridge_Themes_Setup::get_instance();

--- a/includes/class-wc-calypso-bridge-themes-setup.php
+++ b/includes/class-wc-calypso-bridge-themes-setup.php
@@ -35,73 +35,8 @@ class WC_Calypso_Bridge_Themes_Setup {
 	 * Constructor.
 	 */
 	private function __construct() {
-		$this->includes();
-
-		// Suppress WC Admin Notices.
-		add_action( 'admin_head', array( $this, 'suppress_admin_notices' ) );
-		add_filter( 'woocommerce_helper_suppress_connect_notice', '__return_true' );
 		// Set default theme values.
 		add_action( 'init', array( $this, 'set_theme_default_values' ) );
-	}
-
-	/**
-	 * Loads required functionality, classes, and API endpoints.
-	 */
-	private function includes() {
-		include_once dirname( __FILE__ ) . '/class-wc-calypso-bridge-helper-functions.php';
-	}
-
-	/**
-	 * Suppresses admin notifications in wp-admin
-	 *
-	 * @return void
-	 */
-	public function suppress_admin_notices() {
-		/**
-		 * List of extension specific and themes class level functions to suppress
-		 * 'CLASS_NAME' => array( 'FUNCTION_PRIORITY' => 'FUNCTION_NAME' )
-		 */
-		$extension_admin_notices_to_suppress = array(
-			'WC_Shipping_Australia_Post_Init' => array( '10' => 'environment_check' ),
-			'WC_Facebookcommerce_Integration' => array( '10' => 'checks' ),
-			'WC_USPS'                         => array( '10' => 'environment_check' ),
-			'SP_Admin'                        => array( '10' => 'activation_notice' ),
-			'Woocommerce_Square'              => array( '10' => 'is_connected_to_square' ),
-			'WC_Taxjar'                       => array( '10' => 'maybe_display_admin_notices' ),
-			'WC_Klarna_Payments'              => array( '10' => 'order_management_check' ),
-			'Klarna_Checkout_For_WooCommerce' => array( '10' => 'order_management_check' ),
-			'WC_Gateway_PayFast'              => array( '10' => 'admin_notices' ),
-			'WC_Connect_Nux'                  => array( '9' => 'show_banner_before_connection' ),
-			'Storefront_NUX_Admin'            => array( '99' => 'admin_notices' ),
-			'WC_Gateway_PPEC_Plugin'          => array( '10' => 'show_bootstrap_warning' ),
-			'WC_RoyalMail'                    => array( '10' => 'environment_check' ),
-		);
-		foreach ( $extension_admin_notices_to_suppress as $class_name => $function_to_suppress ) {
-			WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', $class_name, current( $function_to_suppress ), key( $function_to_suppress ) );
-		}
-		// Canada Post Specific - refactor after launch to be included in the above loop.
-		WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', 'WC_Shipping_Canada_Post_Init', 'connect_canada_post', 10 );
-		WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', 'WC_Shipping_Canada_Post_Init', 'environment_check', 10 );
-		// Square Specific - refactor after launch to be included in the above loop.
-		WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', 'Woocommerce_Square', 'check_environment', 10 );
-		WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', 'Woocommerce_Square', 'is_connected_to_square', 10 );
-		// List of extensions that do not use class level functions for admin notices.
-		$other_admin_notices = array( 'woocommerce_gateway_paypal_express_upgrade_notice', 'woocommerce_gateway_klarna_welcome_notice' );
-		foreach ( $other_admin_notices as $function_to_suppress ) {
-			remove_action( 'admin_notices', $function_to_suppress );
-		}
-		// Suppress: Looking for the store notice setting? It can now be found in the Customizer.
-		$user_id                 = get_current_user_id();
-		$user_meta_key           = 'dismissed_store_notice_setting_moved_notice';
-		$current_user_meta_value = get_user_meta( $user_id, $user_meta_key, true );
-		if ( ! $current_user_meta_value ) {
-			$updated_user_meta_value = update_user_meta( $user_id, $user_meta_key, true );
-		}
-		// Suppress: Product Add Ons Activation Notice.
-		$deleted = delete_option( 'wpa_activation_notice' );
-		// Suppress all other WC Admin Notices not specified above.
-		WC_Admin_Notices::remove_notice( 'wootenberg' );
-		WC_Admin_Notices::remove_all_notices();
 	}
 
 	/**

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -56,3 +56,5 @@ if ( ! wc_calypso_bridge_is_ecommerce_plan() ) {
 }
 
 require_once dirname( __FILE__ ) . '/class-wc-calypso-bridge.php';
+
+require_once dirname( __FILE__ ) . '/class-wc-calypso-bridge-frontend.php';


### PR DESCRIPTION
This adds the default settings for Storefront and Powerpack.

It also modifies the customizer link in the checklist to load the starter content instead of the standard customizer. This needs testing as I have encountered random 502 errors locally. It relies on forcing fresh_site option to be true.

This also adds some frontend defaults for Storefront including the default footer credits.
