### PR TITLE
Restore OBW payment settings

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1771,9 +1771,16 @@ table.widefat {
 .wc-wizard-service-item.klarna-logo .wc-wizard-service-name img {
 	display: none;
 }
-.wc-wizard-service-item.checked .wc-wizard-service-settings,
-.wc-wizard-services-list-toggle.checked .wc-wizard-service-settings {
-	display: none;
+.wc-wizard-service-setting-ppec_paypal_reroute_requests .payment-checkbox-input,
+.wc-wizard-service-setting-stripe_create_account .payment-checkbox-input {
+	width: auto;
+	margin-top: 3px;
+	position: relative;
+}
+.wc-wizard-service-setting-ppec_paypal_reroute_requests .payment-checkbox-input:before,
+.wc-wizard-service-setting-stripe_create_account .payment-checkbox-input:before {
+	position: absolute;
+	left: 0;
 }
 @media screen and (max-width:600px) {
 	.wc-wizard-service-item, .wc-wizard-services-list-toggle {


### PR DESCRIPTION
Adds back in the payment settings requested in p1542732682554700-slack-wpcom-ecommerce-plan

Fixes #327 

#### Before
<img width="537" alt="screen shot 2018-11-28 at 1 21 15 pm" src="https://user-images.githubusercontent.com/10561050/49130771-81f2cf00-f310-11e8-85cd-a7a2a0e822f2.png">

#### After
<img width="570" alt="screen shot 2018-11-28 at 1 20 55 pm" src="https://user-images.githubusercontent.com/10561050/49130770-80c1a200-f310-11e8-80b6-0e05273c448b.png">

#### Testing
1.  Visit `wp-admin/admin.php?page=wc-setup&step=payment`.
2.  Check that the payment settings ("Set up ___") are once again visible.