### PR TITLE
Fix date/time and address formatting on orders pages

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2509,3 +2509,23 @@ h3#woocommerce_stripe_connection_status {
 	min-width: 300px;
 }
 
+/* Order page */
+#order_data .order_data_column {
+	width: 45%;
+}
+
+#order_data .order_data_column:first-child {
+	width: 100%;
+}
+
+.post-type-shop_order .date-picker[name="order_date"] {
+	margin-right: 8px;
+}
+
+.post-type-shop_order .hour[name="order_date_hour"] {
+	margin-right: 4px;
+}
+
+.post-type-shop_order .minute[name="order_date_minute"] {
+	margin-left: 2px;
+}


### PR DESCRIPTION
Fixes #387.

This wraps the billing and shipping columns under so that there's always enough room for the date/time fields. It also adds a bit of spacing for the `@` and `:` separators.

To Test:
* Visit edit or add order and verify things look OK.

Before:

<img width="727" alt="screen shot 2018-11-30 at 2 52 48 pm" src="https://user-images.githubusercontent.com/689165/49311622-a0db9780-f4af-11e8-944a-7e5dcc638d22.png">

After:

<img width="733" alt="screen shot 2018-11-30 at 2 54 45 pm" src="https://user-images.githubusercontent.com/689165/49311710-e4ce9c80-f4af-11e8-8ff7-a3718dd7f997.png">
