### PR TITLE
Remove clear icon from select2

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -391,13 +391,7 @@ input[type=radio]:checked:before {
 	color: #2e4453;
 }
 .select2-container--default .select2-selection--single .select2-selection__clear {
-	font-size: 0;
-}
-.select2-container--default .select2-selection--single .select2-selection__clear:before {
-	content: '\2715';
-	color: #c3d7e2;
-	font-size: 14px;
-	line-height: 24px;
+	display: none;
 }
 
 /* Select2 tags/tokens */


### PR DESCRIPTION
Clear icon is no longer being used.

Fixes #319 

#### Before
<img width="599" alt="screen shot 2018-11-28 at 11 34 53 am" src="https://user-images.githubusercontent.com/10561050/49127282-bb700e00-f301-11e8-9b86-1c82993992a8.png">

#### After
<img width="613" alt="screen shot 2018-11-28 at 11 34 20 am" src="https://user-images.githubusercontent.com/10561050/49127291-c034c200-f301-11e8-8474-7f09dfa24486.png">

#### Testing
1.  Visit `wp-admin/admin.php?page=wc-settings&tab=advanced`
2.  Check that clear icons have been removed from select2 boxes.