### PR TITLE
Add setup checklist return notice

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2214,7 +2214,7 @@ div.jitm-card  .jitm-banner__info .jitm-banner__title, div.jitm-card  .jitm-bann
 	height: 100%;
 	margin: 0 0 0 auto !important;
 	position: static;
-	padding: 12px !important;
+	padding: 12px 12px 0 12px !important;
 }
 .notice-dismiss:before {
 	display: none;

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -12,65 +12,6 @@
     } );
 
     /**
-     * Record checklist task click
-     */
-    $( '.checklist__task-title a, .checklist__task-secondary a' ).click( function() {
-        const $task = $( this ).closest( '.checklist__task' )
-        const status = $task.hasClass( 'is-completed' ) ? 'complete' : 'incomplete';
-        const taskId = $task.data('id');
-        const taskTitle = $task.data('title');
-        const href = $( this ).attr('href');
-        $( this ).addClass( 'disabled' );
-
-        if ( window.jpTracksAJAX ) {
-            const trackedEvent = window.jpTracksAJAX.record_ajax_event(
-                'atomic_wc_tasklist_click',
-                'click',
-                {
-                    id: taskId,
-                    title: taskTitle, 
-                    status: status,
-                }
-            );
-            trackedEvent.complete( function() {
-                window.location = href;
-            } );
-        } else {
-            window.location = href;
-        }
-    } );
-
-    /**
-     * Track 'I'm done' completion on task list
-     */
-    $( '.setup-footer a' ).click( function(e) {
-        e.preventDefault();
-        const progressNumber = $( '.checklist__header-progress-number' ).text().split( '/' );
-        const complete = progressNumber[0];
-        const total = progressNumber[1];
-        const percentage = parseFloat( complete / total ).toFixed( 2 ) * 100;
-        const href = $( this ).attr('href');
-        $( this ).addClass( 'disabled' );
-
-        if ( window.jpTracksAJAX ) {
-            const trackedEvent = window.jpTracksAJAX.record_ajax_event(
-                'atomic_wc_tasklist_finish',
-                'click',
-                { 
-                    complete: complete,
-                    total: total,
-                    percentage: percentage
-                }
-            );
-            trackedEvent.complete( function() {
-                window.location = href;
-            } );
-        } else {
-            window.location = href;
-        }
-    } );
-
-    /**
      * Append icons to notices
      */
     $( 'div.notice, div.error, div.updated, div.warning' ).each( function() {

--- a/assets/js/setup-checklist.js
+++ b/assets/js/setup-checklist.js
@@ -18,4 +18,115 @@
 		$( '.checklist__header-complete-label' ).text( i18nstrings.hide );
 	} );
 
+	/**
+     * Track 'I'm done' completion on task list
+     */
+    $( '.setup-footer a' ).click( function(e) {
+        e.preventDefault();
+        const progressNumber = $( '.checklist__header-progress-number' ).text().split( '/' );
+        const complete = progressNumber[0];
+        const total = progressNumber[1];
+        const percentage = parseFloat( complete / total ).toFixed( 2 ) * 100;
+        const href = $( this ).attr('href');
+        $( this ).addClass( 'disabled' );
+
+        if ( window.jpTracksAJAX ) {
+            const trackedEvent = window.jpTracksAJAX.record_ajax_event(
+                'atomic_wc_tasklist_finish',
+                'click',
+                { 
+                    complete: complete,
+                    total: total,
+                    percentage: percentage
+                }
+            );
+            trackedEvent.complete( function() {
+                window.location = href;
+            } );
+        } else {
+            window.location = href;
+        }
+	} );
+	
+	/**
+     * Checklist task click event
+     */
+    $( '.checklist__task-title a, .checklist__task-secondary a' ).click( function( e ) {
+        e.preventDefault();
+        const $task = $( this ).closest( '.checklist__task' )
+        const status = $task.hasClass( 'is-completed' ) ? 'complete' : 'incomplete';
+        const taskId = $task.data('id');
+        const taskTitle = $task.data('title');
+        const href = $( this ).attr('href');
+        $( this ).addClass( 'disabled' );
+
+        $.when(
+            trackTaskClick( taskId, taskTitle, status ),
+            setActiveTask( taskId )
+        ).done( function() {
+            window.location = href;
+        } );
+
+    } );
+
+    /**
+     * Track task clicks in Jetpack if enabled
+     *
+     * @param {string} taskId Task ID
+     * @param {string} taskTitle Task title
+     * @param {string} status Status - complete/incomplete
+     */
+    function trackTaskClick( taskId, taskTitle, status ) {
+        if ( window.jpTracksAJAX ) {
+            return window.jpTracksAJAX.record_ajax_event(
+                'atomic_wc_tasklist_click',
+                'click',
+                {
+                    id: taskId,
+                    title: taskTitle, 
+                    status: status,
+                }
+            );
+        } else {
+            return true;
+        }
+    }
+
+	/**
+	 * Sets the active task for return notices
+	 *
+	 * @param {string} taskId Task ID
+	 */
+    function setActiveTask( taskId ) {
+        return $.ajax(
+            {
+                url: wccb.ajaxUrl,
+                data: (
+                    {
+						action: 'set_woocommerce_setup_active_task',
+						nonce: wccb.nonce,
+                        taskId: taskId
+                    }
+                ),
+            }
+        );
+	}
+	
+	/**
+	 * Persist setup checklist notice dismiss
+	 */
+	$( document ).on( 'click', '#woocommerce-setup-return-notice .notice-dismiss', function() {
+		$.ajax(
+            {
+                url: wccb.ajaxUrl,
+                data: (
+                    {
+						action: 'clear_woocommerce_setup_active_task',
+						nonce: wccb.nonce,
+                    }
+                ),
+            }
+        );
+	} );
+
 } )( jQuery );

--- a/assets/js/setup-checklist.js
+++ b/assets/js/setup-checklist.js
@@ -1,6 +1,6 @@
 ( function( $ ) {
 	'use strict';
-
+	
 	/**
 	 * Toggle address line 2 on click
 	 */
@@ -10,123 +10,122 @@
 		$( '.checklist-card.is-completed' ).hide();
 		$( '.checklist__header-complete-label' ).text( i18nstrings.show );
 	} );
-
+	
 	$( document ).on( 'click', '#checklist:not(.is-expanded) .checklist__toggle', function( e ) {
 		e.preventDefault();
 		$( '#checklist' ).addClass( 'is-expanded' );
 		$( '.checklist-card.is-completed' ).show();
 		$( '.checklist__header-complete-label' ).text( i18nstrings.hide );
 	} );
-
-	/**
-     * Track 'I'm done' completion on task list
-     */
-    $( '.setup-footer a' ).click( function(e) {
-        e.preventDefault();
-        const progressNumber = $( '.checklist__header-progress-number' ).text().split( '/' );
-        const complete = progressNumber[0];
-        const total = progressNumber[1];
-        const percentage = parseFloat( complete / total ).toFixed( 2 ) * 100;
-        const href = $( this ).attr('href');
-        $( this ).addClass( 'disabled' );
-
-        if ( window.jpTracksAJAX ) {
-            const trackedEvent = window.jpTracksAJAX.record_ajax_event(
-                'atomic_wc_tasklist_finish',
-                'click',
-                { 
-                    complete: complete,
-                    total: total,
-                    percentage: percentage
-                }
-            );
-            trackedEvent.complete( function() {
-                window.location = href;
-            } );
-        } else {
-            window.location = href;
-        }
-	} );
 	
 	/**
-     * Checklist task click event
-     */
-    $( '.checklist__task-title a, .checklist__task-secondary a' ).click( function( e ) {
-        e.preventDefault();
-        const $task = $( this ).closest( '.checklist__task' )
-        const status = $task.hasClass( 'is-completed' ) ? 'complete' : 'incomplete';
-        const taskId = $task.data('id');
-        const taskTitle = $task.data('title');
-        const href = $( this ).attr('href');
-        $( this ).addClass( 'disabled' );
-
-        $.when(
-            trackTaskClick( taskId, taskTitle, status ),
-            setActiveTask( taskId )
-        ).done( function() {
-            window.location = href;
-        } );
-
-    } );
-
-    /**
-     * Track task clicks in Jetpack if enabled
-     *
-     * @param {string} taskId Task ID
-     * @param {string} taskTitle Task title
-     * @param {string} status Status - complete/incomplete
-     */
-    function trackTaskClick( taskId, taskTitle, status ) {
-        if ( window.jpTracksAJAX ) {
-            return window.jpTracksAJAX.record_ajax_event(
-                'atomic_wc_tasklist_click',
-                'click',
-                {
-                    id: taskId,
-                    title: taskTitle, 
-                    status: status,
-                }
-            );
-        } else {
-            return true;
-        }
-    }
-
+	 * Track 'I'm done' completion on task list
+	 */
+	$( '.setup-footer a' ).click( function(e) {
+		e.preventDefault();
+		const progressNumber = $( '.checklist__header-progress-number' ).text().split( '/' );
+		const complete = progressNumber[0];
+		const total = progressNumber[1];
+		const percentage = parseFloat( complete / total ).toFixed( 2 ) * 100;
+		const href = $( this ).attr('href');
+		$( this ).addClass( 'disabled' );
+		
+		if ( window.jpTracksAJAX ) {
+			const trackedEvent = window.jpTracksAJAX.record_ajax_event(
+				'atomic_wc_tasklist_finish',
+				'click',
+				{ 
+					complete: complete,
+					total: total,
+					percentage: percentage
+				}
+			);
+			trackedEvent.complete( function() {
+				window.location = href;
+			} );
+		} else {
+			window.location = href;
+		}
+	} );
+		
+	/**
+	 * Checklist task click event
+	 */
+	$( '.checklist__task-title a, .checklist__task-secondary a' ).click( function( e ) {
+		e.preventDefault();
+		const $task = $( this ).closest( '.checklist__task' )
+		const status = $task.hasClass( 'is-completed' ) ? 'complete' : 'incomplete';
+		const taskId = $task.data('id');
+		const taskTitle = $task.data('title');
+		const href = $( this ).attr('href');
+		$( this ).addClass( 'disabled' );
+		
+		$.when(
+			trackTaskClick( taskId, taskTitle, status ),
+			setActiveTask( taskId )
+		).done( function() {
+			window.location = href;
+		} );
+	} );
+			
+	/**
+	 * Track task clicks in Jetpack if enabled
+	 *
+	 * @param {string} taskId Task ID
+	 * @param {string} taskTitle Task title
+	 * @param {string} status Status - complete/incomplete
+	 */
+	function trackTaskClick( taskId, taskTitle, status ) {
+		if ( window.jpTracksAJAX ) {
+			return window.jpTracksAJAX.record_ajax_event(
+				'atomic_wc_tasklist_click',
+				'click',
+				{
+					id: taskId,
+					title: taskTitle, 
+					status: status,
+				}
+			);
+		} else {
+			return true;
+		}
+	}
+				
 	/**
 	 * Sets the active task for return notices
 	 *
 	 * @param {string} taskId Task ID
 	 */
-    function setActiveTask( taskId ) {
-        return $.ajax(
-            {
-                url: wccb.ajaxUrl,
-                data: (
-                    {
+	function setActiveTask( taskId ) {
+		return $.ajax(
+			{
+				url: wccb.ajaxUrl,
+				data: (
+					{
 						action: 'set_woocommerce_setup_active_task',
 						nonce: wccb.nonce,
-                        taskId: taskId
-                    }
-                ),
-            }
-        );
+						taskId: taskId
+					}
+				),
+			}
+		);
 	}
-	
+						
 	/**
 	 * Persist setup checklist notice dismiss
 	 */
 	$( document ).on( 'click', '#woocommerce-setup-return-notice .notice-dismiss', function() {
 		$.ajax(
-            {
-                url: wccb.ajaxUrl,
-                data: (
-                    {
+			{
+				url: wccb.ajaxUrl,
+				data: (
+					{
 						action: 'clear_woocommerce_setup_active_task',
 						nonce: wccb.nonce,
-                    }
-                ),
-            }
-        );
+					}
+				),
+			}
+		);
 	} );
-
+			
 } )( jQuery );

--- a/includes/class-wc-calypso-bridge-admin-setup-checklist.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-checklist.php
@@ -167,8 +167,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 					<p>
 						<?php
 						echo sprintf(
-							wp_kses( 'You\'ve completed the task "%s!"  Ready to continue with the setup checklist?  <a href="%s">Back to setup</a>.', 'wc-calypso-bridge' ),
-							esc_attr( $active_task['title'] ),
+							wp_kses( 'Ready to continue with the setup checklist?  <a href="%s">Back to setup</a>.', 'wc-calypso-bridge' ),
 							esc_url( admin_url( 'admin.php?page=wc-setup-checklist' ) )
 						);
 						?>

--- a/includes/class-wc-calypso-bridge-admin-setup-checklist.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-checklist.php
@@ -104,7 +104,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 			'wccb',
 			array(
 				'ajaxUrl' => admin_url( 'admin-ajax.php' ),
-				'nonce' => wp_create_nonce( 'woocommerce_setup_active_task' ),
+				'nonce'   => wp_create_nonce( 'woocommerce_setup_active_task' ),
 			)
 		);
 	}
@@ -167,7 +167,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 					<p>
 						<?php
 						echo sprintf(
-							wp_kses( 'You\'ve completed the task "%s!"  Ready to continue with the setup checklist?  <a href="%s">Back to setup</a>.', 'wc-calypso-brigde' ),
+							wp_kses( 'You\'ve completed the task "%s!"  Ready to continue with the setup checklist?  <a href="%s">Back to setup</a>.', 'wc-calypso-bridge' ),
 							esc_attr( $active_task['title'] ),
 							esc_url( admin_url( 'admin.php?page=wc-setup-checklist' ) )
 						);


### PR DESCRIPTION
Adds a notice to return to the setup checklist after navigating away. Fixes #299.

#### The notice is shown when
* User has clicked on a task from the checklist
* AND the task condition is met (complete)

#### The notice is hidden when
* The user clicks the dismiss "X" icon in the notice (persisted)
* The user returns to the setup checklist page
* The user 'uncompletes' a task

#### Screenshots
<img width="842" alt="screen shot 2018-11-27 at 5 49 43 pm" src="https://user-images.githubusercontent.com/10561050/49073400-58349c00-f26d-11e8-95cf-5fffe4e12e36.png">

#### Testing
1.  Visit the setup checklist `wp-admin/admin.php?page=wc-setup-checklist`
2.  Click on any task item.
3.  Complete that task's requirements if incomplete and you should see the notice to return to checklist.  If already completed, you should see the notice immediately.
4.  The notice will be hidden by either the dismiss button or navigating back to the setup checklist page.

#### Feedback needed
* Do we want to show these notices even after clicking on an already completed item (as it is currently)?
* Do we want to add in completion strings for each task item?  E.g., `You've finished setting up Stripe!` instead of `You've completed the task "Setup payments with Stripe!"`