### PR TITLE
Fix WC settings select dropdown

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -345,7 +345,8 @@ input[type=radio]:checked:before {
 }
 
 /* Select2 inputs */
-.wp-admin select, .select2-container .select2-selection--single {
+.wp-admin #wpwrap select,
+.select2-container .select2-selection--single {
 	-webkit-appearance: none;
 	-moz-appearance: none;
 	appearance: none;


### PR DESCRIPTION
Increases selector specificity for dropdowns to override WC form setting styles.

Fixes #294 

#### Before
<img width="716" alt="screen shot 2018-11-26 at 1 31 26 pm" src="https://user-images.githubusercontent.com/10561050/48994702-9b184600-f17f-11e8-816b-fff04178aa24.png">

#### After
<img width="768" alt="screen shot 2018-11-26 at 1 31 18 pm" src="https://user-images.githubusercontent.com/10561050/48994705-9e133680-f17f-11e8-9ca0-a792c8bf82b3.png">

#### Testing
1.  Visit `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe`
2. Check that select dropdowns are styled correctly and selected placeholder text is visible.