### PR TITLE
Use click based tracking for Stripe task in setup

### DIFF
--- a/includes/class-wc-calypso-bridge-admin-setup-checklist.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-checklist.php
@@ -182,13 +182,13 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 	 * Tracks a step has completed after visting a specific setup link.
 	 */
 	public function track_step_click() {
-		if ( ! isset( $_GET['wc-setup-step'] ) ) {
+		if ( ! isset( $_GET['wc-setup-step'] ) ) { // WPCS: CSRF ok.
 			return;
 		}
 
-		$whitelist = array( 'customize', 'shipping', 'product' );
+		$whitelist = array( 'customize', 'shipping', 'product', 'stripe' );
 		$step      = $_GET['wc-setup-step']; // WPCS: CSRF ok, sanitization ok.
-		if ( ! in_array( $step, $whitelist ) ) {
+		if ( ! in_array( $step, $whitelist, true ) ) {
 			return;
 		}
 
@@ -352,11 +352,9 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
 				'description'     => __( 'Connect your Stripe account to accept credit and debit card payments.', 'wc-calypso-bridge' ),
 				'estimate'        => '2',
-				'link'            => 'admin.php?page=wc-settings&tab=checkout&section=stripe',
+				'link'            => 'admin.php?page=wc-settings&tab=checkout&section=stripe&return=%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-setup-checklist&wc-setup-step=stripe',
 				'learn_more'      => 'https://woocommerce.com/products/stripe/',
-				'condition'       => ! empty( $stripe_settings['publishable_key'] ) &&
-							   ! empty( $stripe_settings['secret_key'] ) &&
-							   'yes' === $stripe_settings['enabled'],
+				'condition'       => isset( $click_settings['stripe'] ) && true === (bool) $click_settings['stripe'],
 				'extension'       => 'woocommerce-gateway-stripe/woocommerce-gateway-stripe.php',
 			),
 


### PR DESCRIPTION
Changes Stripe to use a click based track instead of tracking via setup Stripe keys since these may be auto-provisioned.

Fixes #242 

#### Screenshots
<img width="656" alt="screen shot 2018-11-21 at 7 32 15 am" src="https://user-images.githubusercontent.com/10561050/48809442-973f8a80-ed5f-11e8-8ee3-9617399b3894.png">

#### Testing
1.  Visit `/wp-admin/admin.php?page=wc-setup-checklist`
2.  If your Stripe is already marked completed, you can remove the click tracks from the `wp_options` table by deleting the `woocommerce_setup_checklist_clicks` option.
3.  Click the Stripe task and navigate back to the Setup Checklist to verify that it was marked complete.