### PR TITLE
Fix setup header image in ie11

### DIFF
--- a/assets/css/setup-checklist.css
+++ b/assets/css/setup-checklist.css
@@ -9,6 +9,11 @@
 	flex-direction: row;
 }
 
+.setup-header img {
+	width: 120px;
+	margin-right: 20px;
+}
+
 .setup-header h2 {
 	font-size: 32px;
 	font-weight: 500;


### PR DESCRIPTION
Adds a width and margin to the image.

Fixes #380 

#### Before
<img width="584" alt="screen shot 2018-11-30 at 10 29 55 am" src="https://user-images.githubusercontent.com/10561050/49273576-67eff280-f4b0-11e8-8bdc-60b6beb183d5.png">

#### After
<img width="541" alt="screen shot 2018-11-30 at 2 58 20 pm" src="https://user-images.githubusercontent.com/10561050/49273573-64f50200-f4b0-11e8-9257-1d4bbaf2e5fd.png">

#### Testing
1.  Fire up IE11.
2.  Visit `/wp-admin/admin.php?page=wc-setup-checklist`.
3.  Check that image width and margin looks okay in the checklist setup header.