### PR TITLE
Expand submenu in sidebar on tablets

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1439,8 +1439,20 @@ table.widefat {
 		width: 190px;
 		position: relative !important;
 	}
+	#adminmenu .wp-has-current-submenu .wp-submenu {
+		display: block;
+		top: 0 !important;
+		left: 0;
+		width: 100%;
+	}
+	#adminmenu li.wp-menu-open {
+		background: #f3f6f8 !important;
+	}
 	#wpcontent, #wpfooter {
 		margin-left: 190px;
+	}
+	#adminmenuback {
+		position: fixed !important;
 	}
 }
 @media only screen and (min-width: 661px) and (max-width: 783px) {


### PR DESCRIPTION
This should keep the sidebar submenu items from collapsing when viewing on mobile screen sizes.

#### Before
<img width="347" alt="screen shot 2018-11-19 at 9 11 16 am" src="https://user-images.githubusercontent.com/10561050/48684908-e2865b80-ebee-11e8-870b-afa8287c3ca8.png">

#### After
<img width="227" alt="screen shot 2018-11-19 at 11 31 43 am" src="https://user-images.githubusercontent.com/10561050/48684904-dc907a80-ebee-11e8-98d5-bb53fc44a25a.png">

#### Testing
1.  Visit any dashboard page with a submenu (Orders, Products, etc.)
2.  Narrow viewport between 661px and 782px.
3.  Check that submenu items are shown and menu background/border is also now showing.