### PR TITLE
Update hard-coded icons to use get_gridicons

### DIFF
--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -206,8 +206,8 @@
     /**
      * Add icons to search boxes
      */
-    $( '.search-box' ).prepend( '<button class="search-box__search-icon" aria-label="' + translations.openSearch + '"><svg class="gridicon gridicons-search" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M21 19l-5.154-5.154C16.574 12.742 17 11.42 17 10c0-3.866-3.134-7-7-7s-7 3.134-7 7 3.134 7 7 7c1.42 0 2.742-.426 3.846-1.154L19 21l2-2zM5 10c0-2.757 2.243-5 5-5s5 2.243 5 5-2.243 5-5 5-5-2.243-5-5z"/></g></svg></button>' );
-    $( '.search-box' ).append( '<button class="search-box__close-icon" aria-label="' + translations.closeSearch + '"><svg class="gridicon gridicons-cross" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M18.36 19.78L12 13.41l-6.36 6.37-1.42-1.42L10.59 12 4.22 5.64l1.42-1.42L12 10.59l6.36-6.36 1.41 1.41L13.41 12l6.36 6.36z"/></g></svg></button>' );
+    $( '.search-box' ).prepend( '<button class="search-box__search-icon" aria-label="' + translations.openSearch + '">' + icons.search + '</button>' );
+    $( '.search-box' ).append( '<button class="search-box__close-icon" aria-label="' + translations.closeSearch + '">' + icons.cross + '</button>' );
 
     /**
      * Focus search input on open icon click

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -208,11 +208,12 @@ class WC_Calypso_Bridge {
 		wp_enqueue_script( 'wc-calypso-bridge-calypsoify', $asset_path . 'assets/js/calypsoify.js', array( 'jquery' ), WC_CALYPSO_BRIDGE_CURRENT_VERSION, true );
 
 		$icons = array(
-			'info'        => get_gridicon( 'gridicons-info' ),
 			'checkmark'   => get_gridicon( 'gridicons-checkmark' ),
-			'notice'      => get_gridicon( 'gridicons-notice' ),
-			'cross'       => get_gridicon( 'gridicons-cross' ),
 			'chevronDown' => get_gridicon( 'gridicons-chevron-down' ),
+			'cross'       => get_gridicon( 'gridicons-cross' ),
+			'info'        => get_gridicon( 'gridicons-info' ),
+			'notice'      => get_gridicon( 'gridicons-notice' ),
+			'search'      => get_gridicon( 'gridicons-search' ),
 		);
 		wp_localize_script(
 			'wc-calypso-bridge-calypsoify',

--- a/includes/class-wc-calypso-bridge-action-header.php
+++ b/includes/class-wc-calypso-bridge-action-header.php
@@ -80,10 +80,28 @@ class WC_Calypso_Bridge_Action_Header {
 	 * Back button
 	 */
 	public function back_button() {
+		$svg_atts = array(
+			'svg'   => array(
+				'class'           => true,
+				'aria-hidden'     => true,
+				'aria-labelledby' => true,
+				'role'            => true,
+				'xmlns'           => true,
+				'width'           => true,
+				'height'          => true,
+				'viewbox'         => true,
+			),
+			'g'     => array( 'fill' => true ),
+			'title' => array( 'title' => true ),
+			'path'  => array(
+				'd'    => true,
+				'fill' => true,
+			),
+		);
 		?>
 		<a class="action-header__ground-control-back" aria-label="<?php esc_html_e( 'Close Store', 'wc-calypso-bridge' ); ?>" href="<?php echo esc_url( 'https://wordpress.com/stats/day/' . Jetpack::build_raw_urls( home_url() ) ); ?>">
-			<svg class="gridicon gridicons-cross" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M18.36 19.78L12 13.41l-6.36 6.37-1.42-1.42L10.59 12 4.22 5.64l1.42-1.42L12 10.59l6.36-6.36 1.41 1.41L13.41 12l6.36 6.36z"></path></g></svg>
-			<svg class="gridicon gridicons-chevron-left" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M14 20l-8-8 8-8 1.414 1.414L8.828 12l6.586 6.586"></path></g></svg>
+			<?php echo wp_kses( get_gridicon( 'gridicons-cross' ), $svg_atts ); ?>
+			<?php echo wp_kses( get_gridicon( 'gridicons-chevron-left' ), $svg_atts ); ?>
 		</a>
 		<?php
 	}


### PR DESCRIPTION
Replaces hardcoded SVGs.

Fixes #312 

#### Screenshots
<img width="109" alt="screen shot 2018-11-26 at 3 33 44 pm" src="https://user-images.githubusercontent.com/10561050/48999133-b049a080-f190-11e8-9f75-91e27c82a1c4.png">
<img width="184" alt="screen shot 2018-11-26 at 3 33 47 pm" src="https://user-images.githubusercontent.com/10561050/48999134-b0e23700-f190-11e8-883d-304362fa6f99.png">


#### Testing
* Make sure back and close button on left-hand side of action bar are still correct.
* Check that search and close search icons are still correct.