### PR TITLE
Prevent WooCommerce deactivation

### DIFF
--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -36,7 +36,6 @@ class WC_Calypso_Bridge_Plugins {
 	 */
 	private function __construct() {
 		add_action( 'admin_init', array( $this, 'remove_mailchimp_redirect' ), 5 );
-		add_action( 'admin_init', array( $this, 'remove_mailchimp_redirect' ), 5 );
 		add_filter( 'plugin_action_links', array( $this, 'remove_woocommerce_deactivation_link' ), 10, 2 );
 		add_action( 'update_option_active_plugins', array( $this, 'prevent_woocommerce_deactivation' ), 10, 2 );
 		add_action( 'current_screen', array( $this, 'prevent_woocommerce_deactiation_route' ), 10, 2 );


### PR DESCRIPTION
This PR prevents WC deactivation by several means:
* Removes the deactivation links
* Prevents deactivating directly via URL
* Prevents the plugin from being removed from the active plugins array altogether

#### Screenshots
<img width="728" alt="screen shot 2018-11-27 at 1 44 47 pm" src="https://user-images.githubusercontent.com/10561050/49061026-c9af2300-f24a-11e8-930c-2310af25bd6f.png">
<img width="565" alt="screen shot 2018-11-27 at 1 49 20 pm" src="https://user-images.githubusercontent.com/10561050/49061257-44783e00-f24b-11e8-9779-acb6af7bfdb5.png">

#### Testing
1.  Visit `/wp-admin/plugins.php` and note the lack of a "Deactivate" link next to WooCommerce.
2.  Visit the deactivation link directly `/plugins.php?action=deactivate&plugin=woocommerce%2Fwoocommerce.php&plugin_status=all&paged=1&s&_wpnonce=844b58b1fb` - the plugin should not be deactivated and you should recieve a notice stating it cannot be deactivated.
3.  If you really want to test the limits, try and run `deactivate_plugins( 'woocommerce/woocommerce.php' );` inside a plugin and note that the plugin is still active.