### PR TITLE
Update WC helper button selector specificity

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -534,7 +534,7 @@ input[type=radio]:checked:before {
 .wp-core-ui.wp-admin .button.is-primary,
 .action-header .page-title-action,
 .action-header .add-new-h2,
-.wc-helper .button,
+.wp-core-ui.wp-admin .wc-helper .button,
 .wc_addons_wrap .addons-button-solid,
 .woocommerce_page_wc-status .woocommerce-message a.debug-report,
 .woocommerce_page_wc-status .woocommerce-message #copy-for-support {
@@ -564,8 +564,8 @@ input[type=radio]:checked:before {
 .action-header .page-title-action:focus,
 .action-header .add-new-h2:hover,
 .action-header .add-new-h2:focus,
-.wc-helper .button:hover,
-.wc-helper .button:focus,
+.wp-core-ui.wp-admin .wc-helper .button:hover,
+.wp-core-ui.wp-admin .wc-helper .button:focus,
 .wc_addons_wrap .addons-button-solid:hover,
 .wc_addons_wrap .addons-button-solid:focus,
 .woocommerce_page_wc-status .woocommerce-message a.debug-report:hover,
@@ -630,7 +630,7 @@ input[type=radio]:checked:before {
 .wp-core-ui.wp-admin .button.is-primary:active,
 .action-header .page-title-action:active,
 .action-header .add-new-h2:active,
-.wc-helper .button:active,
+.wp-core-ui.wp-admin .wc-helper .button:active,
 .wc_addons_wrap .addons-button-solid:active {
 	border-width: 2px 1px 1px !important;
 	box-shadow: none;
@@ -642,7 +642,8 @@ input[type=radio]:checked:before {
 .wp-core-ui.wp-admin .button.button-large {
 	height: auto;
 }
-.wc-helper .button-update .dashicons, .wc-helper .button-update:hover .dashicons {
+.wp-core-ui.wp-admin .wc-helper .button-update .dashicons,
+.wp-core-ui.wp-admin .wc-helper .button-update:hover .dashicons {
 	height: 13px;
 }
 #publishing-action {


### PR DESCRIPTION
Fixes the button styles for wc helper buttons.

Fixes #352 

#### Before
<img width="1086" alt="screen shot 2018-11-29 at 3 26 43 pm" src="https://user-images.githubusercontent.com/10561050/49205837-306b4280-f3eb-11e8-9cd8-fa62c6d6b3ce.png">

#### After
<img width="1101" alt="screen shot 2018-11-29 at 3 25 19 pm" src="https://user-images.githubusercontent.com/10561050/49205822-28ab9e00-f3eb-11e8-809d-46536067dac7.png">

#### Testing
1.  Visit `wp-admin/admin.php?page=wc-addons&section=helper`
2.  Button styles look okay?