### PR TITLE
Move Stripe above PayPal in setup checklist

### DIFF
--- a/includes/class-wc-calypso-bridge-admin-setup-checklist.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-checklist.php
@@ -256,6 +256,22 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 			),
 
 			array(
+				'id'              => 'stripe',
+				'title'           => __( 'Setup payments with Stripe', 'wc-calypso-bridge' ),
+				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
+				'description'     => __( 'Connect your Stripe account to accept credit and debit card payments.', 'wc-calypso-bridge' ),
+				'estimate'        => '2',
+				'link'            => 'admin.php?page=wc-settings&tab=checkout&section=stripe&return=%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-setup-checklist&wc-setup-step=stripe',
+				'learn_more'      => 'https://woocommerce.com/products/stripe/',
+				'condition'       => isset( $click_settings['stripe'] ) &&
+								true === (bool) $click_settings['stripe'] &&
+								! empty( $stripe_settings['publishable_key'] ) &&
+								! empty( $stripe_settings['secret_key'] ) &&
+								'yes' === $stripe_settings['enabled'],
+				'extension'       => 'woocommerce-gateway-stripe/woocommerce-gateway-stripe.php',
+			),
+
+			array(
 				'id'              => 'paypal',
 				'title'           => __( 'Setup payments with PayPal', 'wc-calypso-bridge' ),
 				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
@@ -270,22 +286,6 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 								( ! empty( $paypal_settings['api_signature'] ) || ! empty( $paypal_settings['api_certificate'] ) ) &&
 								'yes' === $paypal_settings['enabled'],
 				'extension'       => 'woocommerce-gateway-paypal-express-checkout/woocommerce-gateway-paypal-express-checkout.php',
-			),
-
-			array(
-				'id'              => 'stripe',
-				'title'           => __( 'Setup payments with Stripe', 'wc-calypso-bridge' ),
-				'completed_title' => __( 'View Settings', 'wc-calypso-bridge' ),
-				'description'     => __( 'Connect your Stripe account to accept credit and debit card payments.', 'wc-calypso-bridge' ),
-				'estimate'        => '2',
-				'link'            => 'admin.php?page=wc-settings&tab=checkout&section=stripe&return=%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-setup-checklist&wc-setup-step=stripe',
-				'learn_more'      => 'https://woocommerce.com/products/stripe/',
-				'condition'       => isset( $click_settings['stripe'] ) &&
-								true === (bool) $click_settings['stripe'] &&
-								! empty( $stripe_settings['publishable_key'] ) &&
-								! empty( $stripe_settings['secret_key'] ) &&
-								'yes' === $stripe_settings['enabled'],
-				'extension'       => 'woocommerce-gateway-stripe/woocommerce-gateway-stripe.php',
 			),
 
 			array(


### PR DESCRIPTION
Fixes #378 

#### Before
<img width="335" alt="screen shot 2018-11-30 at 10 13 02 am" src="https://user-images.githubusercontent.com/10561050/49264255-880bbb80-f488-11e8-93c9-09d7c1931aeb.png">

#### After
<img width="466" alt="screen shot 2018-11-30 at 10 10 52 am" src="https://user-images.githubusercontent.com/10561050/49264231-70343780-f488-11e8-94d8-75983d8b7ace.png">

#### Testing
1.  Visit `wp-admin/admin.php?page=wc-setup-checklist`
2.  Is Stripe above PayPal?