### PR TITLE
Add history state for taxonomy form toggle

### DIFF
--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -163,7 +163,15 @@
     $( '.taxonomy-form-toggle' ).click( function(e) {
         e.preventDefault();
         toggleTaxonomyForm();
+        history.pushState( {}, $( '.action-header__breadcrumbs span:last' ).text(), window.location );
     } );
+
+    /**
+     * Toggle form on back button
+     */
+    $( window ).on( 'popstate', function( e ) {
+        toggleTaxonomyForm();
+    });
 
     /**
      * Move cancel button


### PR DESCRIPTION
Adds in history to every time the taxonomy form is toggled so that the browser's back button toggles the form if previously clicking "Add New" or "Cancel."

Fixes #288 

#### Screenshots
![nov-26-2018 12-47-33](https://user-images.githubusercontent.com/10561050/48993594-9d77a180-f179-11e8-9989-106a75ea9ce1.gif)

#### Testing
1.  Visit any taxonomy under `wp-admin/edit.php?post_type=product&page=product_attributes`
2.  Click on the "Add New" and "Cancel" buttons.
3.  Check that the back button toggles the form back respective to the number of clicks on the buttons above.