### PR TITLE
Fix WC Bookings table on mobile

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -53,6 +53,17 @@ div.woocommerce-message, .wc-helper .start-container {
 	margin-right: 8px;
 }
 
+/* WC Bookings Tables */
+.post-type-wc_booking .wp-list-table tr:not(.inline-edit-row):not(.no-items) td:not(.check-column) {
+	display: table-cell;
+}
+.post-type-wc_booking .wp-list-table tr:not(.inline-edit-row):not(.no-items) td:not(.column-primary)::before {
+	display: none;
+}
+.post-type-wc_booking .wp-list-table tr .booking_actions a.button {
+	width: 30px;
+}
+
 /* Pagination */
 .tablenav-pages {
 	display: none;
@@ -249,11 +260,11 @@ input[type=radio]:checked:before {
 	0% {
 		transform: scale(0.3);
 	}
-
+	
 	60% {
 		transform: scale(1.15);
 	}
-
+	
 	100% {
 		transform: scale(1);
 	}


### PR DESCRIPTION
Fixes column collapsing on mobile and allows scrolling.  

Fixes #274 

Will not fix upstream to the WC Bookings repo since we have our own horizontal scrolling on tables that would not work in the standard dashboard (conventionally, the plugin will want to hide columns on mobile).

#### Before
<img width="453" alt="screen shot 2018-11-22 at 3 48 13 pm" src="https://user-images.githubusercontent.com/10561050/48889151-d3621080-ee6f-11e8-9b95-417755f8caa7.png">

#### After
<img width="432" alt="screen shot 2018-11-22 at 3 56 32 pm" src="https://user-images.githubusercontent.com/10561050/48889156-d65d0100-ee6f-11e8-9fcc-38153bd56b0e.png">

#### Testing
1.  Visit `wp-admin/edit.php?post_type=wc_booking`.
2.  Check that table layout is correct and scrollable on mobile.