### PR TITLE
Fix JITM notice styling

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2082,7 +2082,8 @@ div.error {
 .wp-admin .wrap div.notice,
 .wp-admin .wrap div.updated,
 .wp-admin .wrap div.error,
-div.jitm-card {
+div.jitm-card,
+.jitm-banner.jitm-card {
 	display: flex;
 	position: relative;
 	width: 100%;
@@ -2103,7 +2104,7 @@ div.jitm-card  .jitm-banner__info .jitm-banner__title, div.jitm-card  .jitm-bann
 	color: #fff;
 }
 
-#screen-meta-links + .jitm-card {
+.jitm-card {
 	margin: 0 0 24px 0;
 	border-left: 0;
 	padding: 0;
@@ -2122,6 +2123,27 @@ div.jitm-card  .jitm-banner__info .jitm-banner__title, div.jitm-card  .jitm-bann
 	width: 24px;
 	background-image:
 	url("data:image/svg+xml;utf8,<svg class='gridicon gridicons-notice' height='24' width='24' fill='#fff' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><g><path d='M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z'></path></g></svg>");
+}
+
+@media screen and (max-width: 480px) {
+	.jitm-banner.jitm-card {
+		display: flex;
+	}
+}
+
+.jitm-banner__dismiss {
+	position: static;
+	float: right;
+	padding: 0px 12px 0 12px !important;
+	font-size: 13px;
+	line-height: 1.23076923;
+	text-decoration: none;
+}
+
+.jitm-banner__dismiss:before {
+	color: #a3bdd0;
+	font: normal 24px/1 dashicons;
+	content: '\f335';
 }
 
 .wp-admin .wrap div.hidden {

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -56,7 +56,8 @@
     $( document ).ready(function() {
         var $subNavigation = $( '.wrap .subsubsub' );
         if ( $subNavigation.length ) {
-            $( 'div.notice, div.error, div.updated, div.warning' ).insertAfter( $subNavigation.first() );
+			$( 'div.notice, div.error, div.updated, div.warning' ).insertAfter( $subNavigation.first() );
+			$( '.jetpack-jitm-message, .jitm-card' ).insertAfter( $subNavigation.first() );
         }
     } );
 


### PR DESCRIPTION
Fixes #328.

This PR makes some style adjustments to the JITM notices, and also moves them inline with the rest of the notices.

Before:

<img width="434" alt="jitm_mobile" src="https://user-images.githubusercontent.com/689165/49044549-2acbed80-f19c-11e8-9d44-04392d7662e0.png">

<img width="1134" alt="jitm_separate_from_notices" src="https://user-images.githubusercontent.com/689165/49044563-35868280-f19c-11e8-81c6-ba56a329b074.png">


Now:

<img width="607" alt="screen shot 2018-11-30 at 2 28 51 pm" src="https://user-images.githubusercontent.com/689165/49310603-b7342400-f4ac-11e8-9e53-bbdb54f7e232.png">

To Test:
* I haven't found a good way to get these to consistently show up, but they show up for me on the orders and settings pages with Jetpack and WCS activated.