### PR TITLE
Remove Akismet dismiss button

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2119,6 +2119,11 @@ div.jitm-card  .jitm-banner__info .jitm-banner__title, div.jitm-card  .jitm-bann
 	display: none;
 }
 
+/* Akismet notices */
+#akismet-privacy-notice-admin-notice .notice-dismiss {
+	display: none;
+}
+
 /* Taxonomy page */
 .edit-tags-php #col-left,
 .product_page_product_attributes #col-left {


### PR DESCRIPTION
Removes the dismiss notice button since "Enable" or "Disable" are the actions inside the notice that need to be taken to persist the effects.

#### Screenshots
<img width="923" alt="screen shot 2018-11-27 at 2 20 26 pm" src="https://user-images.githubusercontent.com/10561050/49062722-147f6980-f250-11e8-923d-dfe89a23e7a4.png">

#### Testing
1.  Visit any page with Akismet notice.
2.  Check that the dismiss button is hidden from the notice.