### PR TITLE
Add pagination to taxonomies

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -123,17 +123,17 @@ div.woocommerce-message, .wc-helper .start-container {
 .tablenav.bottom.secondary {
 	display: inline-block;
 }
-.tablenav.bottom .wc-calypso-brdige-pagination.tablenav-pages {
+.wc-calypso-brdige-pagination.tablenav-pages {
 	float: none;
 	display: flex;
 	align-items: center;
 	justify-content: center;
 	margin-top: 16px;
 }
-.tablenav .tablenav-pages a,
+.wp-admin .tablenav-pages a,
 .tablenav-pages-navspan,
 .tablenav-pages span.current,
-.tablenav .dots {
+.wp-admin .dots {
 	padding: 8px 12px;
 	background-color: #fff;
 	border: solid 1px #c8d7e1;
@@ -147,14 +147,16 @@ div.woocommerce-message, .wc-helper .start-container {
 	display: flex;
 	align-content: center;
 	height: auto;
+	text-decoration: none;
 }
-.tablenav .tablenav-pages a:hover,
-.tablenav .tablenav-pages a:focus {
+.wp-admin .tablenav-pages a:hover,
+.wp-admin .tablenav-pages a:focus {
 	color: #2e4453;
 	background: #fff;
-	border-color: #C8D7E1
+	border-color: #C8D7E1;
+	box-shadow: none;
 }
-.tablenav .tablenav-pages a:hover .gridicon {
+.wp-admin .tablenav-pages a:hover .gridicon {
 	fill: #2e4453;
 }
 .tablenav-pages span.current {
@@ -162,26 +164,26 @@ div.woocommerce-message, .wc-helper .start-container {
 	background-color: #00aadc;
 	color: #fff;
 }
-.tablenav .gridicon,
-.tablenav .gridicon {
+.wp-admin .gridicon,
+.wp-admin .gridicon {
 	vertical-align: middle;
 	width: 18px;
 	height: 18px;
 	fill: #537994;
 }
-.tablenav .tablenav-pages > *:first-child {
+.wp-admin .tablenav-pages > *:first-child {
 	border-top-left-radius: 4px;
 	border-bottom-left-radius: 4px;
 }
-.tablenav .tablenav-pages > *:first-child .gridicon {
+.wp-admin .tablenav-pages > *:first-child .gridicon {
 	margin-right: 2px;
 }
-.tablenav .tablenav-pages > *:last-child {
+.wp-admin .tablenav-pages > *:last-child {
 	border-top-right-radius: 4px;
 	border-bottom-right-radius: 4px;
 	border-right: 1px solid #c8d7e1;
 }
-.tablenav .tablenav-pages > *:last-child .gridicon {
+.wp-admin .tablenav-pages > *:last-child .gridicon {
 	margin-left: 2px;
 }
 .tablenav-pages-navspan.disabled {

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -123,7 +123,8 @@ div.woocommerce-message, .wc-helper .start-container {
 .tablenav.bottom.secondary {
 	display: inline-block;
 }
-.wc-calypso-brdige-pagination.tablenav-pages {
+.tablenav.bottom .wc-calypso-brdige-pagination.tablenav-pages,
+.edit-tags-php .wc-calypso-brdige-pagination.tablenav-pages {
 	float: none;
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
Since the default pagination is hidden, add in our own Calypsoified version.

Fixes #356 

#### Screenshots
<img width="1145" alt="screen shot 2018-11-29 at 4 48 24 pm" src="https://user-images.githubusercontent.com/10561050/49210006-f0aa5800-f3f6-11e8-8201-83dcf89ceb6c.png">

#### Testing
1.  Visit various taxonomy pages (e.g., `wp-admin/edit-tags.php?taxonomy=product_cat&post_type=product`)
2.  Check that pagination is working and styled correctly.
3.  Check that no regressions have occurred on WP List Table pages (e.g., Products- `wp-admin/edit.php?post_type=product`)