### PR TITLE
Fix the gridicons size

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -157,6 +157,12 @@ div.woocommerce-message, .wc-helper .start-container {
 	border-color: #C8D7E1;
 	box-shadow: none;
 }
+.wp-admin .tablenav-pages .gridicon {
+	width: 18px;
+	height: 18px;
+	vertical-align: middle;
+	fill: #537994;
+}
 .wp-admin .tablenav-pages a:hover .gridicon {
 	fill: #2e4453;
 }
@@ -164,13 +170,6 @@ div.woocommerce-message, .wc-helper .start-container {
 	border-color: #00aadc;
 	background-color: #00aadc;
 	color: #fff;
-}
-.wp-admin .gridicon,
-.wp-admin .gridicon {
-	vertical-align: middle;
-	width: 18px;
-	height: 18px;
-	fill: #537994;
 }
 .wp-admin .tablenav-pages > *:first-child {
 	border-top-left-radius: 4px;


### PR DESCRIPTION
Limits the 18px size change of icons to the pagination icons.

Fixes #396 

#### Before
<img width="149" alt="screen shot 2018-11-30 at 10 55 42 am" src="https://user-images.githubusercontent.com/10561050/49272326-12b1e200-f4ac-11e8-84b8-c5fb39b093fd.png">

#### After
<img width="172" alt="screen shot 2018-11-30 at 2 27 21 pm" src="https://user-images.githubusercontent.com/10561050/49272322-0fb6f180-f4ac-11e8-933c-c5ffcb750ef7.png">

#### Testing
Check places with icons and make sure things look okay:
* Action header cross/arrow (left-hand side)
* Pagination left/right arrows
* Notice icons
* Search icons