### PR TITLE
Remove mailchimp for wc redirect on plugin activation

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -126,6 +126,7 @@ class WC_Calypso_Bridge {
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-admin-setup-checklist.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-page-controller.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-menus.php';
+			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-plugins.php';
 			include_once dirname( __FILE__ ) . '/includes/gutenberg.php';
 			$connect_files = glob( dirname( __FILE__ ) . '/includes/connect/*.php' );
 			foreach ( $connect_files as $connect_file ) {

--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Modifies bundled plugins
+ *
+ * @package WC_Calypso_Bridge/Classes
+ * @since   1.0.0
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC Calypso Bridge Plugins
+ */
+class WC_Calypso_Bridge_Plugins {
+
+	/**
+	 * Class instance.
+	 *
+	 * @var WC_Calypso_Bridge_Plugins instance
+	 */
+	protected static $instance = false;
+
+	/**
+	 * Get class instance
+	 */
+	public static function get_instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor
+	 */
+	private function __construct() {
+		add_action( 'admin_init', array( $this, 'remove_mailchimp_redirect' ), 5 );
+	}
+
+	/**
+	 * Remove Mailchimp redirect
+	 */
+	public function remove_mailchimp_redirect() {
+		delete_option( 'mailchimp_woocommerce_plugin_do_activation_redirect' );
+	}
+
+
+}
+$wc_calypso_bridge_plugins = WC_Calypso_Bridge_Plugins::get_instance();


### PR DESCRIPTION
Removes the redirect option that Mailchimp adds on plugin activation.

Fixes #254 

#### Testing
This may need a release to test on the ecomm plan, but locally this can be tested by:

1. Install [Mailchimp for Woocommerce](https://wordpress.org/plugins/mailchimp-for-woocommerce/).
2. Activate the plugin.
3. You should not be redirected to the Mailchimp settings page on activation.