### PR TITLE
Fix modal styles

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1895,15 +1895,12 @@ p.search-box {
 /** WooCommerce Services / Modal */
 
 .wcs-pointer-page-dimmer {
-	z-index: 100200 !important; /* cover header too, like Calypso */
-	background-color: rgba(233,239,243,0.8) !important;
-}
 
-.wp-pointer {
-	z-index: 100201 !important;
+	background-color: rgba(233,239,243,0.8) !important;
 }
 
 .post-type-shop_order.post-new-php .jitm-card, .post-type-shop_order.post-php .jitm-card {
 	/* Hide JITM card on add/edit page, because the NUX walkthrough already deals with setup, and the notice is present on other pages */
 	display: none;
 }
+

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1891,3 +1891,19 @@ p.search-box {
 	margin-top: -4px;
 	margin-left: 4px;
 }
+
+/** WooCommerce Services / Modal */
+
+.wcs-pointer-page-dimmer {
+	z-index: 100200 !important; /* cover header too, like Calypso */
+	background-color: rgba(233,239,243,0.8) !important;
+}
+
+.wp-pointer {
+	z-index: 100201 !important;
+}
+
+.post-type-shop_order.post-new-php .jitm-card, .post-type-shop_order.post-php .jitm-card {
+	/* Hide JITM card on add/edit page, because the NUX walkthrough already deals with setup, and the notice is present on other pages */
+	display: none;
+}


### PR DESCRIPTION
Fixes #207.

This PR fixes the modal styles by applying a light dim that matches Calypsos. It also hides the JITM notices on add/edit orders, because the WC JITM message is really already handled by the inline notice and NUX walkthrough. This notice is also visible on other pages. When present, the pointer gets pushed down and no longer points at the correct metabox.

Calypso Style:

<img width="405" alt="screen shot 2018-11-19 at 12 09 50 pm" src="https://user-images.githubusercontent.com/689165/48723219-09935c00-ebf4-11e8-986f-ab62853b9780.png">

Before:

<img width="1231" alt="screen shot 2018-11-16 at 1 38 31 pm" src="https://user-images.githubusercontent.com/689165/48640832-d5c2f700-e9a5-11e8-9f70-26b05b656bff.png">

<img width="895" alt="screen shot 2018-11-16 at 1 38 26 pm" src="https://user-images.githubusercontent.com/689165/48640839-dbb8d800-e9a5-11e8-8ae7-9af99ba2e0db.png">

After:

<img width="1287" alt="screen shot 2018-11-19 at 12 11 00 pm" src="https://user-images.githubusercontent.com/689165/48723278-32b3ec80-ebf4-11e8-8b98-47cf3ef843fc.png">

To Test:

* In `woocommerce-services/classes/class-wc-connect-nux.php`, force `is_new_labels_user()` to true, and update `$dismissed_pointers = $this->get_dismissed_pointers();` on line 90 to `$dismissed_pointers = array();`. This should force the NUX to show if previously dismissed.
* Go to edit order or add order page and test the NUX modal.