### PR TITLE
Hide all actions on mobile except first in action header

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -711,15 +711,22 @@ li#wp-admin-bar-menu-toggle {
 	flex-grow: 1;
 	flex-shrink: 2;
 	text-align: right;
-	margin-top: -3px;
 }
-.action-header__actions a {
+.action-header .action-header__actions a {
 	margin-left: 12px;
 	text-decoration: none;
+	display: none;
+	padding: 6px 14px 8px !important;
+}
+.action-header__actions a:first-child {
+	display: inline-block;
 }
 @media screen and ( min-width: 661px ) {
 	.action-header__actions {
 		margin-left: 40px;
+	}
+	.action-header .action-header__actions a {
+		display: inline-block;
 	}
 }
 .action-header__actions-list {


### PR DESCRIPTION
Hides all actions on first on smaller viewports to avoid button crowding.  Also fixes button padding in action header and margin hack previously added.

#### Before
<img width="380" alt="screen shot 2018-11-19 at 7 43 53 am" src="https://user-images.githubusercontent.com/10561050/48679736-e30efa00-ebce-11e8-84ea-a9f75fa545b7.png">

#### After
<img width="381" alt="screen shot 2018-11-19 at 7 41 08 am" src="https://user-images.githubusercontent.com/10561050/48679721-b9ee6980-ebce-11e8-822d-3bde565ec0b4.png">

#### Testing
1.  Visit any page with multiple actions in the action header (e.g., `/wp-admin/edit.php?post_type=product`)
2.  Check that buttons look okay and only first appears on smaller viewports (<661px).