### PR TITLE
Remove product attribute descriptions

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -127,13 +127,20 @@ class WC_Calypso_Bridge {
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-page-controller.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-menus.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-plugins.php';
+			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-breadcrumbs.php';
+			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-pagination.php';
+			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-taxonomies.php';
+			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-action-header.php';
+			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-tables.php';
 			include_once dirname( __FILE__ ) . '/includes/gutenberg.php';
 			$connect_files = glob( dirname( __FILE__ ) . '/includes/connect/*.php' );
 			foreach ( $connect_files as $connect_file ) {
 				include_once $connect_file;
 			}
 
-			add_action( 'current_screen', array( $this, 'load_ui_elements' ) );
+			add_action( 'admin_print_styles', array( $this, 'enqueue_calypsoify_scripts' ), 11 );
+			add_action( 'admin_init', array( $this, 'remove_woocommerce_core_footer_text' ) );
+			add_filter( 'admin_footer_text', array( $this, 'update_woocommerce_footer' ) );
 		}
 	}
 
@@ -171,24 +178,6 @@ class WC_Calypso_Bridge {
 			return false;
 		}
 		return true;
-	}
-
-	/**
-	 * Updates required UI elements for calypso bridge pages only.
-	 */
-	public function load_ui_elements() {
-		if ( is_wc_calypso_bridge_page() || ( isset( $_GET['page'] ) && 'wc-setup' === $_GET['page'] ) ) {
-			add_action( 'admin_print_styles', array( $this, 'enqueue_calypsoify_scripts' ), 11 );
-
-			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-breadcrumbs.php';
-			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-pagination.php';
-			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-taxonomies.php';
-			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-action-header.php';
-			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-tables.php';
-
-			add_action( 'admin_init', array( $this, 'remove_woocommerce_core_footer_text' ) );
-			add_filter( 'admin_footer_text', array( $this, 'update_woocommerce_footer' ) );
-		}
 	}
 
 	/**

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -127,20 +127,13 @@ class WC_Calypso_Bridge {
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-page-controller.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-menus.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-plugins.php';
-			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-breadcrumbs.php';
-			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-pagination.php';
-			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-taxonomies.php';
-			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-action-header.php';
-			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-tables.php';
 			include_once dirname( __FILE__ ) . '/includes/gutenberg.php';
 			$connect_files = glob( dirname( __FILE__ ) . '/includes/connect/*.php' );
 			foreach ( $connect_files as $connect_file ) {
 				include_once $connect_file;
 			}
 
-			add_action( 'admin_print_styles', array( $this, 'enqueue_calypsoify_scripts' ), 11 );
-			add_action( 'admin_init', array( $this, 'remove_woocommerce_core_footer_text' ) );
-			add_filter( 'admin_footer_text', array( $this, 'update_woocommerce_footer' ) );
+			add_action( 'current_screen', array( $this, 'load_ui_elements' ) );
 		}
 	}
 
@@ -178,6 +171,24 @@ class WC_Calypso_Bridge {
 			return false;
 		}
 		return true;
+	}
+
+	/**
+	 * Updates required UI elements for calypso bridge pages only.
+	 */
+	public function load_ui_elements() {
+		if ( is_wc_calypso_bridge_page() || ( isset( $_GET['page'] ) && 'wc-setup' === $_GET['page'] ) ) {
+			add_action( 'admin_print_styles', array( $this, 'enqueue_calypsoify_scripts' ), 11 );
+
+			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-breadcrumbs.php';
+			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-pagination.php';
+			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-taxonomies.php';
+			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-action-header.php';
+			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-tables.php';
+
+			add_action( 'admin_init', array( $this, 'remove_woocommerce_core_footer_text' ) );
+			add_filter( 'admin_footer_text', array( $this, 'update_woocommerce_footer' ) );
+		}
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-taxonomies.php
+++ b/includes/class-wc-calypso-bridge-taxonomies.php
@@ -38,6 +38,7 @@ class WC_Calypso_Bridge_Taxonomies {
 		add_action( 'add_tag_form_pre', array( $this, 'add_action_button' ) );
 		add_action( 'woocommerce_after_add_attribute_fields', array( $this, 'add_action_button' ) );
 		add_action( 'wp_loaded', array( $this, 'remove_taxonomy_form_description' ) );
+		add_action( 'wp_loaded', array( $this, 'remove_product_attribute_description' ) );
 		add_action( 'admin_head', array( $this, 'localize_taxonomy_url' ) );
 	}
 
@@ -64,6 +65,19 @@ class WC_Calypso_Bridge_Taxonomies {
 	public function remove_taxonomy_form_description() {
 		// @TODO: Uncomment the following line if https://github.com/woocommerce/woocommerce/pull/21884 is merged into WC core.
 		// remove_action( 'product_cat_pre_add_form', array( WC_Admin_Taxonomies::get_instance(), 'product_cat_description' ), 10 );
+	}
+
+	/**
+	 * Remove product attribute descriptions
+	 */
+	public function remove_product_attribute_description() {
+		$attribute_taxonomies = wc_get_attribute_taxonomies();
+
+		if ( ! empty( $attribute_taxonomies ) ) {
+			foreach ( $attribute_taxonomies as $attribute ) {
+				WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'pa_' . $attribute->attribute_name . '_pre_add_form', 'WC_Admin_Taxonomies', 'product_attribute_description', 10 );
+			}
+		}
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-taxonomies.php
+++ b/includes/class-wc-calypso-bridge-taxonomies.php
@@ -37,8 +37,8 @@ class WC_Calypso_Bridge_Taxonomies {
 	private function __construct() {
 		add_action( 'add_tag_form_pre', array( $this, 'add_action_button' ) );
 		add_action( 'woocommerce_after_add_attribute_fields', array( $this, 'add_action_button' ) );
-		add_action( 'wp_loaded', array( $this, 'remove_taxonomy_form_description' ) );
-		add_action( 'wp_loaded', array( $this, 'remove_product_attribute_description' ) );
+		add_action( 'admin_head', array( $this, 'remove_taxonomy_form_description' ) );
+		add_action( 'admin_head', array( $this, 'remove_product_attribute_description' ) );
 		add_action( 'admin_head', array( $this, 'localize_taxonomy_url' ) );
 	}
 


### PR DESCRIPTION
Removes the product attribute descriptions that include notes about deleting a term that don't apply to the Calypsoified separated forms.

@justinshreve This PR removes the `load_ui_elements()` method since some of these methods can't be called within the `current_screen` hook.  The dependencies satisfied checks for Calypsoify, was this screen check still needed?

Fixes #304 

#### Before
<img width="1071" alt="screen shot 2018-11-28 at 11 25 11 am" src="https://user-images.githubusercontent.com/10561050/49126872-48b26300-f300-11e8-953c-41a25203c96a.png">

#### After
<img width="1062" alt="screen shot 2018-11-28 at 11 20 47 am" src="https://user-images.githubusercontent.com/10561050/49126860-418b5500-f300-11e8-926f-f7ed29867f89.png">

#### Testing
1.  Visit `wp-admin/edit.php?post_type=product&page=product_attributes`
2.  Click on any term and click "Add new"
3.  Verify that the delete notice above the form has been removed.