### PR TITLE
Fix JITM notice styles to match Calypso

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1566,7 +1566,8 @@ TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10507
 	width: 20%;
 	height: auto;
 }
-/* Notices */
+
+/* Notices and Jetpack JITM */
 div.notice,
 div.updated, 
 div.error {
@@ -1574,7 +1575,8 @@ div.error {
 }
 .wp-admin .wrap div.notice,
 .wp-admin .wrap div.updated, 
-.wp-admin .wrap div.error {
+.wp-admin .wrap div.error,
+div.jitm-card {
 	display: flex;
 	position: relative;
 	width: 100%;
@@ -1590,6 +1592,32 @@ div.error {
 	border: 0;
 	overflow: hidden;
 }
+
+div.jitm-card  .jitm-banner__info .jitm-banner__title, div.jitm-card  .jitm-banner__info .jitm-banner__description {
+	color: #fff;
+}
+
+#screen-meta-links + .jitm-card {
+	margin: 0 0 24px 0;
+	border-left: 0;
+	padding: 0;
+}
+
+.jitm-banner__content {
+    padding: 13px 13px 13px 0px;
+}
+
+.jp-emblem svg {
+	display: none;
+}
+
+.jp-emblem {
+	height: 24px;
+	width: 24px;
+	background-image:
+        url("data:image/svg+xml;utf8,<svg class='gridicon gridicons-notice' height='24' width='24' fill='#fff' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><g><path d='M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z'></path></g></svg>");
+}
+
 .wp-admin .wrap div.hidden {
 	display: none;
 }
@@ -1653,7 +1681,7 @@ div.error {
 .wp-admin div.error .button-primary:active {
 	vertical-align: baseline;
 }
-.wc-calypso-bridge-notice-icon-wrapper {
+.wc-calypso-bridge-notice-icon-wrapper, .jitm-banner__icon-plan {
 	position: relative;
 	background: #537994;
 	color: #fff;


### PR DESCRIPTION
Fixes #208.

This PR fixes the JITM (just in time messaging) notice styles added by Jetpack:

Before:

<img width="1004" alt="screen shot 2018-11-19 at 10 41 43 am" src="https://user-images.githubusercontent.com/689165/48717630-cfbc5880-ebe7-11e8-8422-82822362a132.png">

After:

<img width="996" alt="screen shot 2018-11-19 at 10 42 01 am" src="https://user-images.githubusercontent.com/689165/48717637-d64ad000-ebe7-11e8-93ee-cb345e6da2b6.png">

To Test:
* Activate and Connect Jetpack
* Activate/Connect WCS
* Visit the Add Order Page
* Verify styles are correct.
