### PR TITLE
Fix a JS error preventing "my sites" from working during the OBW

### DIFF
--- a/assets/js/calypsoify-obw.js
+++ b/assets/js/calypsoify-obw.js
@@ -1,3 +1,5 @@
+var pagenow = 'wc-setup';
+
 ( function( $ ) {
     'use strict';
     


### PR DESCRIPTION
Fixes #338.

`Uncaught ReferenceError: pagenow is not defined` is displayed when using the onboarding wizard + Jetpack 6.8. It come's from Jetpack's JS. It prevents the "My Sites" link from being used.

We can just define the `pagenow` value as `wc-setup` since this file is only loaded during the wizard. I'll open up a Jetpack issue to add an undefined check.