### PR TITLE
Fix search input value length check

### DIFF
--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -131,7 +131,7 @@
         $searchBox.attr( 'data-target-form-id', uniqueId );
         $searchBox.appendTo( $searchBoxListItem );
         $subNav.addClass( 'has-search' );
-        if ( $searchInput.val().length ) {
+        if ( $searchInput.val() && $searchInput.val().length ) {
             $searchBox.addClass( 'is-expanded' );
         }
     }


### PR DESCRIPTION
Fixes the console error on pages without a search input box.

Fixes #233 

#### Testing
1.  Inspect on a page without a search input (`/wp-admin/admin.php?page=wcpv-commissions`).
2.  Confirm that no console error is thrown from calypsoify.js.
3.  Make sure that no regressions occur with search inputs on on other pages and that a search query persists the open state of the search input after searching.