### PR TITLE
Remove clear icon in inputs in ie11

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -260,6 +260,9 @@ textarea:focus {
 	-moz-outline: none;
 	-moz-user-focus: ignore;
 }
+input::-ms-clear {
+	display: none;
+}
 input[type="text"]::placeholder,
 input[type="search"]::placeholder,
 input[type="email"]::placeholder,


### PR DESCRIPTION
Remove the ie11 clear icon in inputs since we already have a clear icon for searches.

Fixes #385 

#### Before
<img width="1084" alt="screen shot 2018-11-30 at 10 52 54 am" src="https://user-images.githubusercontent.com/10561050/49274216-9bcc1780-f4b2-11e8-8954-c8cc753a6cc7.png">

#### After
<img width="1365" alt="screen shot 2018-11-30 at 3 12 53 pm" src="https://user-images.githubusercontent.com/10561050/49274212-98389080-f4b2-11e8-9e26-6627a0aee872.png">

#### Testing
1.  Fire up IE11.
2.  Open any search box.
3.  Type some text and verify that only one 'x' is showing to clear the input.