### PR TITLE
Fix IE11 input heights

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -213,7 +213,6 @@ input[type="number"],
 input[type="search"],
 input[type="radio"],
 input[type="tel"],
-input[type="text"],
 input[type="time"],
 input[type="url"],
 input[type="week"],
@@ -240,7 +239,6 @@ input[type="number"]:focus,
 input[type="search"]:focus,
 input[type="radio"]:focus,
 input[type="tel"]:focus,
-input[type="text"]:focus,
 input[type="time"]:focus,
 input[type="url"]:focus,
 input[type="week"]:focus,
@@ -263,6 +261,27 @@ textarea:focus {
 input::-ms-clear,
 select::-ms-expand {
 	display: none;
+}
+@media all and (-ms-high-contrast:none) {
+	input[type="text"],
+	input[type="password"],
+	input[type="checkbox"],
+	input[type="color"],
+	input[type="date"],
+	input[type="datetime"],
+	input[type="datetime-local"],
+	input[type="email"],
+	input[type="month"],
+	input[type="number"],
+	input[type="search"],
+	input[type="radio"],
+	input[type="tel"],
+	input[type="time"],
+	input[type="url"],
+	input[type="week"] {
+		height: 38px;
+		line-height: 1;
+	}
 }
 
 input[type="text"]::placeholder,


### PR DESCRIPTION
Adds a set height to inputs and fixes line-height so text is vertically centered.

Fixes #390 

#### Before
<img width="499" alt="screen shot 2018-12-03 at 12 42 15 pm" src="https://user-images.githubusercontent.com/10561050/49353503-0ff7fc80-f6f9-11e8-89a3-3baa103cce2f.png">

#### After
<img width="527" alt="screen shot 2018-12-03 at 12 39 11 pm" src="https://user-images.githubusercontent.com/10561050/49353506-11c1c000-f6f9-11e8-955d-b8cd2adcc9ae.png">

#### Testing
1.  Fire up IE11.
2.  Visit any page with inputs.
3.  Add text and make sure text is vertically centered and inputs are correct height.