### PR TITLE
Fix setup checklist redirect when logged out

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -296,7 +296,10 @@ class WC_Calypso_Bridge {
 	 * Activates Calypsoify if the setup page is visited directly and it's not previously active.
 	 */
 	public function check_setup_param() {
-		if ( isset( $_GET['page'] ) && 'wc-setup-checklist' === $_GET['page'] ) { // WPCS: CSRF ok.
+		if ( current_user_can( 'manage_woocommerce' )
+			&& isset( $_GET['page'] ) // WPCS: CSRF ok.
+			&& 'wc-setup-checklist' === $_GET['page'] // WPCS: CSRF ok.
+		) {
 			if ( 1 !== (int) get_user_meta( get_current_user_id(), 'calypsoify', true ) ) {
 				update_user_meta( get_current_user_id(), 'calypsoify', 1 );
 				wp_safe_redirect( admin_url( 'admin.php?page=wc-setup-checklist' ) );

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -37,7 +37,7 @@ class WC_Calypso_Bridge {
 	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'check_calyposify_param' ), 1 );
-		add_action( 'admin_init', array( $this, 'check_setup_param' ) );
+		add_action( 'init', array( $this, 'check_setup_param' ) );
 		add_action( 'init', array( $this, 'possibly_load_calypsoify' ), 2 );
 		if ( class_exists( 'Storefront_Powerpack' ) ) {
 			$this->disable_powerpack_features();

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -37,7 +37,7 @@ class WC_Calypso_Bridge {
 	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'check_calyposify_param' ), 1 );
-		add_action( 'init', array( $this, 'check_setup_param' ) );
+		add_action( 'admin_init', array( $this, 'check_setup_param' ) );
 		add_action( 'init', array( $this, 'possibly_load_calypsoify' ), 2 );
 		if ( class_exists( 'Storefront_Powerpack' ) ) {
 			$this->disable_powerpack_features();


### PR DESCRIPTION
Run the check param on `admin_init` to avoid the `wp_safe_redirect` when activating Calypsoify.

Fixes #322 

#### Testing
1.  Visit `wp-admin/admin.php?page=wc-setup-checklist` and make sure things are still working as expected.
2.  Visit `wp-admin/admin.php?page=wc-setup-checklist` when logged out and check that login screen is shown.