### PR TITLE
Fix table action button height

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -41,12 +41,18 @@ div.woocommerce-message, .wc-helper .start-container {
 	height: 0;
 }
 
-/* Pagination */
+/* Table nav */
 .tablenav {
 	height: auto;
 	display: inline-block;
 	width: 100%;
 }
+.tablenav .actions {
+	padding: 0;
+	margin-right: 8px;
+}
+
+/* Pagination */
 .tablenav-pages {
 	display: none;
 }
@@ -503,6 +509,21 @@ input[type=radio]:checked:before {
 }
 #major-publishing-actions > div {
 	max-width: 130px;
+}
+.tablenav .button {
+	line-height: 24px;
+	height: 41px;
+}
+
+/* Taller secondary buttons near select dropdowns */
+.tablenav .button {
+	line-height: 24px;
+	height: 41px;
+}
+.tablenav .button:hover,
+.tablenav .button:focus {
+	line-height: 24px;
+	height: 41px;
 }
 
 /* Delete buttons */


### PR DESCRIPTION
Fixes the buttons inside table actions to match the height of select dropdowns and other inputs.  Also fixes gap if table actions are empty

Fixes #215 

#### Screenshots
<img width="802" alt="screen shot 2018-11-19 at 11 10 11 am" src="https://user-images.githubusercontent.com/10561050/48684245-ba492d80-ebeb-11e8-8e52-f1a6a5286e80.png">

#### Testing
1.  Visit any page with buttons inside table actions (`/wp-admin/admin.php?page=wcpv-commissions` if WC Product Vendors is installed).
2.  Check that buttons match select dropdowns height.