### PR TITLE
Fix stylesheet orders in OBW to restore masterbar

### DIFF
--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -43,7 +43,7 @@ class WC_Calypso_Bridge_Setup {
 			$jetpack_calypsoify = Jetpack_Calypsoify::getInstance();
 			$wc_calypso_bridge  = WC_Calypso_Bridge::instance();
 
-			add_action( 'admin_enqueue_scripts', array( $jetpack_calypsoify, 'enqueue' ) );
+			add_action( 'admin_enqueue_scripts', array( $jetpack_calypsoify, 'enqueue' ), 20 );
 			add_action( 'admin_print_styles', array( $wc_calypso_bridge, 'enqueue_calypsoify_scripts' ), 11 );
 		}
 	}


### PR DESCRIPTION
Changes stylesheet priority so the masterbar is styled correctly.

Fixes #256 

#### Before
<img width="1671" alt="screen shot 2018-11-21 at 7 56 24 am" src="https://user-images.githubusercontent.com/10561050/48810288-7c6f1500-ed63-11e8-9d2a-08c189d52cf8.png">

#### After
<img width="1678" alt="screen shot 2018-11-21 at 8 00 32 am" src="https://user-images.githubusercontent.com/10561050/48810303-8abd3100-ed63-11e8-9c58-0f60ea399348.png">

#### Testing
1.  Visit `/wp-admin/admin.php?page=wc-setup`
2.  Check that masterbar is styled correctly as above.
