### PR TITLE
Change wc helper table background colors to prevent overlapping

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1322,6 +1322,16 @@ th.sortable a, th.sorted a{
 	background: #fafbfc !important;
 }
 
+/* WC Helper Tables */
+.wc-helper .wp-list-table__row td,
+.wc-helper .wp-list-table__row.is-ext-header td {
+	background: transparent;
+}
+.wc-helper .wp-list-table__row.is-ext-header,
+.wc-helper .wp-list-table__row.wp-list-table__ext-updates {
+	background: #fff !important;
+}
+
 /* Adds border to placeholder image */
 table.wp-list-table td.column-thumb img {
 	border: 1px solid #f3f6f8;


### PR DESCRIPTION
Makes the table cells transparent to avoid blocking the date and removes the row hover color.

Fixes #325 

#### Before
<img width="707" alt="screen shot 2018-11-29 at 3 02 15 pm" src="https://user-images.githubusercontent.com/10561050/49204747-d3ba5880-f3e7-11e8-9116-d67541f26a38.png">

#### After
<img width="808" alt="screen shot 2018-11-29 at 2 59 24 pm" src="https://user-images.githubusercontent.com/10561050/49204696-a2da2380-f3e7-11e8-8681-648ec6aa3330.png">

#### Testing
1.  Visit `wp-admin/admin.php?page=wc-addons&section=helper`
2.  Check that the expiration date is visible across all viewport sizes.
3.  Check that no hover color is present on the table rows.