### PR TITLE
Only show Apple Pay notice on settings page

### DIFF
--- a/includes/class-wc-calypso-bridge-hide-alerts.php
+++ b/includes/class-wc-calypso-bridge-hide-alerts.php
@@ -40,7 +40,7 @@ class WC_Calypso_Bridge_Hide_Alerts {
 		add_filter( 'woocommerce_helper_suppress_connect_notice', '__return_true' );
 		add_filter( 'woocommerce_show_admin_notice', '__return_false' );
 
-		add_action( 'admin_head', array( $this, 'hide_apple_pay_alert_on_non_settings_pages' ) );
+		add_action( 'admin_head', array( $this, 'hide_alerts_on_non_settings_pages' ) );
 	}
 
 	/**
@@ -53,11 +53,12 @@ class WC_Calypso_Bridge_Hide_Alerts {
 	}
 
 	/**
-	 * Prevents the Apple Pay alert from being shown on pages besides settings pages.
+	 * Prevents some alerts like the Apple Pay alert and Akismet from being shown on pages besides settings pages / core wp-admin pages.
 	 */
-	public function hide_apple_pay_alert_on_non_settings_pages() {
-		if ( empty( $_GET['page'] ) || 'wc-settings' !== $_GET['page'] ) {
+	public function hide_alerts_on_non_settings_pages() {
+		if ( is_wc_calypso_bridge_page() && ( empty( $_GET['page'] ) || 'wc-settings' !== $_GET['page'] ) ) {
 			WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', 'WC_Stripe_Apple_Pay_Registration', 'admin_notices', 10 );
+			remove_action( 'admin_notices', array( 'Akismet_Admin', 'display_notice' ) );
 		}
 	}
 

--- a/includes/class-wc-calypso-bridge-hide-alerts.php
+++ b/includes/class-wc-calypso-bridge-hide-alerts.php
@@ -39,6 +39,8 @@ class WC_Calypso_Bridge_Hide_Alerts {
 		add_action( 'admin_head', array( $this, 'suppress_admin_notices' ) );
 		add_filter( 'woocommerce_helper_suppress_connect_notice', '__return_true' );
 		add_filter( 'woocommerce_show_admin_notice', '__return_false' );
+
+		add_action( 'admin_head', array( $this, 'hide_apple_pay_alert_on_non_settings_pages' ) );
 	}
 
 	/**
@@ -47,6 +49,15 @@ class WC_Calypso_Bridge_Hide_Alerts {
 	public function hide_woo_obw_alert() {
 		if ( class_exists( 'WC_Admin_Notices' ) ) {
 			WC_Admin_Notices::remove_notice( 'install' );
+		}
+	}
+
+	/**
+	 * Prevents the Apple Pay alert from being shown on pages besides settings pages.
+	 */
+	public function hide_apple_pay_alert_on_non_settings_pages() {
+		if ( empty( $_GET['page'] ) || 'wc-settings' !== $_GET['page'] ) {
+			WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', 'WC_Stripe_Apple_Pay_Registration', 'admin_notices', 10 );
 		}
 	}
 


### PR DESCRIPTION
Closes #321.

Per https://trello.com/c/enIthoPk/86-apple-pay-domain-failure-message-suppress-fix-keep, this might be handled automatically with the webhook solution Hydra has mentioned.

In the meantime, for the initial launch, I think it makes sense to limit this notice to settings pages. That way, it won't be in your face during the other screens, but can still be surfaced enough to take action on. It will also be present when they review shipping settings / Stripe.

This also follows the pattern with some other errors that only show in WC settings:

<img width="1094" alt="screen shot 2018-11-27 at 11 29 16 am" src="https://user-images.githubusercontent.com/689165/49096359-6caa7180-f238-11e8-9e06-2514462cacbb.png">

To Test:
* Add a stripe key/secret. These can be bogus. Verify you can get the notice show.
* Apply branch.
* View a settings page and see the notice.
* View another page, like add a product, and see the notice does not display.