### PR TITLE
Add cancel button to uncategorized category

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -593,7 +593,7 @@ input[type=radio]:checked:before {
 .wc_addons_wrap .addons-button-solid,
 .wc_addons_wrap .addons-button-outline-green,
 .wc_addons_wrap .addons-button-outline-white,
-.edit-tag-actions .button-primary,
+.wp-core-ui.wp-admin .edit-tag-actions .button-primary,
 .woocommerce-BlankState a.button,
 .setup-footer a,
 .action-header .page-title-action,

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -188,7 +188,7 @@
     /**
      * Add cancel button to taxonomy edit forms
      */
-    $( '.edit-tag-actions #delete-link' ).before(
+    $( '.edit-tag-actions .button:first' ).after(
         '<a href="' + ( 'undefined' !== typeof taxonomy ? taxonomy.listUrl : '#' ) + '" class="button button-secondary button-large taxonomy-edit-cancel-button">' + translations.cancel + '</a>'
     );
 


### PR DESCRIPTION
Appends the "Cancel" button for taxonomies to the first button (submit) instead of the delete link since the "Uncategorized" category doesn't have a delete link.

Also adds back in styling for larger input buttons in the taxonomy actions area.

Fixes #337 

#### Screenshots
<img width="660" alt="screen shot 2018-11-28 at 2 01 28 pm" src="https://user-images.githubusercontent.com/10561050/49132193-2a576200-f316-11e8-8fc2-2080bce0c91c.png">

#### Testing
1.  Visit `wp-admin/edit-tags.php?taxonomy=product_cat&post_type=product`
2.  Click "Uncategorized"
3.  Note the Cancel button
4.  Make sure no regressions have occurred with other taxonomy cancel buttons.