### PR TITLE
Fix select and select button line height

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -249,11 +249,11 @@ input[type=radio]:checked:before {
 	0% {
 		transform: scale(0.3);
 	}
-
+	
 	60% {
 		transform: scale(1.15);
 	}
-
+	
 	100% {
 		transform: scale(1);
 	}
@@ -290,17 +290,17 @@ input[type=radio]:checked:before {
 	color: #2e4453;
 	cursor: pointer;
 	display: inline-block;
-	font-size: 14px;
-	font-weight: 600;
-	height: 43px;
+	font-size: 16px;
+	font-weight: 400;
+	height: 41px;
 	line-height: 1.4em;
 	margin: 0;
 	outline: 0;
 	overflow: hidden;
-	padding: 11px 42px 9px 14px !important;
+	padding: 7px 32px 9px 14px;
+	vertical-align: top;
 	text-overflow: ellipsis;
 	text-decoration: none;
-	/*vertical-align: top;*/
 	white-space: nowrap;
 }
 .post-type-shop_order .tablenav .select2-container {
@@ -331,9 +331,9 @@ input[type=radio]:checked:before {
 #post-query-submit,
 .wp-admin select + .button {
 	font-size: 14px;
-	font-weight: 600;
+	font-weight: 400;
 	line-height: 1.4em;
-	height: 43px;
+	height: 41px;
 	margin-top: 0px;
 	margin-bottom: 5px;
 	max-width: 240px;
@@ -342,6 +342,7 @@ input[type=radio]:checked:before {
 .wp-admin select + .button:hover,
 .wp-admin select + .button:focus {
 	padding: 7px 14px;
+	line-height: 1 !important;
 }
 .button.wc-reload::after {
 	line-height: 38px;


### PR DESCRIPTION
Restores the select dropdown and sibling button heights to 41px and adjusts padding to vertically align text.

Before merging, let's make sure that this does not conflict with changes made in https://github.com/Automattic/wc-calypso-bridge/pull/264 /cc @josemarques 
Fixes #276 

#### Before
<img width="508" alt="screen shot 2018-11-22 at 4 05 43 pm" src="https://user-images.githubusercontent.com/10561050/48890442-d0691f00-ee73-11e8-98d5-dfb9363228a0.png">
<img width="803" alt="screen shot 2018-11-22 at 4 32 25 pm" src="https://user-images.githubusercontent.com/10561050/48890604-381f6a00-ee74-11e8-88d5-fb84599fa589.png">

#### After
<img width="544" alt="screen shot 2018-11-22 at 4 27 01 pm" src="https://user-images.githubusercontent.com/10561050/48890436-cc3d0180-ee73-11e8-8137-ca7f2bfe9203.png">
<img width="431" alt="screen shot 2018-11-22 at 4 27 08 pm" src="https://user-images.githubusercontent.com/10561050/48890437-cc3d0180-ee73-11e8-9324-c4e9c545a914.png">

#### Testing
1.  Visit various pages with select forms (any pages with list tables and `/wp-admin/admin.php?page=wc-setup`
2. Check that text is vertically aligned and sibling buttons match height of 41px.