### PR TITLE
Add styling to taxonomy edit form and add cancel button

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -249,18 +249,19 @@ input[type=radio]:checked:before {
 	0% {
 		transform: scale(0.3);
 	}
-
+	
 	60% {
 		transform: scale(1.15);
 	}
-
+	
 	100% {
 		transform: scale(1);
 	}
 }
 
 /* Form wraps */
-.form-wrap {
+.form-wrap,
+#edittag {
 	display: block;
 	margin: 0 auto 10px auto;
 	padding: 16px;
@@ -456,6 +457,7 @@ input[type=radio]:checked:before {
 
 /* Large Buttons */
 .wp-core-ui button.button.button-large,
+.wp-core-ui a.button.button-large,
 .wp-core-ui input.button.button-large,
 .checklist__task-secondary .button-primary,
 #postbox-container-1 .button-primary,
@@ -522,6 +524,12 @@ input[type=radio]:checked:before {
 .tablenav .button {
 	line-height: 24px;
 	height: 41px;
+}
+.edit-tag-actions .taxonomy-edit-cancel-button {
+	margin-left: 5px;
+}
+.edit-tag-actions #delete-link {
+	display: none;
 }
 
 /* Taller secondary buttons near select dropdowns */

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -148,6 +148,14 @@
         $( '#col-container > #col-right' ).toggle();
         $( '.taxonomy-form-toggle' ).toggle();
         $( '.wrap .search-form' ).toggle();
+        $( '.form-wrap h2:first' ).hide();
+        const formTitle = $( '.form-wrap h2:first' ).text();
+        if ( ! $( '#breadcrumb-taxonomy' ).length ) {
+            $( '.action-header__breadcrumbs' ).append(
+                '<span id="breadcrumb-taxonomy" style="display: none;">' + formTitle + '</span>'
+            );
+        }
+        $( '#breadcrumb-taxonomy' ).toggle();
     }
 
     /**
@@ -162,6 +170,13 @@
      * Move cancel button
      */
     $( '.taxonomy-form-cancel-button' ).appendTo( '#addtag p.submit' );
+
+    /**
+     * Add cancel button to taxonomy edit forms
+     */
+    $( '.edit-tag-actions #delete-link' ).before(
+        '<a href="' + ( taxonomy ? taxonomy.listUrl : '#' ) + '" class="button button-secondary button-large taxonomy-edit-cancel-button">' + translations.cancel + '</a>'
+    );
 
     /**
      * Move search box to subnav
@@ -185,8 +200,8 @@
     /**
      * Add icons to search boxes
      */
-    $( '.search-box' ).prepend( '<button class="search-box__search-icon" aria-label="' + wcb.openSearch + '"><svg class="gridicon gridicons-search" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M21 19l-5.154-5.154C16.574 12.742 17 11.42 17 10c0-3.866-3.134-7-7-7s-7 3.134-7 7 3.134 7 7 7c1.42 0 2.742-.426 3.846-1.154L19 21l2-2zM5 10c0-2.757 2.243-5 5-5s5 2.243 5 5-2.243 5-5 5-5-2.243-5-5z"/></g></svg></button>' );
-    $( '.search-box' ).append( '<button class="search-box__close-icon" aria-label="' + wcb.closeSearch + '"><svg class="gridicon gridicons-cross" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M18.36 19.78L12 13.41l-6.36 6.37-1.42-1.42L10.59 12 4.22 5.64l1.42-1.42L12 10.59l6.36-6.36 1.41 1.41L13.41 12l6.36 6.36z"/></g></svg></button>' );
+    $( '.search-box' ).prepend( '<button class="search-box__search-icon" aria-label="' + translations.openSearch + '"><svg class="gridicon gridicons-search" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M21 19l-5.154-5.154C16.574 12.742 17 11.42 17 10c0-3.866-3.134-7-7-7s-7 3.134-7 7 3.134 7 7 7c1.42 0 2.742-.426 3.846-1.154L19 21l2-2zM5 10c0-2.757 2.243-5 5-5s5 2.243 5 5-2.243 5-5 5-5-2.243-5-5z"/></g></svg></button>' );
+    $( '.search-box' ).append( '<button class="search-box__close-icon" aria-label="' + translations.closeSearch + '"><svg class="gridicon gridicons-cross" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M18.36 19.78L12 13.41l-6.36 6.37-1.42-1.42L10.59 12 4.22 5.64l1.42-1.42L12 10.59l6.36-6.36 1.41 1.41L13.41 12l6.36 6.36z"/></g></svg></button>' );
 
     /**
      * Focus search input on open icon click
@@ -330,7 +345,7 @@
             if ( $.inArray( tagName, addedTags ) === -1 ) {
                 addedTags.push( tagName );
                 toggleTaxonomyForm();
-                appendNotice( wcb.taxonomySuccess.replace( '{name}', tagName ), 'success' );
+                appendNotice( translations.taxonomySuccess.replace( '{name}', tagName ), 'success' );
             }
         } );
     } );

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -223,9 +223,10 @@ class WC_Calypso_Bridge {
 		$translations = array(
 			'openSearch'      => __( 'Open Search', 'wc-calypso-bridge' ),
 			'closeSearch'     => __( 'Close Search', 'wc-calypso-bridge' ),
+			'cancel'          => __( 'Cancel', 'wc-calypso-bridge' ),
 			'taxonomySuccess' => __( '"{name}" was successfully added.', 'wc-calypso-bridge' ),
 		);
-		wp_localize_script( 'wc-calypso-bridge-calypsoify', 'wcb', $translations );
+		wp_localize_script( 'wc-calypso-bridge-calypsoify', 'translations', $translations );
 
 	}
 

--- a/includes/class-wc-calypso-bridge-taxonomies.php
+++ b/includes/class-wc-calypso-bridge-taxonomies.php
@@ -37,6 +37,7 @@ class WC_Calypso_Bridge_Taxonomies {
 	private function __construct() {
 		add_action( 'add_tag_form_pre', array( $this, 'add_action_button' ) );
 		add_action( 'wp_loaded', array( $this, 'remove_taxonomy_form_description' ) );
+		add_action( 'admin_head', array( $this, 'localize_taxonomy_url' ) );
 	}
 
 	/**
@@ -63,5 +64,20 @@ class WC_Calypso_Bridge_Taxonomies {
 		// @TODO: Uncomment the following line if https://github.com/woocommerce/woocommerce/pull/21884 is merged into WC core.
 		// remove_action( 'product_cat_pre_add_form', array( WC_Admin_Taxonomies::get_instance(), 'product_cat_description' ), 10 );
 	}
+
+	/**
+	 * Create taxonomy url for cancel button
+	 */
+	public function localize_taxonomy_url() {
+		$screen = get_current_screen();
+		if ( 'term' === $screen->base ) {
+			$list_url = admin_url( 'edit-tags.php?taxonomy=' . $screen->taxonomy . '&post_type=' . $screen->post_type );
+			$taxonomy = array(
+				'listUrl' => $list_url,
+			);
+			wp_localize_script( 'wc-calypso-bridge-calypsoify', 'taxonomy', $taxonomy );
+		}
+	}
+
 }
 $wc_calypso_bridge_taxonomies = WC_Calypso_Bridge_Taxonomies::get_instance();


### PR DESCRIPTION
This PR:
* Adds the card styling to the edit form
* Adds a cancel button back to the taxonomy page
* Removes the delete link on taxonomy edit forms
* Removes page titles on the forms (since they're in the breadcrumbs)

Fixes #244

#### Screenshots
<img width="944" alt="screen shot 2018-11-22 at 12 45 28 pm" src="https://user-images.githubusercontent.com/10561050/48882462-6772ae80-ee55-11e8-8c38-405dd0ed43ec.png">
<img width="595" alt="screen shot 2018-11-22 at 12 47 48 pm" src="https://user-images.githubusercontent.com/10561050/48882463-680b4500-ee55-11e8-864e-6aee066ea5c0.png">

#### Testing
1.  Visit `/wp-admin/edit-tags.php?taxonomy=product_cat&post_type=product`
2.  Edit any category.
3.  Check that styling looks okay and that the "Cancel" button brings you back to the taxonomy list page.
4.  Repeat with `/wp-admin/edit-tags.php?taxonomy=product_tag&post_type=product`
