### PR TITLE
Add dropdown for nav tabs

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -875,16 +875,16 @@ li#wp-admin-bar-menu-toggle {
 }
 
 /* Navigation dropdown */
-.subsubsub-wrapper {
+.nav-tab-container {
 	margin-bottom: 17px;
 	position: relative;
 	display: inline-block;
 	width: 100%;
 }
-.wrap .subsubsub-wrapper .subsubsub {
+.wrap .nav-tab-container .subsubsub {
 	margin-bottom: 0;
 }
-.subsubsub-toggle {
+.nav-tab-toggle {
 	display: none;
 	align-items: center;
 	padding: 15px;
@@ -903,54 +903,58 @@ li#wp-admin-bar-menu-toggle {
 	-webkit-box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
 	box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
 }
-.subsubsub-toggle__current-page {
+.nav-tab-toggle__current-page {
 	margin-right: 4px;
 }
-.subsubsub-toggle .gridicons-chevron-down {
+.nav-tab-toggle .gridicons-chevron-down {
 	width: 18px;
 	height: 18px;
 	transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), -webkit-transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 	fill: #4f748e;
 }
 @media screen and (max-width:480px) {
-	.subsubsub-wrapper {
+	.nav-tab-container {
 		margin-bottom: 9px;
 	}
-	.subsubsub-wrapper.is-open {
+	.nav-tab-container.is-open {
 		-webkit-box-shadow: 0 0 0 1px #87a6bc, 0 2px 4px #c8d7e1;
 		box-shadow: 0 0 0 1px #87a6bc, 0 2px 4px #c8d7e1;
+		overflow: hidden;
 	}
-	.subsubsub-wrapper.is-open .subsubsub li {
+	.nav-tab-container.is-open .subsubsub li {
 		display: block;
 		text-align: left;
 	}
-	.subsubsub-wrapper.is-open .subsubsub-toggle .gridicons-chevron-down {
+	.nav-tab-container.is-open .nav-tab-toggle .gridicons-chevron-down {
 		-webkit-transform: rotate(-180deg);
 		transform: rotate(-180deg);
 	}
-	.subsubsub-toggle {
+	.nav-tab-toggle {
 		display: flex;
 	}
-	.subsubsub-wrapper .subsubsub.has-search {
+	.nav-tab-container .subsubsub.has-search {
 		padding-right: 0;
 	}
-	.subsubsub-wrapper .subsubsub {
+	.nav-tab-container .nav-tab-wrapper,
+	.nav-tab-container .subsubsub {
 		margin-top: 0;
 		margin-bottom: 0;
 		position: static;
 		display: contents;
 	}
-	.subsubsub-wrapper .subsubsub li:not(.subsubsub__search-item) {
+	.nav-tab-container .subsubsub li:not(.subsubsub__search-item) {
 		display: none;
 		text-align: left;
 	}
-	.subsubsub-wrapper.is-open .subsubsub li {
+	.nav-tab-container.is-open .subsubsub li {
 		display: block;
 	}
-	.subsubsub-wrapper .subsubsub__search-item {
+	.nav-tab-container .subsubsub__search-item {
 		display: list-item;
 	}
-	.subsubsub-wrapper .subsubsub li a {
+	.nav-tab-container .nav-tab-wrapper a,
+	.nav-tab-container .subsubsub li a {
+		background: #fff;
 		color: #2e4453;
 		display: flex;
 		-webkit-box-align: center;
@@ -964,20 +968,37 @@ li#wp-admin-bar-menu-toggle {
 		font-weight: 600;
 		line-height: 18px;
 	}
-	.subsubsub-wrapper .subsubsub li a:not(.current):hover {
+	.nav-tab-container .nav-tab-wrapper a:not(.nav-tab-active):hover,
+	.nav-tab-container .subsubsub li a:not(.current):hover {
 		color: #00aadc;
 	}
-	.subsubsub-wrapper .subsubsub a.current {
+	.nav-tab-container .nav-tab-wrapper a.nav-tab-active,
+	.nav-tab-container .subsubsub a.current {
 		color: #fff;
 		background-color: #00aadc;
 		border-bottom: 0;
 	}
-	.subsubsub-wrapper .subsubsub a.current > * {
+	.nav-tab-container .subsubsub a.current > * {
 		color: #fff;
 		border-color: #fff;
 	}
-	.subsubsub-wrapper .subsubsub .search-box {
+	.nav-tab-container .subsubsub .search-box {
 		height: 46px;
+	}
+	.nav-tab-container .nav-tab-wrapper {
+		display: none;
+		margin: 0 !important;
+		overflow: hidden;
+	}
+	.nav-tab-container.is-open .nav-tab-wrapper {
+		display: block;
+	}
+	.nav-tab-container .nav-tab-wrapper a.nav-tab {
+		margin: 0;
+		padding-left: 20px;
+	}
+	.nav-tab-container .nav-tab-wrapper a.nav-tab:first-child {
+		padding-left: 15px;
 	}
 }
 

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -124,19 +124,18 @@
      * Append subnav dropdown for mobile
      */
     $( document ).ready(function() {
-        const $subNavigation = $( '.wrap .subsubsub' );
-        if ( $subNavigation.length ) {
-            const currentPage = $subNavigation.find( 'a.current' ).text();
-            const $toggle = $( '<div class="subsubsub-toggle"><span class="subsubsub-toggle__current-page">' + currentPage + '</span>' + icons.chevronDown + '</div>' );
-            $subNavigation.first().wrap( '<div class="subsubsub-wrapper"></div>' );
-            $( '.subsubsub-wrapper' ).prepend( $toggle );
-        }
+        $( '.wrap .subsubsub, .wrap .nav-tab-wrapper' ).each( function() {
+            const currentText = $( this ).find( 'a.current, .nav-tab-active' ).text();
+            const $toggle = $( '<div class="nav-tab-toggle"><span class="nav-tab-toggle__current-page">' + currentText + '</span>' + icons.chevronDown + '</div>' );
+            $( this ).wrap( '<div class="nav-tab-container"></div>' );
+            $( this ).before( $toggle );
+        } );
     } );
 
     /**
      * Append subnav dropdown for mobile
      */
-    $( document ).on( 'click', '.subsubsub-toggle', function() {
+    $( document ).on( 'click', '.nav-tab-toggle', function() {
         $( this ).parent().toggleClass( 'is-open' );
     } );
 


### PR DESCRIPTION
Previously #221 added in dropdowns for sub nav menus on mobile.  This does the same for top level nav tabs.

Fixes #258 

#### Screenshots
<img width="369" alt="screen shot 2018-11-23 at 12 17 04 pm" src="https://user-images.githubusercontent.com/10561050/48928477-1c6e9f00-ef1a-11e8-835e-1ba9267c4fa0.png">
<img width="370" alt="screen shot 2018-11-23 at 12 16 54 pm" src="https://user-images.githubusercontent.com/10561050/48928478-1d073580-ef1a-11e8-98b7-7c38279443a7.png">

#### Testing
1.  Go to `wp-admin/edit.php?post_status=publish&post_type=product` or any other page with navtabs
2.  Check that styling is correct and that the dropdown works as expected.
3.  Check that no regressions have occurred with the subnavs.