### PR TITLE
Use 'Add new' toggle form pattern for product attributes

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1909,11 +1909,13 @@ div.jitm-card  .jitm-banner__info .jitm-banner__title, div.jitm-card  .jitm-bann
 }
 
 /* Taxonomy page */
-.edit-tags-php #col-left {
+.edit-tags-php #col-left,
+.product_page_product_attributes #col-left {
 	width: 100%;
 	display: none;
 }
-.edit-tags-php #col-right {
+.edit-tags-php #col-right,
+.product_page_product_attributes #col-right {
 	width: 100%;
 }
 .wp-core-ui .button.taxonomy-form-cancel-button {
@@ -1924,7 +1926,8 @@ div.jitm-card  .jitm-banner__info .jitm-banner__title, div.jitm-card  .jitm-bann
 	padding: 0;
 }
 /* @TODO: Remove the following selector if https://github.com/woocommerce/woocommerce/pull/21884 is merged into WC core. */
-.edit-tags-php #col-left > .col-wrap > p:first-child {
+.edit-tags-php #col-left > .col-wrap > p:first-child,
+.product_page_product_attributes #col-left > .col-wrap > p:first-child {
 	display: none;
 }
 

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -161,7 +161,14 @@
     /**
      * Move cancel button
      */
-    $( '.taxonomy-form-cancel-button' ).appendTo( '#addtag p.submit' );
+    $( '.taxonomy-form-cancel-button' ).appendTo( 'p.submit' );
+
+    /**
+     * Product attributes form is not AJAX'ed so toggle back if any errors
+     */
+    if ( $( '#woocommerce_errors' ).length ) {
+        toggleTaxonomyForm();
+    }
 
     /**
      * Move search box to subnav

--- a/includes/class-wc-calypso-bridge-taxonomies.php
+++ b/includes/class-wc-calypso-bridge-taxonomies.php
@@ -36,6 +36,7 @@ class WC_Calypso_Bridge_Taxonomies {
 	 */
 	private function __construct() {
 		add_action( 'add_tag_form_pre', array( $this, 'add_action_button' ) );
+		add_action( 'woocommerce_after_add_attribute_fields', array( $this, 'add_action_button' ) );
 		add_action( 'wp_loaded', array( $this, 'remove_taxonomy_form_description' ) );
 	}
 


### PR DESCRIPTION
Adds the "Add new" button to header and cancel buttons to toggle form/list on product attributes page.

Fixes #247 

#### Screenshots
<img width="967" alt="screen shot 2018-11-22 at 2 05 00 pm" src="https://user-images.githubusercontent.com/10561050/48884464-9f7eef00-ee5f-11e8-88eb-471ea5c0281d.png">

#### Testing
1.  Visit `/wp-admin/edit.php?post_type=product&page=product_attributes`
2.  Check that styling is correct.
3.  Check that "Add new" in action header toggles the form and hides the list.
4.  Check that the "Cancel" button hides the form.
5.  Check that submitting the form without info shows the form when the new page is rendered (due to form errors).