### PR TITLE
Update load order for Store on WP.com REST API

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -23,6 +23,7 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 * 1.0.11 =
+* Store on WP.com: Update API endpoint load order.
 * eCommerce Plan: Fix duplicated "manage your subscriptions" banner.
 
 = 1.0.10 =

--- a/store-on-wpcom/class-wc-calypso-bridge.php
+++ b/store-on-wpcom/class-wc-calypso-bridge.php
@@ -39,17 +39,6 @@ class WC_Calypso_Bridge {
 	}
 
 	/**
-	 * Loads API includes and registers routes.
-	 */
-	private function init() {
-		if ( $this->is_woocommerce_valid() ) {
-			$this->includes();
-			// Ensure wc-api-dev has already registered routes.
-			add_action( 'rest_api_init', array( $this, 'register_routes' ), 20 );
-		}
-	}
-
-	/**
 	 * Makes sure WooCommerce is installed and up to date.
 	 */
 	public function is_woocommerce_valid() {

--- a/store-on-wpcom/class-wc-calypso-bridge.php
+++ b/store-on-wpcom/class-wc-calypso-bridge.php
@@ -32,7 +32,10 @@ class WC_Calypso_Bridge {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( 'woocommerce_init', array( $this, 'init' ), 20 );
+		if ( $this->is_woocommerce_valid() ) {
+			$this->includes();
+			add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+		}
 	}
 
 	/**
@@ -86,11 +89,6 @@ class WC_Calypso_Bridge {
 		include_once dirname( __FILE__ ) . '/api/class-wc-calypso-bridge-settings-email-groups-controller.php';
 		include_once dirname( __FILE__ ) . '/api/class-wc-calypso-bridge-data-counts-controller.php';
 		include_once dirname( __FILE__ ) . '/api/class-wc-calypso-bridge-product-reviews-controller.php';
-
-		if ( class_exists( 'MailChimp_Woocommerce' ) ) {
-			include_once dirname( __FILE__ ) . '/api/class-wc-calypso-bridge-mailchimp-settings-controller.php';
-		}
-
 	}
 
 	/**
@@ -107,7 +105,8 @@ class WC_Calypso_Bridge {
 		);
 
 		if ( class_exists( 'MailChimp_Woocommerce' ) ) {
-				$controllers[] = 'WC_Calypso_Bridge_MailChimp_Settings_Controller';
+			include_once dirname( __FILE__ ) . '/api/class-wc-calypso-bridge-mailchimp-settings-controller.php';
+			$controllers[] = 'WC_Calypso_Bridge_MailChimp_Settings_Controller';
 		}
 
 		foreach ( $controllers as $controller ) {


### PR DESCRIPTION
Re https://github.com/Automattic/wpcomsh/pull/230 @timmyc 

> when attempting to test out reviews - I was getting a rest_no_route response:

I swear that this was working for me before, but I can confirm that `calypso-reviews` (and `data/counts`) are not loading. These are loaded by `wc-calypso-bridge` in Store on WP.com mode.

I got this to work after updating the load order.

To test: Load up a Store on WP.com with this branch and test the reviews tab.
Note that I plan on rebuilding the .zip/release and regenerating the wpcomsh PR, so testing can happen there after that is well.