### PR TITLE
Fix selected sidebar menu styles

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -894,13 +894,24 @@ li#wp-admin-bar-menu-toggle {
 	color: #0073aa !important;
 }
 
-/* MailChimp for WooCommerce: Menu item */
-#adminmenu li.current a.menu-top.toplevel_page_mailchimp-woocommerce div.wp-menu-name {
+
+/* Fix selected styles for WooCommerce menu items */
+#adminmenu li.current div.wp-menu-name {
 	color: #fff !important;
 }
 
-#adminmenu li.current a.menu-top.toplevel_page_mailchimp-woocommerce .svg {
+#adminmenu li.current .svg {
 	filter: none;
+}
+
+#adminmenu li.wp-has-current-submenu:hover div.wp-menu-image:before,
+#adminmenu .wp-has-current-submenu div.wp-menu-image:before,
+#adminmenu .current div.wp-menu-image:before,
+#adminmenu a.wp-has-current-submenu:hover div.wp-menu-image:before,
+#adminmenu a.current:hover div.wp-menu-image:before,
+#adminmenu li.wp-has-current-submenu a:focus div.wp-menu-image:before,
+#adminmenu li.wp-has-current-submenu.opensub div.wp-menu-image:before {
+	color: #fff !important;
 }
 
 /* WooCommercer Orders */


### PR DESCRIPTION
Fixes #223.

We previously fixed a similar issue with the MailChimp issue. This PR fixes the styles in a way that all icons/text going forward should have the correct styles applied.

Before:

<img width="297" alt="screen shot 2018-11-19 at 9 29 01 am" src="https://user-images.githubusercontent.com/689165/48713205-ba423100-ebdd-11e8-9334-e6b962b45247.png">


After:

<img width="278" alt="screen shot 2018-11-19 at 11 11 35 am" src="https://user-images.githubusercontent.com/689165/48719707-21ff7880-ebec-11e8-8701-f448b213899b.png">

To Test:
* Verify that both the MailChimp and Product Vendors Commissions menu items have the same styles as WooCommerce and Products.