### PR TITLE
Move setup menu item to top level

### DIFF
--- a/includes/class-wc-calypso-bridge-action-header.php
+++ b/includes/class-wc-calypso-bridge-action-header.php
@@ -149,8 +149,10 @@ class WC_Calypso_Bridge_Action_Header {
 
 		$parent = false;
 		foreach ( $menu as $top_level_menu_item ) {
-			if ( $top_level_menu_item[2] === $page_parent && $crumbs[0]['name'] !== $top_level_menu_item[0] ) {
+			$parent_name = ! empty( $top_level_menu_item[3] ) ? $top_level_menu_item[3] : $top_level_menu_item[0];
+			if ( $top_level_menu_item[2] === $page_parent && $crumbs[0]['name'] !== $parent_name ) {
 				$parent = $top_level_menu_item;
+				break;
 			}
 		}
 
@@ -158,7 +160,7 @@ class WC_Calypso_Bridge_Action_Header {
 			array_unshift(
 				$crumbs,
 				array(
-					'name' => $parent[0],
+					'name' => $parent_name,
 					'url'  => $this->get_parent_url( $parent[2] ),
 				)
 			);
@@ -199,7 +201,7 @@ class WC_Calypso_Bridge_Action_Header {
 					<?php if ( isset( $crumb['url'] ) ) { ?>
 						<a href="<?php echo esc_url( admin_url( $crumb['url'] ) ); ?>">
 					<?php } ?>
-						<?php echo esc_html( $crumb['name'] ); ?>
+						<?php echo esc_html( wp_strip_all_tags( $crumb['name'] ) ); ?>
 					<?php if ( isset( $crumb['url'] ) ) { ?>
 						</a>
 					<?php } ?>

--- a/includes/connect/wc-calypso-bridge.php
+++ b/includes/connect/wc-calypso-bridge.php
@@ -1,5 +1,15 @@
 <?php
-wc_calypso_bridge_connect_page( array(
-	'screen_id' => 'woocommerce_page_wc-setup-checklist',
-	'menu'      => 'woocommerce',
-) );
+/**
+ * WC Calypso Bridge pages
+ *
+ * @package WC_Calypso_Bridge/Connect
+ * @since   1.0.0
+ * @version 1.0.0
+ */
+
+wc_calypso_bridge_connect_page(
+	array(
+		'screen_id' => 'toplevel_page_wc-setup-checklist',
+		'menu'      => 'wc-setup-checklist',
+	)
+);


### PR DESCRIPTION
Sets the "Setup" menu as a top level item so that it's always visible and not hidden when the WooCommerce menu is collapsed.

#### Screenshots
<img width="321" alt="screen shot 2018-11-27 at 3 06 10 pm" src="https://user-images.githubusercontent.com/10561050/49064497-0fbdb400-f256-11e8-9fcf-010b7e64584c.png">

#### Testing
1.  Visit any dashboard page in Calypsoify and confirm that Setup is now a top level menu item.
2.  Check that the page is still accessible from the same URL ( `wp-admin/admin.php?page=wc-setup-checklist` ).
3.  Check that "Setup" breadcrumbs are correct and don't show html span tag.