### PR TITLE
Fix extra stripe notices display

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -476,7 +476,8 @@ input[type=radio]:checked:before {
 .wp-core-ui.wp-admin .button-secondary,
 .wc_addons_wrap .addons-button-outline-green,
 .wc_addons_wrap .addons-button-outline-white,
-.woocommerce_page_wc-status .woocommerce-message a.docs {
+.woocommerce_page_wc-status .woocommerce-message a.docs,
+.wcc-root .stripe__connect-account .stripe__connect-account-body .stripe__connect-account-details .stripe__connect-account-disconnect {
 	color: #2e4453;
 	background: #fff;
 	border-color: #c8d7e1;
@@ -537,7 +538,8 @@ input[type=radio]:checked:before {
 .wc-helper .button,
 .wc_addons_wrap .addons-button-solid,
 .woocommerce_page_wc-status .woocommerce-message a.debug-report,
-.woocommerce_page_wc-status .woocommerce-message #copy-for-support {
+.woocommerce_page_wc-status .woocommerce-message #copy-for-support,
+.notice.wcs-nux__notice .wcs-nux__notice-content .wcs-nux__notice-content-button {
 	background: #00aadc !important;
 	border-color: #008ab3 !important;
 	border-width: 1px 1px 2px !important;
@@ -571,7 +573,8 @@ input[type=radio]:checked:before {
 .woocommerce_page_wc-status .woocommerce-message a.debug-report:hover,
 .woocommerce_page_wc-status .woocommerce-message a.debug-report:focus,
 .woocommerce_page_wc-status .woocommerce-message #copy-for-support:focus,
-.woocommerce_page_wc-status .woocommerce-message #copy-for-support:hover {
+.woocommerce_page_wc-status .woocommerce-message #copy-for-support:hover,
+.notice.wcs-nux__notice .wcs-nux__notice-content .wcs-nux__notice-content-button:hover {
 	background: #00aadc !important;
 	border-color: #005082 !important;
 	color: #fff;
@@ -2351,6 +2354,61 @@ p.search-box {
 	margin-left: 4px;
 }
 
+/** WooCommerce Services / Stripe */
+.wcc-root .stripe__connect-account .stripe__connect-account-body {
+	background: #fff;
+	border: 1px solid rgba(200,215,225,0.5);
+	border-top: 0;
+	max-width: 100%;
+}
+
+.wcc-root.wc-connect-stripe-connect-account {
+	max-width: 100%;
+}
+
+h3#woocommerce_stripe_connection_status {
+	padding-bottom: 0;
+}
+
+.wcc-root .stripe__connect-account .stripe__connect-account-body .stripe__connect-account-details .stripe__connect-account-status.account-not-activated,
+.wcc-root .stripe__connect-account .stripe__connect-account-body .stripe__connect-account-details .stripe__connect-account-status.account-activated {
+	vertical-align: super;
+}
+
+.wp-admin .wrap .wc-connect-stripe-connect-account .notice {
+	background: #fff;
+	color: #537994;
+	font-size: 12px;
+	line-height: 18px;
+	padding: 0 24px 8px 14px;
+	border: 1px solid rgba(200,215,225,0.5);
+	border-top: 0;
+	box-shadow: none;
+}
+
+.wc-connect-stripe-connect-account .notice__icon-wrapper {
+	display: none;
+}
+
+.wcc-root .stripe-connect-account__placeholder-container .stripe-connect-account__placeholder-body {
+	max-width: 100%;
+	background: #fff;
+	border: 1px solid rgba(200,215,225,0.5);
+	border-top: 0;
+}
+
+.wcs-nux__notice .wcs-nux__notice-logo.is-compact .wcs-nux__notice-logo-graphic {
+	display: none;
+}
+
+.wcs-nux__notice .wcs-nux__notice-content .wcs-nux__notice-content-title {
+	display: none;
+}
+
+.notice.wcs-nux__notice .wcs-nux__notice-content-text {
+	padding-top: 8px;
+}
+
 /** WooCommerce Services / Modal */
 
 .wcs-pointer-page-dimmer {
@@ -2366,3 +2424,4 @@ p.search-box {
 .woocommerce_page_wc-settings .select2-selection.select2-selection--single {
 	min-width: 300px;
 }
+

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2360,6 +2360,7 @@ p.search-box {
 	border: 1px solid rgba(200,215,225,0.5);
 	border-top: 0;
 	max-width: 100%;
+	padding-left: 24px;
 }
 
 .wcc-root.wc-connect-stripe-connect-account {


### PR DESCRIPTION
Fixes #232.

WooCommerce Services and Stripe show some additional notifications in different contexts (auto-provisioned accounts, previously existing Stripe account, etc). These notices needed some style updates.

Before:

<img width="980" alt="screen shot 2018-11-19 at 3 16 56 pm" src="https://user-images.githubusercontent.com/689165/48732773-86333400-ec0e-11e8-8c00-cc68b44bcf9e.png">

<img width="996" alt="screen shot 2018-11-19 at 3 17 07 pm" src="https://user-images.githubusercontent.com/689165/48732784-8c291500-ec0e-11e8-8015-db132c620d8e.png">

<img width="1076" alt="screen shot 2018-11-28 at 3 16 49 pm" src="https://user-images.githubusercontent.com/689165/49183654-6e089680-f32b-11e8-8078-b52b3cfedcf4.png">

After:

<img width="815" alt="screen shot 2018-11-28 at 4 30 17 pm" src="https://user-images.githubusercontent.com/689165/49183674-7cef4900-f32b-11e8-9c52-fdc906bc7fe4.png">

<img width="851" alt="screen shot 2018-11-28 at 3 58 08 pm" src="https://user-images.githubusercontent.com/689165/49183698-88427480-f32b-11e8-98f9-83377298548c.png">

<img width="815" alt="screen shot 2018-11-28 at 4 45 22 pm" src="https://user-images.githubusercontent.com/689165/49184343-1a974800-f32d-11e8-8a81-767577732592.png">

To Test:

* Test connecting an account via the onboarding wizard, and then verify that the connected box looks OK.
* Disconnect using the provided button and verify the notice looks OK.
* Force the connection banner ("it looks like there is..") to display using the following directions, and make sure the notice looks OK.


To force the notice to show, you can make a couple edits in `woocommerce-services/classes/class-wc-connect-stripe.php`

in `connection_banner`, comment out the if statements and use

```
$options['email'] = 'justin@automattic.com';
$result = '';
```

 instead.

 in `maybe_show_notice`, you can comment out the if statments with `return` and `exit`, so `$screen = get_current_screen();` is the first line.


