### PR TITLE
Fix notice height and padding

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1597,7 +1597,7 @@ div.error {
 .wp-admin div.updated > p, 
 .wp-admin div.error > p,
 .wc-calypso-bridge-notice-content {
-	padding: 8px 13px;
+	padding: 6px 13px;
 	margin: 0;
 	flex-direction: column;
 }
@@ -1690,7 +1690,7 @@ div.error {
 	height: 100%;
 	margin: 0 0 0 auto !important;
 	position: static;
-	padding: 9px !important;
+	padding: 12px !important;
 }
 .notice-dismiss:before {
 	display: none;


### PR DESCRIPTION
Fixes the notice height to 47px and vertically aligns the dismiss button.

Fixes #237 

#### Before
<img width="563" alt="screen shot 2018-11-20 at 5 45 58 pm" src="https://user-images.githubusercontent.com/10561050/48765332-e39db280-ecec-11e8-8aec-d3072de87581.png">

#### After
<img width="613" alt="screen shot 2018-11-20 at 5 49 04 pm" src="https://user-images.githubusercontent.com/10561050/48765328-e26c8580-ecec-11e8-952a-0741d9a97578.png">

#### Testing
Visit any page in the dashboard and check that notice heights are 47px when only 1 line of text is present and that dismiss button is vertically aligned.