### PR TITLE
Use search label as placeholder for search inputs

### DIFF
--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -192,8 +192,10 @@
         var $searchBoxListItem = $( '<li class="subsubsub__search-item"></li>').appendTo( $subNav );
         var $searchBox = $( '#posts-filter .search-box' );
         var $searchInput = $searchBox.find( 'input[type=search]' );
+        var $searchLabel = $searchInput.siblings( 'label' );
         var uniqueId = Math.floor(Math.random() * 26) + Date.now();
 
+        $searchInput.attr( 'placeholder', $searchLabel.text().replace(/\:$/, '') );
         $searchBox.closest( 'form' ).attr( 'data-form-id', uniqueId );
         $searchBox.attr( 'data-target-form-id', uniqueId );
         $searchBox.appendTo( $searchBoxListItem );


### PR DESCRIPTION
Uses the text from the label as the placeholder text for the search input and removes the trailing colon `:` if it exists.

Fixes #224 

#### Before
<img width="381" alt="screen shot 2018-11-26 at 3 46 37 pm" src="https://user-images.githubusercontent.com/10561050/48999756-90b37780-f192-11e8-9981-b8df84cf7e14.png">

#### After
<img width="377" alt="screen shot 2018-11-26 at 3 46 24 pm" src="https://user-images.githubusercontent.com/10561050/48999761-927d3b00-f192-11e8-92fc-13b54abc1143.png">

#### Testing
Visit pages with the search input (Products, Orders, etc) and check that the label is correctly used as the placeholder.
