### PR TITLE
Add styling for select2 clear icon

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -320,6 +320,15 @@ input[type=radio]:checked:before {
 .select2-container--default .select2-selection--single .select2-selection__placeholder {
 	color: #2e4453;
 }
+.select2-container--default .select2-selection--single .select2-selection__clear {
+	font-size: 0;
+}
+.select2-container--default .select2-selection--single .select2-selection__clear:before {
+	content: '\2715';
+	color: #c3d7e2;
+	font-size: 14px;
+	line-height: 24px;
+}
 
 /* Fixes for button height next to select dropdowns */
 .post-type-product .tablenav input,
@@ -2090,4 +2099,9 @@ p.search-box {
 .post-type-shop_order.post-new-php .jitm-card, .post-type-shop_order.post-php .jitm-card {
 	/* Hide JITM card on add/edit page, because the NUX walkthrough already deals with setup, and the notice is present on other pages */
 	display: none;
+}
+
+/* WC Settings */
+.woocommerce_page_wc-settings .select2-selection.select2-selection--single {
+	min-width: 300px;
 }


### PR DESCRIPTION
Adds in styling for the clear icons in select2 dropdowns and increases the width of the settings dropdowns.

@josemarques I don't think there's precedent for clear icons in Calypso, but I used a similar close icon that seems to be commonly used.  Can you let me know if this looks okay or if we should revert?

Fixes #281 

#### Screenshots
<img width="609" alt="screen shot 2018-11-23 at 12 27 00 pm" src="https://user-images.githubusercontent.com/10561050/48928578-7cb21080-ef1b-11e8-8572-f731cb551e9a.png">

#### Testing
1.  Visit `/wp-admin/admin.php?page=wc-settings&tab=advanced`
2.  Check that styling for clear icons looks okay and is not overlapping text.
3.  Check that clear icon still works as expected.