### PR TITLE
Force cache invalidation on calypsoify param

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -99,7 +99,8 @@ class WC_Calypso_Bridge {
 
 			if ( isset( $_SERVER['REQUEST_URI'] ) ) {
 				$page = remove_query_arg( 'calypsoify', wp_basename( $_SERVER['REQUEST_URI'] ) ); // WPCS: Sanitization ok.
-				wp_safe_redirect( admin_url( $page ) );
+				header( 'Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0' );
+				wp_safe_redirect( admin_url( $page ), 307 );
 				exit;
 			}
 		}


### PR DESCRIPTION
This PR forces cache invalidation and changes the redirect status when checking the calypsoify param.  This should force calypsoify to activate when visiting from the store setup.

Fixes (possibly) #231 

#### Testing
1.  Visit `wp-admin/admin.php?page=wc-setup&calypsoify=0` 2 times to "cache" the route.
2.  Visit `wp-admin/admin.php?page=wc-setup&calypsoify=1` and calypsoify should be active.

This needs to be tested through an ecommerce plan purchase on wp.com to verify that it's working.

#### Other possible solutions
When testing, it seems like the check param also was fired every time when a `sleep(2)` was added to the `check_calyposify_param()` function.

Unclear as to whether or not this managed to invalidate the cache somehow or if there are other issues with the `update_user_meta` not completing in time.