### PR TITLE
Wait for link track completion and continue to href

### DIFF
--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -15,20 +15,28 @@
      * Record checklist task click
      */
     $( '.checklist__task-title a, .checklist__task-secondary a' ).click( function() {
-        var $task = $( this ).closest( '.checklist__task' )
-        var status = $task.hasClass( 'is-completed' ) ? 'complete' : 'incomplete';
-        var taskId = $task.data('id');
-        var taskTitle = $task.data('title');
+        const $task = $( this ).closest( '.checklist__task' )
+        const status = $task.hasClass( 'is-completed' ) ? 'complete' : 'incomplete';
+        const taskId = $task.data('id');
+        const taskTitle = $task.data('title');
+        const href = $( this ).attr('href');
 
-        window.jpTracksAJAX.record_ajax_event(
-            'atomic_wc_tasklist_click',
-            'click',
-            {
-                id: taskId,
-                title: taskTitle, 
-                status: status,
-            }
-        );
+        if ( window.jpTracksAJAX ) {
+            const trackedEvent = window.jpTracksAJAX.record_ajax_event(
+                'atomic_wc_tasklist_click',
+                'click',
+                {
+                    id: taskId,
+                    title: taskTitle, 
+                    status: status,
+                }
+            );
+            trackedEvent.complete( function() {
+                window.location = href;
+            } );
+        } else {
+            window.location = href;
+        }
     } );
 
     /**
@@ -36,12 +44,13 @@
      */
     $( '.setup-footer a' ).click( function(e) {
         e.preventDefault();
-        var progressNumber = $( '.checklist__header-progress-number' ).text().split( '/' );
-        var complete = progressNumber[0];
-        var total = progressNumber[1];
-        var percentage = parseFloat( complete / total ).toFixed( 2 ) * 100;
-        if (window.jpTracksAJAX) {
-            window.jpTracksAJAX.record_ajax_event(
+        const progressNumber = $( '.checklist__header-progress-number' ).text().split( '/' );
+        const complete = progressNumber[0];
+        const total = progressNumber[1];
+        const percentage = parseFloat( complete / total ).toFixed( 2 ) * 100;
+        const href = $( this ).attr('href');
+        if ( window.jpTracksAJAX ) {
+            const trackedEvent = window.jpTracksAJAX.record_ajax_event(
                 'atomic_wc_tasklist_finish',
                 'click',
                 { 
@@ -50,6 +59,11 @@
                     percentage: percentage
                 }
             );
+            trackedEvent.complete( function() {
+                window.location = href;
+            } );
+        } else {
+            window.location = href;
         }
     } );
 

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -20,6 +20,7 @@
         const taskId = $task.data('id');
         const taskTitle = $task.data('title');
         const href = $( this ).attr('href');
+        $( this ).addClass( 'disabled' );
 
         if ( window.jpTracksAJAX ) {
             const trackedEvent = window.jpTracksAJAX.record_ajax_event(
@@ -49,6 +50,8 @@
         const total = progressNumber[1];
         const percentage = parseFloat( complete / total ).toFixed( 2 ) * 100;
         const href = $( this ).attr('href');
+        $( this ).addClass( 'disabled' );
+
         if ( window.jpTracksAJAX ) {
             const trackedEvent = window.jpTracksAJAX.record_ajax_event(
                 'atomic_wc_tasklist_finish',


### PR DESCRIPTION
Waits for the link track AJAX completion event before directing the window to the clicked link's href.

Fixes #252 

#### Screenshots
<img width="319" alt="screen shot 2018-11-21 at 11 53 21 am" src="https://user-images.githubusercontent.com/10561050/48818034-16df5080-ed84-11e8-844d-df06dd18a6cf.png">
<img width="190" alt="screen shot 2018-11-21 at 11 53 24 am" src="https://user-images.githubusercontent.com/10561050/48818035-16df5080-ed84-11e8-8a4a-b7583280fbf0.png">

#### Testing
1.  Go to `/wp-admin/admin.php?page=wc-setup-checklist`.
2.  Click on both the task action buttons and the "I'm Done" button.
3.  Verify that clicks are still tracked and that each goes to the link after tracking.

Note: You can update the `atomic-ecommerce-setup-checklist-complete` option to `0` if you need to "uncomplete" the setup.