### PR TITLE
Fix Orders table layout

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1309,7 +1309,7 @@ th.sortable a, th.sorted a{
 .widefat tfoot td.check-column  {
 	padding: 16px 8px;
 }
-.wp-list-table-wrapper .wp-list-table tr:not(.inline-edit-row):not(.no-items) td:not(.check-column) {
+.wp-list-table-wrapper .wp-list-table tr:not(.inline-edit-row):not(.no-items) td:not(.check-column):not(.hidden) {
 	display: table-cell;
 	clear: none;
 }


### PR DESCRIPTION
Fixes previous table cell display that was overriding the hidden class on shipping and billing cells.

Fixes #383 

#### Before
<img width="1060" alt="screen shot 2018-11-30 at 10 46 35 am" src="https://user-images.githubusercontent.com/10561050/49270581-fc545800-f4a4-11e8-9efe-e2e57d8aab34.png">

#### After
<img width="1077" alt="screen shot 2018-11-30 at 1 31 55 pm" src="https://user-images.githubusercontent.com/10561050/49270554-eba3e200-f4a4-11e8-86ab-3079880a55e8.png">

#### Testing 
Visit `/wp-admin/edit.php?post_type=shop_order` and make sure the table layout looks okay.