### PR TITLE
Store on WP.com: Fix fatal error on MailChimp deactivation + 1.0.9 bump

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "automattic/wc-calypso-bridge",
-	"version": "v1.0.8",
+	"version": "v1.0.9",
 	"autoload": {
 		"files": [
 			"wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 1.0.8
+Stable tag: 1.0.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ This section describes how to install the plugin and get it working.
 1. Activate the plugin through the 'Plugins' screen in WordPress
 
 == Changelog ==
+
+= 1.0.9 =
+* Fix for fatal errors that can occur when deactivating MailChimp on Store on WP.com stores.
 
 = 1.0.8 =
 * Add support links (with tracking) to the interface

--- a/store-on-wpcom/inc/wc-calypso-bridge-mailchimp-deactivate-hook.php
+++ b/store-on-wpcom/inc/wc-calypso-bridge-mailchimp-deactivate-hook.php
@@ -1,6 +1,8 @@
 <?php
 /**
  * Clear out MailChimp tables on deactivation
+ *
+ * @package WC_Calypso_Bridge
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -9,6 +11,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 register_deactivation_hook( 'mailchimp-for-woocommerce/mailchimp-woocommerce.php', 'wc_calypso_bridge_clear_mailchimp_tables' );
 
+/**
+ * Clears out MailChimp queue tables on deactivation.
+ */
 function wc_calypso_bridge_clear_mailchimp_tables() {
 	global $wpdb;
 	$logger = false;
@@ -23,10 +28,8 @@ function wc_calypso_bridge_clear_mailchimp_tables() {
 		"{$wpdb->prefix}mailchimp_carts",
 	);
 
-	foreach( (array) $mailchimp_tables as $table ) {
-		$sql = $wpdb->prepare( "TRUNCATE TABLE `$table`" );
-
-		if ( $wpdb->query( $sql ) ) {
+	foreach ( (array) $mailchimp_tables as $table ) {
+		if ( $wpdb->query( "TRUNCATE TABLE `$table`" ) ) { // WPCS: unprepared SQL ok.
 			$log_message = "Plugin Deactivated: success clearing `$table` table.";
 		} else {
 			$log_message = "Plugin Deactivated: FAILURE clearing `$table` table.";

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 1.0.8
+ * Version: 1.0.9
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -30,7 +30,7 @@ if ( file_exists( WP_PLUGIN_DIR . '/wc-calypso-bridge/wc-calypso-bridge.php' ) )
 	}
 }
 
-define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.0.8' );
+define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.0.9' );
 define( 'WC_MIN_VERSION', '3.0.0' );
 
 /**


### PR DESCRIPTION
This PR targets Store on WP.com specifically. In Slack (p1545234153492100-slack-atomic), a fatal was reported that can occur when MailChimp is deactivated.

`PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function wpdb::prepare(), 1 passed in /wordpress/plugins/wpcomsh/2.3.49/vendor/automattic/wc-calypso-bridge/store-on-wpcom/inc/wc-calypso-bridge-mailchimp-deactivate-hook.php on line 27 and exactly 2`

This PR fixes the fatal. I've moved the prepare since we are not using placeholders (and doing so here would add quotes around the table name). It also does some minor code cleanup to make the linter happy, and it bumps the version to 1.0.9.

To Test:
* In `wc-calypso-bridge.php` you can edit `if ( ! wc_calypso_bridge_is_ecommerce_plan() ) {` to be `if( true ) {` instead, to force Store on WP.com code to load instead of the eCommerce plan.
* Deactivate MailChimp.
* Go to `/wp-admin/admin.php?page=wc-status&tab=logs` and check out the mailchimp log for the day. You should see some success messages instead of a a fatal.