### PR TITLE
Add Calypsoify testing instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,41 @@ To check WPCS and lint errors via CLI, run the following from the root directory
 To automatically fix errors and beautify files, run the following from the root directory.
 `./vendor/bin/phpcbf [filename]`
 
+### Activating Calypsoify
+
+To Calypsoify the dashboard and test various functionality in this plugin, there are a number of conditions that must be met.
+
+#### Plugin Dependencies
+* WooCommerce >= 3.0.0
+* Jetpack
+
+Note that the plugin expects to find these plugins in their original folders, so renaming these folders may prevent the plugin from running.
+
+#### Jetpack Connection
+You will need either a connected Jetpack site or set your Jetpack development environment constants.  To enable Jetpack's dev mode, add this to your `wp-config.php` file:
+
+`define( 'JETPACK_DEV_DEBUG', true );`
+
+However, if your site is still not connected via Jetpack, you will not be able to fully test the Masterbar.  If you're working locally, you can Ngrok your local site to connect via Jetpack.  Also note that the `JETPACK_DEV_DEBUG` constant above will prevent making a new Jetpack connection.
+
+#### Option Values
+
+To make the bridge work, the site must have the ecommerce plan option set under the `at_options` option.  You can add this to your site by temporarily adding this to the plugin file:
+
+`update_option( 'at_options', array( 'plan_slug' => 'ecommerce' ) );`
+
+Clicking the "I'm Done Setting Up" button on the Setup Checklist page will mark the option `atomic-ecommerce-setup-checklist-complete` as true.  If you need to access this page again, you can update this in your database or temporarily add the following to your plugin file:
+
+`update_option( 'atomic-ecommerce-setup-checklist-complete', false );`
+
+#### Calypsoify Param
+Adding the Calypsoify param `calypsoify=1` to the URL will Calypsoify any WooCommerce or WC Calypso Bridge route once the above dependencies have been met.
+
+`/wp-admin/edit.php?post_type=shop_order&calypsoify=1`
+
+If you manually visit a route that is not able to be Calypsoified (i.e, visiting `wp-admin/*` directly via URL) you will be bumped out of Calypsoify mode and need to add the param to the URL once again to reactivate it.
+
+
 ## Test Suite
 
 This repository does have a test suite, which depends upon `wc-api-dev`, and `woocommerce` both being present witin the same `wp-content/plugins` directory. Much like the test suite in `wc-api-dev` it borrows heavily from the base `woocommerce` API test suite to enable quick testing via all of the core helper methods.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,52 @@ Adding the Calypsoify param `calypsoify=1` to the URL will Calypsoify any WooCom
 If you manually visit a route that is not able to be Calypsoified (i.e, visiting `wp-admin/*` directly via URL) you will be bumped out of Calypsoify mode and need to add the param to the URL once again to reactivate it.
 
 
+### Plugin Integrations
+
+The ecommerce plan comes bundled with a number of plugins that this plugin integrates with if activated.  To fully test this plugin's functionality, the following plugins can be installed.
+
+* Payments
+    * [WooCommerce Stripe Payment Gateway](https://href.li/?https://wordpress.org/plugins/woocommerce-gateway-stripe/)
+    * [WooCommerce PayPal Checkout Payment Gateway](https://href.li/?https://wordpress.org/plugins/woocommerce-gateway-paypal-express-checkout/)
+    * [WooCommerce Square](https://href.li/?https://wordpress.org/plugins/woocommerce-square/)
+    * [Klarna Payments for WooCommerce](https://href.li/?https://wordpress.org/plugins/klarna-payments-for-woocommerce/)
+    * [Klarna Checkout for WooCommerce](https://href.li/?https://wordpress.org/plugins/klarna-checkout-for-woocommerce/)
+    * [WooCommerce eWAY Gateway](https://href.li/?https://wordpress.org/plugins/woocommerce-gateway-eway/)
+    * [WooCommerce PayFast Gateway](https://href.li/?https://wordpress.org/plugins/woocommerce-payfast-gateway/)
+* Taxes:
+    * [TaxJar -- Sales Tax Automation for WooCommerce](https://href.li/?https://wordpress.org/plugins/taxjar-simplified-taxes-for-woocommerce/)
+* Shipping:
+    * [WooCommerce Services](https://href.li/?https://wordpress.org/plugins/woocommerce-services/)
+* Marketing:
+    * [MailChimp for WooCommerce](https://href.li/?https://wordpress.org/plugins/mailchimp-for-woocommerce/)
+    * [Facebook  for WooCommerce](https://href.li/?https://woocommerce.com/products/facebook/)
+* Store Management:
+    * [TaxJar -- Sales Tax Automation for WooCommerce](https://href.li/?https://wordpress.org/plugins/taxjar-simplified-taxes-for-woocommerce/)
+
+* Theme:
+    * [Storefront](https://href.li/?https://woocommerce.com/storefront/)
+
+#### Paid extensions
+
+* Shipping (everywhere):
+    * [UPS Shipping Method](https://href.li/?https://woocommerce.com/products/ups-shipping-method/)
+* Shipping (based on geo):
+    * [USPS Shipping Method](https://href.li/?https://woocommerce.com/products/usps-shipping-method/)
+    * [Canada Post shipping](https://href.li/?https://woocommerce.com/products/canada-post-shipping-method/)
+    * [Royal Mail](https://href.li/?https://woocommerce.com/products/royal-mail/)
+    * [Australia Post Shipping Method](https://href.li/?https://woocommerce.com/products/australia-post-shipping-method/)
+* Product Page Features:
+    * [Product Add-Ons](https://href.li/?https://woocommerce.com/products/product-add-ons/)
+* Storefront premium options
+    * [Galleria](https://href.li/?https://woocommerce.com/products/galleria/)
+    * [Homestore](https://href.li/?https://woocommerce.com/products/homestore/)
+    * [Bookshop](https://href.li/?https://woocommerce.com/products/bookshop/)
+    * [Storefront Powerpack design options](https://href.li/?https://woocommerce.com/products/storefront-powerpack/)
+    * [Blog Customizer](https://woocommerce.com/products/storefront-blog-customiser/)
+    * [Parallax Hero](https://woocommerce.com/products/storefront-parallax-hero/)
+    * [Product Hero](https://woocommerce.com/products/storefront-product-hero/)
+    * [Reviews](https://woocommerce.com/products/storefront-reviews/)
+
 ## Test Suite
 
 This repository does have a test suite, which depends upon `wc-api-dev`, and `woocommerce` both being present witin the same `wp-content/plugins` directory. Much like the test suite in `wc-api-dev` it borrows heavily from the base `woocommerce` API test suite to enable quick testing via all of the core helper methods.


### PR DESCRIPTION
Adds basic dependency and testing instructions to the README to get Calypsoify working in the dashboard.

Fixes #392 

#### Screenshots
<img width="1163" alt="screen shot 2018-12-03 at 3 31 02 pm" src="https://user-images.githubusercontent.com/10561050/49359230-83593880-f710-11e8-80cb-1a44a2091cd4.png">

#### Testing
1.  Check the README on this branch.
2.  Follow instructions provided to see if they work to Calypsoify a new site.