### PR TITLE
Hide WC core notices

### DIFF
--- a/includes/class-wc-calypso-bridge-hide-alerts.php
+++ b/includes/class-wc-calypso-bridge-hide-alerts.php
@@ -38,6 +38,7 @@ class WC_Calypso_Bridge_Hide_Alerts {
 		add_action( 'admin_init', array( $this, 'hide_woo_obw_alert' ) );
 		add_action( 'admin_head', array( $this, 'suppress_admin_notices' ) );
 		add_filter( 'woocommerce_helper_suppress_connect_notice', '__return_true' );
+		add_filter( 'woocommerce_show_admin_notice', '__return_false' );
 	}
 
 	/**


### PR DESCRIPTION
Hides all the WC core notices since they will not pertain to ecommerce plan sites.  This includes hiding:

Fixes #250 

```php
	private static $core_notices = array(
		'install'                 => 'install_notice',
		'update'                  => 'update_notice',
		'template_files'          => 'template_file_check_notice',
		'legacy_shipping'         => 'legacy_shipping_notice',
		'no_shipping_methods'     => 'no_shipping_methods_notice',
		'simplify_commerce'       => 'simplify_commerce_notice',
		'regenerating_thumbnails' => 'regenerating_thumbnails_notice',
		'no_secure_connection'    => 'secure_connection_notice',
		'wootenberg'              => 'wootenberg_feature_plugin_notice',
	);
```

#### Testing
1.  Load up any WC screen with calypsoify enabled.
2.  Make sure none of the above notices are shown.