### PR TITLE
Fix styling and alignment for nav-tabs outside of wrapper

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -718,9 +718,10 @@ html.wp-toolbar {
 #edittag {
     max-width: 100%;
 }
-#wpbody-content > .nav-tab-wrapper {
+#wpbody-content > .nav-tab-container {
 	max-width: 1040px;
-    margin: 0 auto !important;
+	margin: 0 auto 17px !important;
+    display: block;
 }
 
 /* Action header */
@@ -987,6 +988,7 @@ li#wp-admin-bar-menu-toggle {
 	-webkit-box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
 	box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
 	box-sizing: border-box;
+	margin-top: 0;
 }
 .subsubsub a, .filter-links li>a {
 	padding: 11px 15px;
@@ -1017,6 +1019,12 @@ li#wp-admin-bar-menu-toggle {
 	position: relative;
 	display: inline-block;
 	width: 100%;
+}
+.wp-admin .nav-tab-container .nav-tab-wrapper {
+	margin: 0 !important;
+	width: 100%;
+	border: 0;
+	box-shadow: 0 0 0 1px rgba(200,215,225,0.5), 0 1px 2px #e9eff3;
 }
 .wrap .nav-tab-container .subsubsub {
 	margin-bottom: 0;
@@ -1123,12 +1131,12 @@ li#wp-admin-bar-menu-toggle {
 	.nav-tab-container .subsubsub .search-box {
 		height: 46px;
 	}
-	.nav-tab-container .nav-tab-wrapper {
+	#wpbody-content .nav-tab-container .nav-tab-wrapper {
 		display: none;
 		margin: 0 !important;
 		overflow: hidden;
 	}
-	.nav-tab-container.is-open .nav-tab-wrapper {
+	#wpbody-content .nav-tab-container.is-open .nav-tab-wrapper {
 		display: block;
 	}
 	.nav-tab-container .nav-tab-wrapper a.nav-tab {

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -124,7 +124,7 @@
      * Append subnav dropdown for mobile
      */
     $( document ).ready(function() {
-        $( '.wrap .subsubsub, .wrap .nav-tab-wrapper' ).each( function() {
+        $( '#wpbody-content .subsubsub, #wpbody-content .nav-tab-wrapper' ).each( function() {
             const currentText = $( this ).find( 'a.current, .nav-tab-active' ).text();
             const $toggle = $( '<div class="nav-tab-toggle"><span class="nav-tab-toggle__current-page">' + currentText + '</span>' + icons.chevronDown + '</div>' );
             $( this ).wrap( '<div class="nav-tab-container"></div>' );


### PR DESCRIPTION
Fixes alignment, box shadow, border, and mobile dropdown for nav tab wrapper that appears outside `<div class="wrap">`.

Fixes #292 

#### Before
<img width="1678" alt="screen shot 2018-11-26 at 1 16 11 pm" src="https://user-images.githubusercontent.com/10561050/48994326-9b174680-f17d-11e8-8e94-0127e06e63ae.png">
<img width="395" alt="screen shot 2018-11-26 at 1 16 20 pm" src="https://user-images.githubusercontent.com/10561050/48994327-9b174680-f17d-11e8-8d88-08c52c932f16.png">

#### After
<img width="1677" alt="screen shot 2018-11-26 at 1 15 48 pm" src="https://user-images.githubusercontent.com/10561050/48994332-9fdbfa80-f17d-11e8-92b2-aa29bbd305ef.png">
<img width="397" alt="screen shot 2018-11-26 at 1 15 58 pm" src="https://user-images.githubusercontent.com/10561050/48994333-9fdbfa80-f17d-11e8-97bf-f907513b131e.png">

#### Testing
1.  Visit any page with a nav tab outside the `wrap`. (e.g., `/wp-admin/post-new.php?post_type=wc_product_tab` in Tab Manager)
2.  Check that box shadow is correct and that nav tab aligns properly with surround elements.  Also check the dropdown works okay on mobile.
3.  Verify no other regressions with navtabs or subnavs have occurred on other pages.