### PR TITLE
Bump version to 1.0.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "automattic/wc-calypso-bridge",
-	"version": "v1.0.7",
+	"version": "v1.0.8",
 	"autoload": {
 		"files": [
 			"wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 1.0.7
+Stable tag: 1.0.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,12 @@ This section describes how to install the plugin and get it working.
 1. Activate the plugin through the 'Plugins' screen in WordPress
 
 == Changelog ==
+
+= 1.0.8 =
+* Add support links (with tracking) to the interface
+* Redirect checlist to setup if the setup wizard hasn't ran yet
+* Add testing instructions to README
+* Fix some IE11 styles
 
 = 1.0.7 =
 * Storefront customizer setup nonce fix

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 1.0.7
+ * Version: 1.0.8
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -30,7 +30,7 @@ if ( file_exists( WP_PLUGIN_DIR . '/wc-calypso-bridge/wc-calypso-bridge.php' ) )
 	}
 }
 
-define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.0.7' );
+define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.0.8' );
 define( 'WC_MIN_VERSION', '3.0.0' );
 
 /**


### PR DESCRIPTION
I didn't end up packaging this release last week, but it closes out a few open issues in the eCommerce plan Trello like support links and redirecting to setup if needed.