### PR TITLE
Make checklist action button large again

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -585,7 +585,7 @@ input[type=radio]:checked:before {
 .wp-core-ui.wp-admin button.button.button-large,
 .wp-core-ui.wp-admin a.button.button-large,
 .wp-core-ui.wp-admin input.button.button-large,
-.checklist__task-secondary .button-primary,
+.wp-core-ui.wp-admin .checklist__task-secondary .button-primary,
 #postbox-container-1 .button-primary,
 .wp-core-ui.wp-admin .woocommerce-save-button,
 .wc_addons_wrap .addons-button-solid,


### PR DESCRIPTION
Fixes the checklist action buttons selector specificity.

Fixes #368 

#### Before
<img width="172" alt="screen shot 2018-11-29 at 6 42 29 pm" src="https://user-images.githubusercontent.com/10561050/49216666-97e2bb80-f406-11e8-90a0-9413c4a2d22e.png">

#### After
<img width="173" alt="screen shot 2018-11-29 at 6 42 21 pm" src="https://user-images.githubusercontent.com/10561050/49216676-9ca76f80-f406-11e8-8b86-4fdf80189f4f.png">

#### Testing
1.  Visit `/wp-admin/admin.php?page=wc-setup-checklist`
2.  Check that buttons are big again.