### PR TITLE
Add Jetpack dependencies early on to prevent breaking disconnected sites

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -68,7 +68,7 @@ class WC_Calypso_Bridge {
 	 */
 	public function possibly_load_calypsoify() {
 		add_action( 'admin_init', array( $this, 'track_calypsoify_toggle' ) );
-		if ( 1 === (int) get_user_meta( get_current_user_id(), 'calypsoify', true ) ) {
+		if ( $this->dependencies_satisfied() ) {
 
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-setup.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-admin-setup-checklist.php';
@@ -81,6 +81,32 @@ class WC_Calypso_Bridge {
 
 			add_action( 'current_screen', array( $this, 'load_ui_elements' ) );
 		}
+	}
+
+	/**
+	 * Check if dependencies are met to load Calypsoify
+	 *
+	 * @return bool
+	 */
+	public function dependencies_satisfied() {
+		if ( 1 !== (int) get_user_meta( get_current_user_id(), 'calypsoify', true ) ) {
+			return false;
+		}
+		if ( ! class_exists( 'Jetpack' ) || ! class_exists( 'Jetpack_Calypsoify' ) ) {
+			return false;
+		}
+		if (
+			! Jetpack::is_active()
+			&& ! Jetpack::is_development_mode()
+			&& ! Jetpack::is_onboarding()
+			&& (
+				! is_multisite()
+				|| ! get_site_option( 'jetpack_protect_active' )
+			)
+		) {
+			return false;
+		}
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
Adds in early dependency checks to avoid fatal errors and removal of admin menu items if Jetpack is disconnected or somehow disabled.

Fixes #198 

#### Testing
1.  Check that plugin still loads correctly with a connected Jetpack site.
2.  Disabling Jetpack should not throw any fatal errors on WooCommerce routes (e.g. Orders, Products, etc).
3.  Enabling Jetpack should still not load this plugin unless `JETPACK_DEV_DEBUG` is set to true or Jetpack is connected.