### PR TITLE
Adds styling to paragraphs that follow H3 titles on forms

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1204,7 +1204,9 @@ table.widefat {
 }
 
 #mainform h2 + div p,
-#mainform h2 + p {
+#mainform h2 + p,
+#mainform h3 + div p,
+#mainform h3 + p {
 	color: #537994;
 	font-size: 12px;
 	line-height: 18px;
@@ -1212,7 +1214,8 @@ table.widefat {
 	padding: 0 24px 8px;
 }
 
-#mainform h2 + p {
+#mainform h2 + p,
+#mainform h3 + p {
 	background-color: #fff;
 	border-left: 1px solid rgba(200,215,225,0.5);
 	border-right: 1px solid rgba(200,215,225,0.5);


### PR DESCRIPTION
Some pages use sections with H3 titles and the subtitle paragraphs were not properly style so there was a gap in the form. 

Before:
![screen shot 2018-11-22 at 16 16 36](https://user-images.githubusercontent.com/57050/48913984-01485480-ee72-11e8-83c8-b3ad7efca3dd.png)

After:
![screen shot 2018-11-22 at 16 11 29](https://user-images.githubusercontent.com/57050/48913812-74050000-ee71-11e8-81e8-71064a2f85ee.png)

**Testing:**
- Go to a settings screen that uses H3 titles such as /wp-admin/admin.php?page=wc-settings&tab=checkout&section=paypal
- Got to another settings screen with multiple sections and check that everything is looking like it should: /wp-admin/admin.php?page=wc-settings&tab=general


