### PR TITLE
Bump version to 1.0.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "automattic/wc-calypso-bridge",
-	"version": "v1.0.10",
+	"version": "v1.0.11",
 	"autoload": {
 		"files": [
 			"wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 1.0.10
+Stable tag: 1.0.11
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+* 1.0.11 =
+* eCommerce Plan: Fix duplicated "manage your subscriptions" banner.
+
 = 1.0.10 =
 * eCommerce Plan: Fix blank state button size.
 * eCommerce Plan: Forces the customizer setup checklist link to load the Starter Content.

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 1.0.10
+ * Version: 1.0.11
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -30,7 +30,7 @@ if ( file_exists( WP_PLUGIN_DIR . '/wc-calypso-bridge/wc-calypso-bridge.php' ) )
 	}
 }
 
-define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.0.10' );
+define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.0.11' );
 define( 'WC_MIN_VERSION', '3.0.0' );
 
 /**


### PR DESCRIPTION
This PR bumps `wc-calypso-bridge` to 1.0.11.

It contains one fix for fixing a duplicate subscription banner from showing up on the eCommerce plan.

I'm bundling this up to include in a `wpcomsh` version bump along-side with removing `wc-api-dev`.