### PR TITLE
Focus select2 search field when opened

### DIFF
--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -392,5 +392,14 @@
         $( html ).insertAfter( 'h1.wp-heading-inline:first' );
     }
 
+    /**
+     * Focus select2 input on click
+     */
+    $( document ).on( 'click', '.select2', function() {
+        setTimeout( function() {
+            $( '.select2-container--open .select2-search__field' ).focus();
+        }, 0 );
+    } );
+
 
 } )( jQuery );


### PR DESCRIPTION
Focuses the search input when clicked to allow typing and avoiding shortcut triggers in masterbar ("n" opens the notifications) that might occur when searching for a country or state.

Fixes #344 

#### Screenshots
![select2focus](https://user-images.githubusercontent.com/10561050/49133734-157dcd00-f31c-11e8-8c57-9b827d726092.gif)

#### Testing
1.  Visit `/wp-admin/admin.php?page=wc-setup`
2.  Click on the Country, State, or Currency dropdowns.
3.  Check that the search input is focused.
4.  Check that typing "n" does not open the notifications from the masterbar.