### PR TITLE
Make new post pages full width

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -724,7 +724,8 @@ html.wp-toolbar {
 .post-type-product.edit-php .wrap,
 .post-type-product.post-php .wrap,
 .toplevel_page_wcpv-commissions .wrap,
-.post-type-wc_booking .wrap {
+.post-type-wc_booking .wrap,
+.post-new-php .wrap {
 	max-width: none;
 }
 #edittag {


### PR DESCRIPTION
Makes new post pages wider to accommodate meta boxes and other content.
#### Before
<img width="1619" alt="screen shot 2018-11-27 at 6 02 09 pm" src="https://user-images.githubusercontent.com/10561050/49074138-09880180-f26f-11e8-8ebc-50d1062c1db6.png">

#### After
<img width="1618" alt="screen shot 2018-11-27 at 6 01 58 pm" src="https://user-images.githubusercontent.com/10561050/49074137-09880180-f26f-11e8-88b4-836fd3039fc4.png">

#### Testing
1.  Visit the new product page `wp-admin/post-new.php?post_type=product`
2.  Check that it's once again full width ⬅️ ➡️ 