### PR TITLE
Add support links with tracking

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2594,3 +2594,8 @@ h3#woocommerce_stripe_connection_status {
 .post-type-shop_order .minute[name="order_date_minute"] {
 	margin-left: 2px;
 }
+
+/* WooCommerce Footer help text */
+.woocommerce-help-text {
+	text-align: center;
+}

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -341,7 +341,41 @@
         setTimeout( function() {
             $( '.select2-container--open .select2-search__field' ).focus();
         }, 0 );
-    } );
+	} );
+
+	$( document ).ready( function() {
+		$( '.toplevel_page_wc-support' ).attr( 'target', '_blank' );
+	} );
+
+	/**
+	 * Support link click event
+	 */
+	$( '.wc-support-link' ).unbind("click").click( function( e ) {
+		const source = $( this ).data( 'source' )
+		const href = $( this ).attr('href');
+		trackSupportClick( source, href );
+	} );
+
+	/**
+	 * Track support link clicks in Jetpack if enabled
+	 *
+	 * @param {string} source Source of click (footer or sidebar)
+	 * @param {string} href Link location
+	 */
+	function trackSupportClick( source, href ) {
+		if ( window.jpTracksAJAX ) {
+			return window.jpTracksAJAX.record_ajax_event(
+				'atomic_wc_support_link_click',
+				'click',
+				{
+					href,
+					source,
+				}
+			);
+		} else {
+			return true;
+		}
+	}
 
 
 } )( jQuery );

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -291,8 +291,16 @@ class WC_Calypso_Bridge {
 			</g>
 		</svg>';
 
+		$help_text = sprintf(
+			// translators: "Need help? Read the {link to support document}eCommerce plan support document{/link to support document} or {link to help}get in touch with support{/link to help}.".
+			__( 'Need help? Read the <a href="%1$s" class="wc-support-link" data-source="footer" target="_blank">eCommerce plan support document</a> or <a href="%2$s" class="wc-support-link" data-source="footer" target="_blank">get in touch with support</a>.', 'wc-calypso-bridge' ),
+			'https://en.support.wordpress.com/ecommerce-plan/',
+			'https://wordpress.com/help/contact'
+		);
+
 		// translators: "Powered by <WooCommerce Logo SVG>".
 		echo '<div class="woocommerce-colophon"><span>' . sprintf( __( 'Powered by %s', 'wc-calypso-bridge' ), $svg ) . '</span></div>'; // WPCS: XSS ok.
+		echo '<p class="woocommerce-help-text">' . $help_text . '</p>'; // WPCS: XSS ok.
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-menus.php
+++ b/includes/class-wc-calypso-bridge-menus.php
@@ -40,6 +40,7 @@ class WC_Calypso_Bridge_Menus {
 		add_action( 'admin_menu', array( $this, 'remove_create_new_menu_items' ), 100 );
 
 		add_action( 'admin_menu', array( $this, 'add_calypso_link' ), -10 ); // Before Setup.
+		add_action( 'admin_menu', array( $this, 'add_support_link' ) );
 	}
 
 	/**
@@ -68,6 +69,36 @@ class WC_Calypso_Bridge_Menus {
 		$redirect_url = 'https://wordpress.com/stats/day/' . $site_slug;
 
 		wp_redirect( $redirect_url );
+		exit;
+	}
+
+	/**
+	 * Adds a support link to the sidebar.
+	 */
+	public function add_support_link() {
+		add_menu_page(
+			__( 'Support', 'wc-calypso-bridge' ),
+			__( 'Support', 'wc-calypso-bridge' ),
+			'manage_woocommerce',
+			'wc-support',
+			array( $this, 'support_link' ),
+			'dashicons-editor-help',
+			1000
+		);
+	}
+
+	/**
+	 * Redirects the user to support.
+	 */
+	public function support_link() {
+		WC_Calypso_Bridge::record_event(
+			'jetpack_atomic_wc_support_link_click',
+			array(
+				'source' => 'sidebar',
+				'href'   => 'https://wordpress.com/help/contact',
+			)
+		);
+		wp_redirect( 'https://wordpress.com/help/contact' );
 		exit;
 	}
 

--- a/includes/connect/wc-calypso-bridge.php
+++ b/includes/connect/wc-calypso-bridge.php
@@ -20,3 +20,10 @@ wc_calypso_bridge_connect_page(
 		'menu'      => 'wc-wp-manage-site',
 	)
 );
+
+wc_calypso_bridge_connect_page(
+	array(
+		'screen_id' => 'toplevel_page_wc-support',
+		'menu'      => 'wc-support',
+	)
+);


### PR DESCRIPTION
Fixes #416.

This PR adds support links to the footer and sidebar per the issue. It also adds tracks events so we can see how often these are clicked, and from which area.

To Test:
* Test on a Jetpack Connected site.
* Test the sidebar link and make sure you are sent to the contact form, in a new window.
* Test both of the footer links to verify you are opened in a new window.
* Open tracks live `tracks/live/?eventname=jetpack_atomic_wc_support_link_click` (may take a few minutes to show up) and verify events trigger for all three of these clicks.

<img width="650" alt="screen shot 2018-12-07 at 9 45 23 am" src="https://user-images.githubusercontent.com/689165/49654085-de3aaa80-fa04-11e8-8ea4-8b9f2250e2ce.png">

<img width="288" alt="screen shot 2018-12-07 at 9 45 28 am" src="https://user-images.githubusercontent.com/689165/49654091-e1ce3180-fa04-11e8-851b-7ee43724a7c5.png">

<img width="430" alt="screen shot 2018-12-07 at 9 45 34 am" src="https://user-images.githubusercontent.com/689165/49654094-e4c92200-fa04-11e8-8d69-bbaeaaf59274.png">


