### PR TITLE
Fix blank state button size

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -622,7 +622,7 @@ input[type=radio]:checked:before {
 .wc_addons_wrap .addons-button-outline-green,
 .wc_addons_wrap .addons-button-outline-white,
 .wp-core-ui.wp-admin .edit-tag-actions .button-primary,
-.woocommerce-BlankState a.button,
+.wp-core-ui.wp-admin .woocommerce-BlankState a.button,
 .setup-footer a,
 .wp-core-ui.wp-admin .action-header .page-title-action,
 .wp-core-ui.wp-admin .action-header .add-new-h2,


### PR DESCRIPTION
Fixes #422 

Makes the primary blank slate button size large to match the secondary button.

### Before
<img width="555" alt="screen shot 2019-01-15 at 5 34 05 pm" src="https://user-images.githubusercontent.com/10561050/51171917-0fa07300-18ed-11e9-9d52-5a22a69ced8e.png">

### After
<img width="579" alt="screen shot 2019-01-15 at 5 42 25 pm" src="https://user-images.githubusercontent.com/10561050/51171924-116a3680-18ed-11e9-8aa3-71639ad3b50e.png">

### Testing
1.  Create a new site or delete existing products (including trash and drafts).
2.  Visit the products page with calypsoify enabled `/wp-admin/edit.php?post_type=product`.
3.  Check that the primary (blue) button is large and matches the secondary button size.