### PR TITLE
Hide hidden notices

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1562,6 +1562,9 @@ div.error {
 	border: 0;
 	overflow: hidden;
 }
+.wp-admin .wrap div.hidden {
+	display: none;
+}
 .wp-admin div.notice > p,
 .wp-admin div.updated > p, 
 .wp-admin div.error > p,


### PR DESCRIPTION
Hides notices with the `hidden` class that were being overridden by calypsoify notice styling.

Fixes #209 

#### Before
<img width="1102" alt="screen shot 2018-11-19 at 7 18 33 am" src="https://user-images.githubusercontent.com/10561050/48680064-4189a780-ebd2-11e8-9a64-e3226765d994.png">

#### After
<img width="898" alt="screen shot 2018-11-19 at 8 07 05 am" src="https://user-images.githubusercontent.com/10561050/48680059-3b93c680-ebd2-11e8-845d-b28e4d8fab91.png">

#### Testing
1.  Find a page with hidden notices (looks like there is one included with any wp-posts-lists-table).
2.  Make sure those notices aren't shown.