### PR TITLE
Hide large Klarna setup banners

### DIFF
--- a/includes/class-wc-calypso-bridge-hide-alerts.php
+++ b/includes/class-wc-calypso-bridge-hide-alerts.php
@@ -86,6 +86,9 @@ class WC_Calypso_Bridge_Hide_Alerts {
 		WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', 'Woocommerce_Square', 'check_environment', 10 );
 		WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', 'Woocommerce_Square', 'is_connected_to_square', 10 );
 
+		WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'in_admin_header', 'WC_Klarna_Banners', 'klarna_banner', 10 );
+		WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'in_admin_header', 'WC_Klarna_Banners_KP', 'klarna_banner', 10 );
+
 		// List of extensions that do not use class level functions for admin notices.
 		$other_admin_notices = array( 'woocommerce_gateway_paypal_express_upgrade_notice', 'woocommerce_gateway_klarna_welcome_notice' );
 		foreach ( $other_admin_notices as $function_to_suppress ) {


### PR DESCRIPTION
Fixes #222.

Depending on your settings, Klarna will display a large banner to finish setting up. This is already part of our setup tasks, and the same information is on the payment gateway page.

<img width="1383" alt="screen shot 2018-11-19 at 9 22 29 am" src="https://user-images.githubusercontent.com/689165/48712847-cf6a9000-ebdc-11e8-8f78-e253fc15830e.png">

This PR removes those notices.

To Test:
* Before applying this branch, force the Klarna notice to show. You can edit `if ( $show_banner && false === get_transient( 'klarna_hide_banner' ) ) {` to be `if ( true ) {` in `klarna-checkout-for-woocommerce/includes/class-wc-klarna-banners.php` or `if ( $show_banner  && false === get_transient( 'klarna_kp_hide_banner' ) ) {`  to be `if ( true ) {` in `klarna-payments-for-woocommerce/includes/class-wc-klarna-banners.php` if you have previously dismissed the notice. 
* Test with this branch to verify that the notices do not show.