### PR TITLE
Move h2 action buttons to action header

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -249,11 +249,11 @@ input[type=radio]:checked:before {
 	0% {
 		transform: scale(0.3);
 	}
-
+	
 	60% {
 		transform: scale(1.15);
 	}
-
+	
 	100% {
 		transform: scale(1);
 	}
@@ -412,6 +412,7 @@ input[type=radio]:checked:before {
 /* Primary Buttons */
 .wp-core-ui .button-primary,
 .action-header .page-title-action,
+.action-header .add-new-h2,
 .wc-helper .button,
 .wc_addons_wrap .addons-button-solid,
 .woocommerce_page_wc-status .woocommerce-message a.debug-report,
@@ -438,6 +439,8 @@ input[type=radio]:checked:before {
 .wp-core-ui .button-primary:focus,
 .action-header .page-title-action:hover,
 .action-header .page-title-action:focus,
+.action-header .add-new-h2:hover,
+.action-header .add-new-h2:focus,
 .wc-helper .button:hover,
 .wc-helper .button:focus,
 .wc_addons_wrap .addons-button-solid:hover,
@@ -466,7 +469,8 @@ input[type=radio]:checked:before {
 .edit-tag-actions .button-primary,
 .woocommerce-BlankState a.button,
 .setup-footer a,
-.action-header .page-title-action {
+.action-header .page-title-action,
+.action-header .add-new-h2 {
 	font-size: 14px !important;
 	padding: 7px 14px 9px !important;
 	line-height: 21px !important;
@@ -493,6 +497,7 @@ input[type=radio]:checked:before {
 /* Specific Buttons */
 .wp-core-ui .button-primary:active,
 .action-header .page-title-action:active,
+.action-header .add-new-h2:active,
 .wc-helper .button:active,
 .wc_addons_wrap .addons-button-solid:active {
 	border-width: 2px 1px 1px !important;
@@ -696,10 +701,6 @@ li#wp-admin-bar-menu-toggle {
 	color: #668eaa;
 	margin: 2px 0 -3px;
 }
-.action-header .page-title-action,
-.action-header .button {
-	padding: 5px 14px 7px !important;
-}
 @media screen and (max-width: 782px) {
 	.action-header__site-title {
 		max-width: 150px;
@@ -746,11 +747,12 @@ li#wp-admin-bar-menu-toggle {
 	flex-shrink: 2;
 	text-align: right;
 }
-.action-header .action-header__actions a {
+.action-header .action-header__actions a,
+.action-header .action-header__actions button {
 	margin-left: 12px;
 	text-decoration: none;
 	display: none;
-	padding: 6px 14px 8px !important;
+	padding: 5px 14px 7px !important;
 }
 .action-header__actions a:first-child {
 	display: inline-block;
@@ -759,7 +761,8 @@ li#wp-admin-bar-menu-toggle {
 	.action-header__actions {
 		margin-left: 40px;
 	}
-	.action-header .action-header__actions a {
+	.action-header .action-header__actions a,
+	.action-header .action-header__actions button {
 		display: inline-block;
 	}
 }

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -104,7 +104,7 @@
     /**
      * Move page actions to action header
      */
-    $( '.page-title-action' ).appendTo( '#action-header .action-header__actions' );
+    $( '.page-title-action, .add-new-h2' ).appendTo( '#action-header .action-header__actions' );
 
     /** 
      * Move notices on pages with sub navigation


### PR DESCRIPTION
Moves all h2 action buttons to action header.

Fixes #245 

#### Before
<img width="414" alt="screen shot 2018-11-22 at 1 28 36 pm" src="https://user-images.githubusercontent.com/10561050/48883511-14035f00-ee5b-11e8-9936-aaebd9510dfb.png">

#### After
<img width="1321" alt="screen shot 2018-11-22 at 1 28 26 pm" src="https://user-images.githubusercontent.com/10561050/48883505-0cdc5100-ee5b-11e8-91ec-8b273aa480be.png">

#### Testing
1.  Visit `wp-admin/edit.php?post_type=product&page=addons`
2.  Check that "Add new" button is moved to action header.