### PR TITLE
Cannot use a private method here:

### DIFF
--- a/store-on-wpcom/class-wc-calypso-bridge.php
+++ b/store-on-wpcom/class-wc-calypso-bridge.php
@@ -38,7 +38,7 @@ class WC_Calypso_Bridge {
 	/**
 	 * Loads API includes and registers routes.
 	 */
-	private function init() {
+	public function init() {
 		if ( $this->is_woocommerce_valid() ) {
 			$this->includes();
 			// Ensure wc-api-dev has already registered routes.


### PR DESCRIPTION
E_WARNING: wp-includes/class-wp-hook.php:286 - call_user_func_array() expects parameter 1 to be a valid callback, cannot access private method WC_Calypso_Bridge::init()
require('wp-blog-header.php'), require_once('wp-load.php'), require_once('/srv/htdocs/wp-config.php'), require_once('wp-settings.php'), do_action('init'), WP_Hook->do_action, WP_Hook->apply_filters, WooCommerce->init, do_action('woocommerce_init'), WP_Hook->do_action, WP_Hook->apply_filters