### PR TITLE
Flush rewrite rules during setup.

### DIFF
--- a/includes/class-wc-calypso-bridge-admin-setup-wizard.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-wizard.php
@@ -374,6 +374,7 @@ class WC_Calypso_Bridge_Admin_Setup_Wizard extends WC_Admin_Setup_Wizard {
 			}
 		}
 		activate_plugin( 'woocommerce-shipping-ups/woocommerce-shipping-ups.php' );
+		flush_rewrite_rules();
 	}
 
 	/**


### PR DESCRIPTION
This PR is an attempt at fixing #324. After creating a store and then creating a product, the permalink won't work. I was able to flush the rewrite rules under Settings > Permalinks, and then the product links work. I think the rules are never flushed after WooCommerce is installed, since we are installing it automatically -- so flushing the rules during setup should fix this. If anyone has other ideas I'm open to them.

To Test:
* Delete 'rewrite_rules' from your `wp_options` table.
* Visit `/wp-admin/admin.php?page=wc-setup` and verify no rules are set still in the option.
* Save your address.
* Confirm `rewrite_rules` exists again, and contains `product/([^/]+)(` somewhere in it.