### PR TITLE
Fix error content height

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1965,7 +1965,7 @@ div.jitm-card  .jitm-banner__info .jitm-banner__title, div.jitm-card  .jitm-bann
 	margin: 0;
 	flex-direction: column;
 }
-.wc-calypso-bridge-notice-content p {
+.wp-admin .wc-calypso-bridge-notice-content p {
 	margin: 5px 0;
 	font-size: 14px;
 }


### PR DESCRIPTION
Changes the margin on p tags inside error notices so that heights match to 47px.

Fixes #293 

#### Screenshots
<img width="473" alt="screen shot 2018-11-26 at 1 22 21 pm" src="https://user-images.githubusercontent.com/10561050/48994486-81c2ca00-f17e-11e8-9113-8efa5a03d964.png">

#### Testing
1.  Visit any page with single line error notices.
2.  Check that heights of all single line notices are 47px.