### PR TITLE
Add dropdown toggle for subnavs on mobile

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -832,6 +832,114 @@ li#wp-admin-bar-menu-toggle {
 	font-weight: 400;
 }
 
+/* Navigation dropdown */
+.subsubsub-wrapper {
+	margin-bottom: 17px;
+	position: relative;
+	display: inline-block;
+	width: 100%;
+}
+.wrap .subsubsub-wrapper .subsubsub {
+	margin-bottom: 0;
+}
+.subsubsub-toggle {
+	display: none;
+	align-items: center;
+	padding: 15px;
+	font-size: 14px;
+	line-height: 16px;
+	height: 46px;
+	color: #2e4453;
+	font-weight: 600;
+	cursor: pointer;
+	position: relative;
+	width: 100%;
+	margin: 0;
+	background: #fff;
+	-webkit-box-sizing: border-box;
+	box-sizing: border-box;
+	-webkit-box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
+	box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
+}
+.subsubsub-toggle__current-page {
+	margin-right: 4px;
+}
+.subsubsub-toggle .gridicons-chevron-down {
+	width: 18px;
+	height: 18px;
+	transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), -webkit-transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+	fill: #4f748e;
+}
+@media screen and (max-width:480px) {
+	.subsubsub-wrapper {
+		margin-bottom: 9px;
+	}
+	.subsubsub-wrapper.is-open {
+		-webkit-box-shadow: 0 0 0 1px #87a6bc, 0 2px 4px #c8d7e1;
+		box-shadow: 0 0 0 1px #87a6bc, 0 2px 4px #c8d7e1;
+	}
+	.subsubsub-wrapper.is-open .subsubsub li {
+		display: block;
+		text-align: left;
+	}
+	.subsubsub-wrapper.is-open .subsubsub-toggle .gridicons-chevron-down {
+		-webkit-transform: rotate(-180deg);
+		transform: rotate(-180deg);
+	}
+	.subsubsub-toggle {
+		display: flex;
+	}
+	.subsubsub-wrapper .subsubsub.has-search {
+		padding-right: 0;
+	}
+	.subsubsub-wrapper .subsubsub {
+		margin-top: 0;
+		margin-bottom: 0;
+		position: static;
+		display: contents;
+	}
+	.subsubsub-wrapper .subsubsub li:not(.subsubsub__search-item) {
+		display: none;
+		text-align: left;
+	}
+	.subsubsub-wrapper.is-open .subsubsub li {
+		display: block;
+	}
+	.subsubsub-wrapper .subsubsub__search-item {
+		display: list-item;
+	}
+	.subsubsub-wrapper .subsubsub li a {
+		color: #2e4453;
+		display: flex;
+		-webkit-box-align: center;
+		-ms-flex-align: center;
+		align-items: center;
+		-webkit-box-sizing: border-box;
+		box-sizing: border-box;
+		padding: 15px;
+		width: 100%;
+		font-size: 14px;
+		font-weight: 600;
+		line-height: 18px;
+	}
+	.subsubsub-wrapper .subsubsub li a:not(.current):hover {
+		color: #00aadc;
+	}
+	.subsubsub-wrapper .subsubsub a.current {
+		color: #fff;
+		background-color: #00aadc;
+		border-bottom: 0;
+	}
+	.subsubsub-wrapper .subsubsub a.current > * {
+		color: #fff;
+		border-color: #fff;
+	}
+	.subsubsub-wrapper .subsubsub .search-box {
+		height: 46px;
+	}
+}
+
+
 /* Pill toggle styles */
 .woocommerce-input-toggle {
 	background: #00aadc;

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -102,6 +102,27 @@
         }
     } );
 
+
+    /**
+     * Append subnav dropdown for mobile
+     */
+    $( document ).ready(function() {
+        const $subNavigation = $( '.wrap .subsubsub' );
+        if ( $subNavigation.length ) {
+            const currentPage = $subNavigation.find( 'a.current' ).text();
+            const $toggle = $( '<div class="subsubsub-toggle"><span class="subsubsub-toggle__current-page">' + currentPage + '</span>' + icons.chevronDown + '</div>' );
+            $subNavigation.first().wrap( '<div class="subsubsub-wrapper"></div>' );
+            $( '.subsubsub-wrapper' ).prepend( $toggle );
+        }
+    } );
+
+    /**
+     * Append subnav dropdown for mobile
+     */
+    $( document ).on( 'click', '.subsubsub-toggle', function() {
+        $( this ).parent().toggleClass( 'is-open' );
+    } );
+
     /**
      * Toggle taxonomy form
      */

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -205,10 +205,11 @@ class WC_Calypso_Bridge {
 		wp_enqueue_script( 'wc-calypso-bridge-calypsoify', $asset_path . 'assets/js/calypsoify.js', array( 'jquery' ), WC_CALYPSO_BRIDGE_CURRENT_VERSION, true );
 
 		$icons = array(
-			'info'      => get_gridicon( 'gridicons-info' ),
-			'checkmark' => get_gridicon( 'gridicons-checkmark' ),
-			'notice'    => get_gridicon( 'gridicons-notice' ),
-			'cross'     => get_gridicon( 'gridicons-cross' ),
+			'info'        => get_gridicon( 'gridicons-info' ),
+			'checkmark'   => get_gridicon( 'gridicons-checkmark' ),
+			'notice'      => get_gridicon( 'gridicons-notice' ),
+			'cross'       => get_gridicon( 'gridicons-cross' ),
+			'chevronDown' => get_gridicon( 'gridicons-chevron-down' ),
 		);
 		wp_localize_script(
 			'wc-calypso-bridge-calypsoify',


### PR DESCRIPTION
Adds in a dropdown toggle for sub navigation items on smaller viewports.

Fixes #214 

#### Screenshots
<img width="457" alt="screen shot 2018-11-19 at 3 40 42 pm" src="https://user-images.githubusercontent.com/10561050/48692586-7ff28700-ec11-11e8-8162-8bff9045f09e.png">
<img width="456" alt="screen shot 2018-11-19 at 3 40 39 pm" src="https://user-images.githubusercontent.com/10561050/48692588-8123b400-ec11-11e8-853c-8b3025a71ef1.png">

#### Testing
1.  Visit a page with a subnav (e.g. Products - `/wp-admin/edit.php?post_type=product`)
2.  Narrow your viewport to <481px.
3.  Check that the styling on the dropdown looks okay and that toggling it opens the submenu items.  Also check that the search icon continues to work.

#### Questions
* Do we want to do this up tablet or larger devices for subnavs with many items?
* Do we also want to apply this to nav-tabs?  Are there any design implications for having 2 toggles on top of each other?  /cc @josemarques 