### PR TITLE
Fix checklist action button colors

### DIFF
--- a/assets/css/setup-checklist.css
+++ b/assets/css/setup-checklist.css
@@ -537,13 +537,13 @@
 }
 
 @media (max-width: 480px) {
-	.wp-core-ui .checklist__task-secondary .button-primary {
+	.wp-admin.wp-core-ui .checklist__task-secondary .button-primary {
 		color: #2e4453 !important;
 		background: #fff !important;
 		border-color: #c8d7e1 !important;
 	}
-	.wp-core-ui .checklist__task-secondary .button-primary:hover,
-	.wp-core-ui .checklist__task-secondary .button-primary:focus {
+	.wp-admin.wp-core-ui .checklist__task-secondary .button-primary:hover,
+	.wp-admin.wp-core-ui .checklist__task-secondary .button-primary:focus {
 		color: #2e4453 !important;
 		border-color: #a8bece !important;
 		background: #fff !important;


### PR DESCRIPTION
Fixes #391 

Sets the button colors to the secondary (white) color on mobile per original checklist designs.

#### Before
<img width="281" alt="screen shot 2018-12-03 at 1 23 34 pm" src="https://user-images.githubusercontent.com/10561050/49354610-a7138300-f6fe-11e8-97a6-065f1ef9f884.png">

#### After
<img width="299" alt="screen shot 2018-12-03 at 1 23 26 pm" src="https://user-images.githubusercontent.com/10561050/49354614-ad096400-f6fe-11e8-90f5-eb0946d76346.png">

#### Testing
1.  Visit the setup checklist `wp-admin/admin.php?page=wc-setup-checklist`.
2.  Narrow your viewport to 480px or less.
3.  Check that buttons are styled correctly.