### PR TITLE
Add card styling to product addons form

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -273,7 +273,8 @@ input[type=radio]:checked:before {
 /* Form wraps */
 .form-wrap,
 #edittag,
-.product_page_addons .wrap > form {
+.product_page_addons .wrap > form,
+.product_page_addons .wrap > div:not([class]) {
 	display: block;
 	margin: 0 auto 10px auto;
 	padding: 16px;
@@ -286,6 +287,15 @@ input[type=radio]:checked:before {
 	font-weight: 300;
 	margin: 0 0 20px 0;
 	line-height: 36px;
+}
+.product_page_addons .wrap > div:not([class]) {
+	margin: 0;
+	color: #537994;
+    font-size: 12px;
+    line-height: 18px;
+}
+.product_page_addons .wrap > div:not([class]) + br {
+	display: none;
 }
 
 /* Select2 inputs */

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -272,7 +272,8 @@ input[type=radio]:checked:before {
 
 /* Form wraps */
 .form-wrap,
-#edittag {
+#edittag,
+.product_page_addons .wrap > form {
 	display: block;
 	margin: 0 auto 10px auto;
 	padding: 16px;

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1707,7 +1707,9 @@ TODO: This can be removed after https://github.com/Automattic/jetpack/pull/10497
 
 /* Fix title padding */
 .wp-admin .wrap > h1:first-child,
-.wp-admin .wrap > h2:first-child  {
+.wp-admin .wrap > h2:first-child,
+.wp-admin .wrap > h1:nth-child(2),
+.wp-admin .wrap > h2:nth-child(2) {
 	display: none;
 }
 .wp-admin .wrap h1, .wp-admin .wrap h2 {


### PR DESCRIPTION
Adds the card around the form for the product addons page.

@josemarques  Does this look okay?  We don't have any other divs we can apply this style to so I wanted to make sure the nested "Add-on fields" box looks okay.

Fixes #246 

#### Screenshots
<img width="980" alt="screen shot 2018-11-22 at 1 48 36 pm" src="https://user-images.githubusercontent.com/10561050/48883975-5463dc80-ee5d-11e8-9b60-80803ee16805.png">

#### Testing
1.  Visit `/wp-admin/edit.php?post_type=product&page=addons&add=1`
2.  Check that form is styled properly.