### PR TITLE
Remove select arrow dropdowns in IE11

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -259,9 +259,12 @@ textarea:focus {
 	-moz-outline: none;
 	-moz-user-focus: ignore;
 }
-input::-ms-clear {
+
+input::-ms-clear,
+select::-ms-expand {
 	display: none;
 }
+
 input[type="text"]::placeholder,
 input[type="search"]::placeholder,
 input[type="email"]::placeholder,


### PR DESCRIPTION
Removes the default arrow in select boxes in IE11.

Fixes #382 

#### Before
<img width="528" alt="screen shot 2018-11-30 at 10 44 54 am" src="https://user-images.githubusercontent.com/10561050/49273921-89051300-f4b1-11e8-8ebd-4b4d8e9ccf47.png">

#### After
<img width="645" alt="screen shot 2018-11-30 at 3 06 14 pm" src="https://user-images.githubusercontent.com/10561050/49273906-7f7bab00-f4b1-11e8-98f6-2a9cd75e3266.png">

#### Testing
1.  Visit any page with a select dropdown (e.g., Products, Orders, etc.)
2.  Check that the default IE11 arrow is gone.