### PR TITLE
Fix setup list margins for new layout padding

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -517,9 +517,19 @@ input[type=radio]:checked:before {
 html.wp-toolbar {
 	padding-top: 106px;
 }
-#wpcontent {
+.wp-admin #wpcontent {
 	height: 100%;
-	padding: 30px;
+	padding: 20px 32px;
+}
+@media (max-width: 960px) {
+	.wp-admin #wpcontent {
+		padding: 24px;
+	}
+}
+@media screen and (max-width: 480px) {
+	.wp-admin #wpcontent {
+		padding: 16px;
+	}
 }
 #wpbody {
 	padding-top: 0;

--- a/assets/css/setup-checklist.css
+++ b/assets/css/setup-checklist.css
@@ -491,7 +491,9 @@
 }
 
 /* Checklist overrides */
-
+.checklist {
+	margin: 20px 0 25px 0;
+}
 .checklist__header-action {
 	background: #fff;
 }
@@ -546,8 +548,8 @@
 	}
 }
 
-@media (max-width: 600px) {
+@media (max-width: 480px) {
 	.checklist {
-		margin: 20px 0px 25px -15px;
+		margin: 20px -15px 25px -15px;
 	}
 }


### PR DESCRIPTION
Fixes the margin around the setup checklist since we updated the layout padding.

Fixes #195 

#### Screenshots
<img width="1166" alt="screen shot 2018-11-16 at 2 53 36 pm" src="https://user-images.githubusercontent.com/10561050/48602878-95687680-e9af-11e8-950f-6398f6080891.png">
<img width="542" alt="screen shot 2018-11-16 at 2 53 42 pm" src="https://user-images.githubusercontent.com/10561050/48602879-95687680-e9af-11e8-96c6-f588cadc1681.png">
<img width="404" alt="screen shot 2018-11-16 at 2 53 47 pm" src="https://user-images.githubusercontent.com/10561050/48602880-96010d00-e9af-11e8-9473-fbe6015b9346.png">

#### Testing
1.  Visit the setup page `/wp-admin/admin.php?page=wc-setup-checklist`
2.  Check that the margin around the checklist looks good on all screen sizes.