### PR TITLE
Update wc tracking checkbox color

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1135,6 +1135,19 @@ table.widefat {
 	font: normal 21px/1 dashicons;
 	display: inline-block;
 }
+.wc-setup-content .checkbox input[type=checkbox]+label::before,
+.wc-setup-content .checkbox input[type=checkbox]+label::after {
+	display: none;
+}
+.wc-setup-content .checkbox input[type=checkbox] {
+	opacity: 1;
+	position: static;
+	left: 0;
+	margin-top: -1px;
+}
+.wc-setup-content .checkbox label {
+	padding-left: 0;
+}
 
 .wc-setup label {
 	color: #2E4453;


### PR DESCRIPTION
Changes the tracking checkbox color from WC purple to Calypso's.

Fixes #230 

#### Screenshots
<img width="561" alt="screen shot 2018-11-20 at 11 52 17 am" src="https://user-images.githubusercontent.com/10561050/48750616-ee3f5400-ecba-11e8-8f72-0770b07659ac.png">

#### Testing
1.  Update your option to view the tracking option `update_option( 'woocommerce_allow_tracking', 'unknown' );`
2.  Visit the OBW setup wizard's first page `/wp-admin/admin.php?page=wc-setup`
3.  Check that the checkbox is styled correctly.