### PR TITLE
Fix orders table layout on mobile

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1329,6 +1329,27 @@ th.sortable a, th.sorted a{
 .wp-list-table-wrapper .wp-list-table tr:not(.inline-edit-row):not(.no-items) td:not(.column-primary)::before {
 	display: none;
 }
+@media screen and (max-width: 782px) {
+	.wp-list-table-wrapper .wp-list-table th.column-primary ~ th,
+	.wp-list-table-wrapper .wp-list-table tr:not(.inline-edit-row):not(.no-items) td.column-primary ~ td:not(.check-column) {
+		display: none;
+	}
+	.post-type-shop_order .wp-list-table td.column-order_date, .post-type-shop_order .wp-list-table td.column-order_status {
+		display: table-cell !important;
+		padding: 16px 8px !important;
+	}
+	th#order_date,
+	th#order_status {
+		display: table-cell !important;
+	}
+	.post-type-shop_order .wp-list-table td.column-order_status {
+		float: none;
+		text-align: right;
+	}
+	th#order_status {
+		text-align: right;
+	}
+}
 
 /* Makes all rows have white background */
 .striped>tbody > :nth-child(odd), ul.striped > :nth-child(odd) {


### PR DESCRIPTION
Unhides table headers and fixes layout to match Calypso style on viewports less than 782px.

Fixes #409 

#### Before
<img width="578" alt="screen shot 2018-12-03 at 12 55 21 pm" src="https://user-images.githubusercontent.com/10561050/49358171-b6013200-f70c-11e8-89fa-f2f3532cd882.png">

#### After
<img width="560" alt="screen shot 2018-12-03 at 3 02 15 pm" src="https://user-images.githubusercontent.com/10561050/49358175-b8638c00-f70c-11e8-90a5-a9be9cc785d7.png">

#### Testing
1.  Visit `wp-admin/edit.php?post_type=shop_order`.
2.  Narrow viewport to <=782px
3.  Check that Orders table is not broken and layout matches Calypso's.