### PR TITLE
Add table cell padding and fix alignment

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1079,11 +1079,25 @@ table.wc-shipping-classes td.wc-shipping-zone-method-blank-state, table.wc-shipp
 .hndle a, .widefat tfoot td, .widefat th, .widefat thead td {
 	font-weight: 600;
 	color: #2e4453;
-	padding: 16px;
 }
-
 th.sortable a, th.sorted a{
 	color: #0087be;
+	padding: 8px 0;
+	margin-top: -8px;
+	margin-bottom: -8px;
+}
+.wp-list-table-wrapper .wp-list-table.widefat thead th,
+.wp-list-table-wrapper .wp-list-table.widefat thead td {
+	padding: 16px 8px;
+	border-bottom-color: rgb(200, 215, 225);
+	line-height: 1.5;
+}
+.wp-list-table-wrapper .wp-list-table.widefat td,
+.widefat thead td.check-column,
+.widefat tbody th.check-column,
+.updates-table tbody td.check-column,
+.widefat tfoot td.check-column  {
+	padding: 16px 8px;
 }
 
 /* Makes all rows have white background */


### PR DESCRIPTION
Matches table header and row padding to Calypso's, adds a table header border color, and fixes left alignment of table header cells with table rows.

Fixes #287 

#### Before
![products calypswoo test wordpress 2018-11-23 12-10-39](https://user-images.githubusercontent.com/22080/48959224-e41a9100-ef18-11e8-853c-c708865d9fe2.png)

#### After
![image](https://user-images.githubusercontent.com/22080/48959219-e11fa080-ef18-11e8-800e-3193c35b3938.png)


#### Testing
1.  Visit various tables around the dashboard that use the WP List Table.
2.  Check that the table header height is 54px and that table headers align left with table row data.