### PR TITLE
Remove subnav separators from extensions

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1020,6 +1020,9 @@ li#wp-admin-bar-menu-toggle {
 .wrap .subsubsub {
 	margin-bottom: 1em;
 }
+.wc_addons_wrap .subsubsub li::after {
+	display: none;
+}
 .nav-tab, .subsubsub a, .filter-links li>a {
 	color: #00aadc;
 }


### PR DESCRIPTION
Removes the `|` to keep the subnav consistent with others that are Calypsoified.

Fixes #362 

#### Before
<img width="662" alt="screen shot 2018-11-29 at 6 37 14 pm" src="https://user-images.githubusercontent.com/10561050/49216375-e2b00380-f405-11e8-9d4e-7bb4474ffb95.png">

#### After
<img width="688" alt="screen shot 2018-11-29 at 6 36 33 pm" src="https://user-images.githubusercontent.com/10561050/49216382-e5aaf400-f405-11e8-8513-2ed7f1b2dd2b.png">

#### Testing
1.  Visit `wp-admin/admin.php?page=wc-addons`
2.  Check that `|` have been removed between subnav items.
