### PR TITLE
Align nav tabs left on smaller screens

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -882,6 +882,7 @@ li#wp-admin-bar-menu-toggle {
 }
 .wrap .subsubsub-wrapper .subsubsub {
 	margin-bottom: 0;
+	text-align: left;
 }
 .subsubsub-toggle {
 	display: none;


### PR DESCRIPTION
Fixes #248 

#### Screenshots
<img width="641" alt="screen shot 2018-11-22 at 10 31 45 am" src="https://user-images.githubusercontent.com/10561050/48878331-eb22a000-ee41-11e8-8309-e4eed0b31ccd.png">

#### Testing
1.  Visit `/wp-admin/edit.php?post_type=product`
2.  Narrow viewport between 481px and 781px.
3.  Check that tabs are aligned left.