### PR TITLE
Forces the customizer setup checklist link to load the Starter Content.

### DIFF
--- a/includes/class-wc-calypso-bridge-admin-setup-checklist.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-checklist.php
@@ -330,16 +330,9 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 		$wc_canada_post_merchant_username = get_option( 'wc_canada_post_merchant_username' );
 		$wc_canada_post_merchant_password = get_option( 'wc_canada_post_merchant_password' );
 
-		$count_wc_product_posts      = wp_count_posts( 'product' );
-		$wc_published_products_count = $count_wc_product_posts->publish;
-		$customize_extra_params      = '';
-		$sf_nonce                    = wp_create_nonce( 'storefront_ecommerce_plan_starter_content' );
-		if ( 0 === absint( $wc_published_products_count ) ) {
-			$customize_extra_params = esc_attr( 'sf_starter_content=1&homepage=on&products=on&action=storefront_ecommerce_plan_starter_content&_wpnonce=' . $sf_nonce );
-			$customizer_link        = 'admin-post.php?' . $customize_extra_params;
-		} else {
-			$customizer_link = 'customize.php?return=%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-setup-checklist&wc-setup-step=customize';
-		}
+		$sf_nonce               = wp_create_nonce( 'storefront_ecommerce_plan_starter_content' );
+		$customize_extra_params = esc_attr( 'sf_starter_content=1&homepage=on&products=on&action=storefront_ecommerce_plan_starter_content&_wpnonce=' . $sf_nonce );
+		$customizer_link        = 'admin-post.php?' . $customize_extra_params;
 
 		$all_tasks = array(
 			array(

--- a/includes/class-wc-calypso-bridge-admin-setup-checklist.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-checklist.php
@@ -329,10 +329,15 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 		$click_settings                   = get_option( 'woocommerce_setup_checklist_clicks' );
 		$wc_canada_post_merchant_username = get_option( 'wc_canada_post_merchant_username' );
 		$wc_canada_post_merchant_password = get_option( 'wc_canada_post_merchant_password' );
+		$has_starter_content_imported     = get_option( 'wpcom_ec_plan_starter_content_imported', false );
 
-		$sf_nonce               = wp_create_nonce( 'storefront_ecommerce_plan_starter_content' );
-		$customize_extra_params = esc_attr( 'sf_starter_content=1&homepage=on&products=on&action=storefront_ecommerce_plan_starter_content&_wpnonce=' . $sf_nonce );
-		$customizer_link        = 'admin-post.php?' . $customize_extra_params;
+		if ( ! $has_starter_content_imported ) {
+			$sf_nonce               = wp_create_nonce( 'storefront_ecommerce_plan_starter_content' );
+			$customize_extra_params = esc_attr( 'sf_starter_content=1&homepage=on&products=on&action=storefront_ecommerce_plan_starter_content&_wpnonce=' . $sf_nonce . '&wc-setup-step=customize' );
+			$customizer_link        = 'admin-post.php?' . $customize_extra_params;
+		} else {
+			$customizer_link = 'customize.php?return=%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-setup-checklist&wc-setup-step=customize';
+		}
 
 		$all_tasks = array(
 			array(

--- a/includes/class-wc-calypso-bridge-themes-setup.php
+++ b/includes/class-wc-calypso-bridge-themes-setup.php
@@ -37,6 +37,16 @@ class WC_Calypso_Bridge_Themes_Setup {
 	private function __construct() {
 		// Set default theme values.
 		add_action( 'init', array( $this, 'set_theme_default_values' ) );
+		add_action( 'customize_save_after', array( $this, 'mark_import_as_completed' ) );
+	}
+
+	/**
+	 * Sets starter content import of products to complete.
+	 *
+	 * @return void
+	 */
+	public function mark_import_as_completed() {
+		update_option( 'wpcom_ec_plan_starter_content_imported', true );
 	}
 
 	/**


### PR DESCRIPTION
Test Plan:

1. Start with a fresh site with none of the checklist items completed.
2. Test that the correct starter content loads when clicking the "Do It" button for the second step "View and Customize" - you should see the Welcome paralax hero area, example products, and the widgets in the footer.
3. Add a new product in the first step of the checklist, and publish it.
4. Go back to the checklist page.
5. Click the "Do It" button or "Open Customizer" link in the "View and Customize" second step.
6. The starter content should still load with the example content.
7. Navigate to the Shop page where the 12 example products should load, with your added product appended to the end of this list.

CC @danieldudzic 