### PR TITLE
Fix checkmark color

### DIFF
--- a/assets/css/setup-checklist.css
+++ b/assets/css/setup-checklist.css
@@ -424,6 +424,7 @@
 
 .checklist__task.is-completed .gridicons-checkmark {
 	display: block;
+	fill: #fff;
 }
 
 .checklist__task.is-completed .checklist__task-description,


### PR DESCRIPTION
There was a slight regression with the checkmark style.

Before:

<img width="281" alt="screen shot 2018-11-29 at 3 16 01 pm" src="https://user-images.githubusercontent.com/689165/49249327-df0e8380-f3e9-11e8-9d54-a4617e19142f.png">

Now:

<img width="356" alt="screen shot 2018-11-29 at 3 16 05 pm" src="https://user-images.githubusercontent.com/689165/49249335-e33aa100-f3e9-11e8-8603-046e854d306e.png">

To Test:
* Load up the task list and make sure the checkmarks are good.