### PR TITLE
Update wrap max width

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -573,7 +573,8 @@ html.wp-toolbar {
 	top: 0;
 }
 .wrap {
-	margin: 0;
+	margin: 0 auto;
+	max-width: 1040px;
 }
 #adminmenu {
 	margin-top: 0;
@@ -582,6 +583,17 @@ html.wp-toolbar {
 	html.wp-toolbar {
 		padding-top: 93px;
 	}
+}
+
+/* Larger width pages */
+.post-type-product.edit-php .wrap,
+.post-type-product.post-php .wrap,
+.toplevel_page_wcpv-commissions .wrap,
+.post-type-wc_booking .wrap {
+	max-width: none;
+}
+#edittag {
+    max-width: 100%;
 }
 
 /* Action header */


### PR DESCRIPTION
Adds in a max width for the wrap to make the content area narrower like Calypso's.  We set the width of all to 1040px and "whitelist" specific pages that need to be wider due to large tables.

Fixes #279

#### Before
<img width="1628" alt="screen shot 2018-11-23 at 9 15 08 am" src="https://user-images.githubusercontent.com/10561050/48925591-4fa43480-ef00-11e8-87cb-6f626b6dc23f.png">

#### After
<img width="1630" alt="screen shot 2018-11-23 at 9 14 49 am" src="https://user-images.githubusercontent.com/10561050/48925594-516df800-ef00-11e8-92ca-f5c73d9b5387.png">

#### Testing
Visit various pages in the dashboard and check that the content has been narrowed to a max of 1040px and is centered.

The following pages should not have a max width:
* Products list
* Products single
* Commissions list
* Bookings list
