### PR TITLE
Get breadcrumbs parent URL from first submenu item

### DIFF
--- a/includes/class-wc-calypso-bridge-action-header.php
+++ b/includes/class-wc-calypso-bridge-action-header.php
@@ -135,16 +135,38 @@ class WC_Calypso_Bridge_Action_Header {
 				$parent = $top_level_menu_item;
 			}
 		}
+
 		if ( $parent ) {
 			array_unshift(
 				$crumbs,
 				array(
 					'name' => $parent[0],
-					'url' => $parent[2],
+					'url'  => $this->get_parent_url( $parent[2] ),
 				)
 			);
 		}
 		return $crumbs;
+	}
+
+	/**
+	 * Get parent page URL from slug
+	 *
+	 * @param string $parent_menu_slug Parent page slug.
+	 */
+	public function get_parent_url( $parent_menu_slug ) {
+		global $submenu;
+		$submenu_items = $submenu[ $parent_menu_slug ];
+		if ( $submenu_items ) {
+			$first_menu_item = array_pop( array_reverse( $submenu_items ) );
+			$menu_hook       = get_plugin_page_hook( $first_menu_item[2], $parent_menu_slug );
+
+			if ( ! empty( $menu_hook ) ) {
+				return 'admin.php?page=' . $first_menu_item[2];
+			} else {
+				return $first_menu_item[2];
+			}
+		}
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
Makes the breadcrumb parent link based on the first submenu item and formats the link based on the plugin page.

Fixes #190 

#### Screenshots
<img width="639" alt="screen shot 2018-11-16 at 5 18 07 am" src="https://user-images.githubusercontent.com/10561050/48593979-009f5200-e98a-11e8-986d-6bcc21308c74.png">

#### Testing
1.  Click around various submenu items in the dashboard.
2.  Make sure the parent breadcrumb link goes to the correct place (first menu item).  Specifically this should resolve the "WooCommerce" parent link seen above.