### PR TITLE
Fix table manager table

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1299,6 +1299,13 @@ th.sortable a, th.sorted a{
 .widefat tfoot td.check-column  {
 	padding: 16px 8px;
 }
+.wp-list-table-wrapper .wp-list-table tr:not(.inline-edit-row):not(.no-items) td:not(.check-column) {
+	display: table-cell;
+	clear: none;
+}
+.wp-list-table-wrapper .wp-list-table tr:not(.inline-edit-row):not(.no-items) td:not(.column-primary)::before {
+    display: none;
+}
 
 /* Makes all rows have white background */
 .striped>tbody > :nth-child(odd), ul.striped > :nth-child(odd) {


### PR DESCRIPTION
Adds in styles for list tables with a wrapper to prevent default table collapse on mobile.

Fixes #329 

#### Before
<img width="650" alt="screen shot 2018-11-28 at 1 33 35 pm" src="https://user-images.githubusercontent.com/10561050/49131212-49ec8b80-f312-11e8-98bb-728cf742c455.png">

#### After
<img width="641" alt="screen shot 2018-11-28 at 1 34 00 pm" src="https://user-images.githubusercontent.com/10561050/49131208-4822c800-f312-11e8-90ff-755499fd7f3e.png">

#### Testing
1.  Visit `/wp-admin/edit.php?post_type=wc_product_tab`
2.  Narrow your viewport to <782px.
3.  Check that table formatting is correct.