### PR TITLE
Always load Calypsoify during the setup wizard.

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -110,10 +110,17 @@ class WC_Calypso_Bridge {
 	 */
 	public function possibly_load_calypsoify() {
 		add_action( 'admin_init', array( $this, 'track_calypsoify_toggle' ) );
-		if ( $this->dependencies_satisfied() ) {
 
+		// TODO Add composer.json to GridIcons, and pull this in via wpcomsh instead.
+		if ( ! function_exists( 'get_gridicon' ) ) {
+			include_once dirname( __FILE__ ) . '/includes/gridicons.php';
+		}
+
+		// We always want the Calypso branded OBW to run on eCommerce plan sites.
+		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-setup.php';
+
+		if ( $this->dependencies_satisfied() ) {
 			include_once( dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-helper-functions.php' );
-			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-setup.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-themes-setup.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-admin-setup-checklist.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-page-controller.php';
@@ -167,11 +174,6 @@ class WC_Calypso_Bridge {
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-taxonomies.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-action-header.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-tables.php';
-
-			// TODO Add composer.json to GridIcons, and pull this in via wpcomsh instead.
-			if ( ! function_exists( 'get_gridicon' ) ) {
-				include_once dirname( __FILE__ ) . '/includes/gridicons.php';
-			}
 
 			add_action( 'admin_init', array( $this, 'remove_woocommerce_core_footer_text' ) );
 			add_filter( 'admin_footer_text', array( $this, 'update_woocommerce_footer' ) );

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -39,6 +39,12 @@ class WC_Calypso_Bridge_Setup {
 			add_filter( 'woocommerce_setup_wizard_steps', array( $this, 'remove_unused_steps' ) );
 			add_filter( 'woocommerce_enable_setup_wizard', '__return_false' );
 			add_action( 'wp_loaded', array( $this, 'setup_wizard' ), 20 );
+
+			$jetpack_calypsoify = Jetpack_Calypsoify::getInstance();
+			$wc_calypso_bridge  = WC_Calypso_Bridge::instance();
+
+			add_action( 'admin_enqueue_scripts', array( $jetpack_calypsoify, 'enqueue' ) );
+			add_action( 'admin_print_styles', array( $wc_calypso_bridge, 'enqueue_calypsoify_scripts' ), 11 );
 		}
 	}
 
@@ -46,6 +52,8 @@ class WC_Calypso_Bridge_Setup {
 	 * Show the setup wizard.
 	 */
 	public function setup_wizard() {
+		// Always tell Calypsoify to run during the setup wizard.
+		update_user_meta( get_current_user_id(), 'calypsoify', 1 );
 		include_once dirname( __FILE__ ) . '/class-wc-calypso-bridge-admin-setup-wizard.php';
 	}
 


### PR DESCRIPTION
This PR is an attempt to fix #231. While the issue could be caching (#236) -- I'm worried this might not fix the issue. My gut feeling is some kind of load order issue and the meta not being set on the first ever load of the store.

Instead, I think it's safe to assume that if the wizard is ran on a site with the eCommerce plan, we can also just force enable Calypsoify theme (and also then update the usermeta without a redirect). 

This PR moves the setup file out of the dependency check and also loads setup assets.

To Test:
* Disable Calypsoify.
* Visit `/wp-admin/admin.php?page=wc-setup` (no calypsoify parameter) and verify you see Calypso styles.
* Try clicking to the next screen and verify the styles are still loaded.