### PR TITLE
Navigation to calypso update

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -819,7 +819,6 @@ li#wp-admin-bar-menu-toggle {
 	flex: 0 0 auto;
 	margin: 0 0 0 7px;
 	border: none;
-	min-width: 40px;
 	padding: 0;
 	text-align: center;
 }

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -947,6 +947,10 @@ li#wp-admin-bar-menu-toggle {
 }
 
 /* Sidebar header */
+#adminmenu>li.wp-first-item {
+	border-bottom: 0;
+}
+
 .auto-fold #adminmenu {
 	top: 0;
 }

--- a/includes/class-wc-calypso-bridge-action-header.php
+++ b/includes/class-wc-calypso-bridge-action-header.php
@@ -100,7 +100,6 @@ class WC_Calypso_Bridge_Action_Header {
 		);
 		?>
 		<a class="action-header__ground-control-back" aria-label="<?php esc_html_e( 'Close Store', 'wc-calypso-bridge' ); ?>" href="<?php echo esc_url( 'https://wordpress.com/stats/day/' . Jetpack::build_raw_urls( home_url() ) ); ?>">
-			<?php echo wp_kses( get_gridicon( 'gridicons-cross' ), $svg_atts ); ?>
 			<?php echo wp_kses( get_gridicon( 'gridicons-chevron-left' ), $svg_atts ); ?>
 		</a>
 		<?php

--- a/includes/class-wc-calypso-bridge-menus.php
+++ b/includes/class-wc-calypso-bridge-menus.php
@@ -32,12 +32,43 @@ class WC_Calypso_Bridge_Menus {
 	}
 
 	/**
-	 * Constructor
+	 * Constructor.
 	 */
 	private function __construct() {
 		add_action( 'current_screen', array( $this, 'setup_menu_hooks' ) );
 		add_action( 'admin_menu', array( $this, 'change_woocommerce_menu_item_name' ), 100 );
 		add_action( 'admin_menu', array( $this, 'remove_create_new_menu_items' ), 100 );
+
+		add_action( 'admin_menu', array( $this, 'add_calypso_link' ), -10 ); // Before Setup.
+	}
+
+	/**
+	 * Adds a link back to Calypso.
+	 */
+	public function add_calypso_link() {
+		add_menu_page(
+			__( 'Manage site', 'wc-calypso-bridge' ),
+			__( 'Manage site', 'wc-calypso-bridge' ),
+			'manage_woocommerce',
+			'wc-wp-manage-site',
+			array( $this, 'manage_site' ),
+			'dashicons-arrow-left-alt2',
+			0
+		);
+	}
+
+	/**
+	 * Redirects the user back to Calypso.
+	 */
+	public function manage_site() {
+		$strip_http = '/.*?:\/\//i';
+		$site_slug  = preg_replace( $strip_http, '', get_home_url() );
+		$site_slug  = str_replace( '/', '::', $site_slug );
+
+		$redirect_url = 'https://wordpress.com/stats/day/' . $site_slug;
+
+		wp_redirect( $redirect_url );
+		exit;
 	}
 
 	// TODO If any extensions add new pages to wp-admin's settings section, we will want to copy those over,

--- a/includes/connect/wc-calypso-bridge.php
+++ b/includes/connect/wc-calypso-bridge.php
@@ -13,3 +13,10 @@ wc_calypso_bridge_connect_page(
 		'menu'      => 'wc-setup-checklist',
 	)
 );
+
+wc_calypso_bridge_connect_page(
+	array(
+		'screen_id' => 'toplevel_page_wc-wp-manage-site',
+		'menu'      => 'wc-wp-manage-site',
+	)
+);


### PR DESCRIPTION
Closes #402 

This PR removes the 'X' that lead back to Calypso and adds a manage site link instead.

<img width="785" alt="screen shot 2018-11-30 at 3 14 14 pm" src="https://user-images.githubusercontent.com/689165/49312796-42181d00-f4b3-11e8-85df-ffb1b9441155.png">


To Test:
* Test that the link shows up, above all other links.
* Test that you are directed to Calypso.