### PR TITLE
Always enable the tracking option for eCommerce plans

### DIFF
--- a/includes/class-wc-calypso-bridge-admin-setup-wizard.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-wizard.php
@@ -278,24 +278,6 @@ class WC_Calypso_Bridge_Admin_Setup_Wizard extends WC_Admin_Setup_Wizard {
 				<?php esc_html_e( 'I will also be selling products or services in person.', 'wc-calypso-bridge' ); ?>
 			</label>
 
-			<?php
-			if ( 'unknown' === get_option( 'woocommerce_allow_tracking', 'unknown' ) ) {
-				?>
-				<div class="woocommerce-tracker">
-					<p class="checkbox">
-						<input type="checkbox" id="wc_tracker_checkbox" name="wc_tracker_checkbox" value="yes" checked />
-						<label for="wc_tracker_checkbox"><?php esc_html_e( 'Help WooCommerce improve with usage tracking.', 'wc-calypso-bridge' ); ?></label>
-					</p>
-					<p>
-					<?php
-					esc_html_e( 'Gathering usage data allows us to make WooCommerce better &mdash; your store will be considered as we evaluate new features, judge the quality of an update, or determine if an improvement makes sense. If you would rather opt-out, and do not check this box, we will not know this store exists and we will not collect any usage data.', 'wc-calypso-bridge' );
-					echo ' <a target="_blank" href="https://woocommerce.com/usage-tracking/">' . esc_html__( 'Read more about what we collect.', 'wc-calypso-bridge' ) . '</a>';
-					?>
-					</p>
-				</div>
-				<?php
-			}
-			?>
 			<p class="wc-setup-actions step">
 				<button type="submit" class="button-primary button button-large button-next" value="<?php esc_attr_e( "Let's go!", 'wc-calypso-bridge' ); ?>" name="save_step"><?php esc_html_e( "Let's go!", 'wc-calypso-bridge' ); ?></button>
 			</p>
@@ -375,6 +357,9 @@ class WC_Calypso_Bridge_Admin_Setup_Wizard extends WC_Admin_Setup_Wizard {
 		}
 		activate_plugin( 'woocommerce-shipping-ups/woocommerce-shipping-ups.php' );
 		flush_rewrite_rules();
+
+		// Always track usage for eCommerce plans: https://github.com/Automattic/wc-calypso-bridge/issues/361.
+		$_POST['wc_tracker_checkbox'] = 'yes';
 	}
 
 	/**


### PR DESCRIPTION
Fixes #361.

This PR hides the tracker check box, but sets it to 'yes' during setup.

To test: 
* Update `woocommerce_allow_tracking` to `no` or `unknown`.
* Go to `/wp-admin/admin.php?page=wc-setup` and verify the tracker option is not visible.
* Complete your address and go to the next screen.
* Check the option value. It should be `yes`.