### PR TITLE
Redirect to setup checklist if no payment gateways are available

### DIFF
--- a/includes/class-wc-calypso-bridge-admin-setup-wizard.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-wizard.php
@@ -36,6 +36,7 @@ class WC_Calypso_Bridge_Admin_Setup_Wizard extends WC_Admin_Setup_Wizard {
 	public function __construct() {
 		if ( current_user_can( 'manage_woocommerce' ) ) {
 			add_action( 'admin_menu', array( $this, 'admin_menus' ) );
+			add_action( 'admin_init', array( $this, 'skip_empty_payment_step' ), 9 );
 			add_action( 'admin_init', array( $this, 'setup_wizard' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_calypsoify_scripts' ) );
@@ -373,6 +374,18 @@ class WC_Calypso_Bridge_Admin_Setup_Wizard extends WC_Admin_Setup_Wizard {
 			}
 		}
 		activate_plugin( 'woocommerce-shipping-ups/woocommerce-shipping-ups.php' );
+	}
+
+	/**
+	 * Skip the empty payment step if no gateways are present
+	 */
+	public function skip_empty_payment_step() {
+		if ( isset( $_GET['step'] ) && 'payment' === $_GET['step'] ) { // WPCS: CSRF ok.
+			$gateways = $this->get_wizard_in_cart_payment_gateways();
+			if ( empty( $gateways ) ) {
+				wp_safe_redirect( admin_url( 'admin.php?page=wc-setup-checklist' ) );
+			}
+		}
 	}
 
 }


### PR DESCRIPTION
Skips the payment step if none is available based on country/currency.

Fixes #286 

#### With payment gateways
![withgateway](https://user-images.githubusercontent.com/10561050/48933162-41730a00-ef3a-11e8-8e6f-d2ccbf589084.gif)

#### Without payment gateways
![withoutgateway](https://user-images.githubusercontent.com/10561050/48933160-3fa94680-ef3a-11e8-9917-688abf070b0f.gif)

#### Testing
1.  Go to `wp-admin/admin.php?page=wc-setup`
2.  Select a country and currency that has no payment gateway options (e.g., Ukraine and AFN) and click "Continue" and check that you're redirected to the setup checklist.
3.  Go back and select a currency with gateway options and check that you're sent to the payment setup step.