### PR TITLE
Store added tags on load to prevent 'add' notice on dom tree changes

### DIFF
--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -324,6 +324,9 @@
      * Detect changes to tag/category table
      */
     var addedTags = [];
+    $( '#the-list[data-wp-lists="list:tag"] tr .name .row-title' ).each( function() {
+        addedTags.push( $( this ).text() );
+    } );
     $( window ).load( function() {
         $( 'body' ).on( 'DOMSubtreeModified', '#the-list[data-wp-lists="list:tag"]', function() {
             var tagName = $( this ).find( 'tr:first .name .row-title' ).text();


### PR DESCRIPTION
Storing the previously added tags on loads prevents the success notice and form switch from triggering when clicking a category link.

Fixes #268

#### Testing
1.  Visit `/wp-admin/edit-tags.php?taxonomy=product_cat&post_type=product`
2.  Click on a category link and make sure it takes you to the category page in addition to *not* showing a successful tag addition notice.
3.  Add a tag through the form and check that the success notice still gets added and form toggles back to category list.