### PR TITLE
Ecom Setup Checklist: Look at the proper Paypal settings.

### DIFF
--- a/includes/class-wc-calypso-bridge-admin-setup-checklist.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-checklist.php
@@ -434,9 +434,6 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 				'learn_more'      => 'https://woocommerce.com/products/woocommerce-gateway-paypal-checkout/',
 				'condition'       => isset( $click_settings['paypal'] ) &&
 								true === (bool) $click_settings['paypal'] &&
-								! empty( $paypal_settings['api_username'] ) &&
-								! empty( $paypal_settings['api_password'] ) &&
-								( ! empty( $paypal_settings['api_signature'] ) || ! empty( $paypal_settings['api_certificate'] ) ) &&
 								'yes' === $paypal_settings['enabled'],
 				'extension'       => 'woocommerce-gateway-paypal-express-checkout/woocommerce-gateway-paypal-express-checkout.php',
 			),


### PR DESCRIPTION
This was checking for paypal api keys, but the setup item is for express checkout
that doesn't have api keys so it was not posible to complete the item.

Testing:
I am not sure how to test this, any pointers?