### PR TITLE
Change submit actions to large buttons

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -583,7 +583,9 @@ input[type=radio]:checked:before {
 .woocommerce-BlankState a.button,
 .setup-footer a,
 .action-header .page-title-action,
-.action-header .add-new-h2 {
+.action-header .add-new-h2,
+.wp-core-ui p.submit input,
+.wp-core-ui p.submit button {
 	font-size: 14px !important;
 	padding: 7px 14px 9px !important;
 	line-height: 21px !important;


### PR DESCRIPTION
Make the primary submit buttons large size instead of small buttons.

Fixes #291 

#### Screenshots
<img width="326" alt="screen shot 2018-11-26 at 12 58 02 pm" src="https://user-images.githubusercontent.com/10561050/48993855-23481c80-f17b-11e8-900b-408aa363a0bc.png">
<img width="325" alt="screen shot 2018-11-26 at 12 58 19 pm" src="https://user-images.githubusercontent.com/10561050/48993856-23481c80-f17b-11e8-8fc4-c2573b8d15d6.png">

#### Testing
1.  Visit these pages:
* `wp-admin/edit-tags.php?taxonomy=product_cat&post_type=product` and click "Add New"
* `wp-admin/edit-tags.php?taxonomy=product_tag&post_type=product` and click "Add New"
* `wp-admin/edit.php?post_type=product&page=addons` and click any addon
* `wp-admin/edit.php?post_type=product&page=product_attributes` and click "Add New"
2.  Check that the button sizes are large.
3.  Check that no other buttons have been made large that shouldn't be.