### PR TITLE
Vertically center site icon

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -843,8 +843,10 @@ li#wp-admin-bar-menu-toggle {
 .action-header__content .site-icon {
 	height: 32px;
 	width: 32px;
-	line-height: 32px;
 	font-size: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 	margin-right: 8px;
 	text-align: center;
 }

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -844,9 +844,9 @@ li#wp-admin-bar-menu-toggle {
 	height: 32px;
 	width: 32px;
 	font-size: 32px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	margin-right: 8px;
 	text-align: center;
 }


### PR DESCRIPTION
Fixes the alignment issue with the site icon.

Fixes #381 

#### Before
<img width="178" alt="screen shot 2018-11-30 at 10 33 15 am" src="https://user-images.githubusercontent.com/10561050/49269568-a087d000-f4a0-11e8-8318-8c34ac8854d2.png">

#### After
<img width="155" alt="screen shot 2018-11-30 at 1 05 11 pm" src="https://user-images.githubusercontent.com/10561050/49269565-9d8cdf80-f4a0-11e8-9225-b2b872eeee67.png">

#### Testing
Visit any Calypsoified dashboard page and make sure the site icon is vertically centered.