### PR TITLE
Remove space on top of checklist page image

### DIFF
--- a/assets/css/setup-checklist.css
+++ b/assets/css/setup-checklist.css
@@ -7,7 +7,6 @@
 	-webkit-box-direction: normal;
 	-ms-flex-direction: row;
 	flex-direction: row;
-	margin-top: 40px;
 }
 
 .setup-header h2 {


### PR DESCRIPTION
Removes the extra space on top of this page since we've added padding around the wrapper area.

Fixes #295 

#### Before
<img width="850" alt="screen shot 2018-11-26 at 3 37 38 pm" src="https://user-images.githubusercontent.com/10561050/48999378-70cf8400-f191-11e8-8bb6-c645dc2a5e0c.png">

#### After
<img width="923" alt="screen shot 2018-11-26 at 3 37 43 pm" src="https://user-images.githubusercontent.com/10561050/48999379-72994780-f191-11e8-8811-a31a51fadd6c.png">

#### Testing
Visit `wp-admin/admin.php?page=wc-setup-checklist` and check that styling is correct.