### PR TITLE
Fix Calypsoify on Woo Post Types

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -74,6 +74,7 @@ class WC_Calypso_Bridge {
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-admin-setup-checklist.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-page-controller.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-menus.php';
+			include_once dirname( __FILE__ ) . '/includes/gutenberg.php';
 			$connect_files = glob( dirname( __FILE__ ) . '/includes/connect/*.php' );
 			foreach ( $connect_files as $connect_file ) {
 				include_once $connect_file;
@@ -96,7 +97,6 @@ class WC_Calypso_Bridge {
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-taxonomies.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-action-header.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-tables.php';
-			include_once dirname( __FILE__ ) . '/includes/gutenberg.php';
 
 			// TODO Add composer.json to GridIcons, and pull this in via wpcomsh instead.
 			if ( ! function_exists( 'get_gridicon' ) ) {


### PR DESCRIPTION
I _think_ this might have been a regression introduced in #183 - but with `master` of calypso-bridge installed, and Gutenberg 4.4 activated, visiting an edit/create page for a woo post type ( orders, coupons, products etc ) resulted in a partially calypsoified state:

![image](https://user-images.githubusercontent.com/22080/48586913-2f63ec80-e8e6-11e8-9756-f9582220150f.png)

__Steps to Reproduce the Bug__
- Install `master` of calypso-bridge
- Install/activate gutenberg 4.4
- View an order edit page and verify the screen above

__Steps to test this fix__
- Checkout the branch
- Visit a coupon/order/product page and verify all is calypsoified as expected