### PR TITLE
Store on WPCOM: Only include API logic on rest requests.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "automattic/wc-calypso-bridge",
-	"version": "v1.0.13",
+	"version": "v1.0.14",
 	"autoload": {
 		"files": [
 			"wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 1.0.13
+Stable tag: 1.0.14
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ This section describes how to install the plugin and get it working.
 1. Activate the plugin through the 'Plugins' screen in WordPress
 
 == Changelog ==
+
+* 1.0.14 =
+* Fix for Core Woo REST controllers only being loaded on rest requests in 3.6 beta 1 
 
 * 1.0.11 =
 * eCommerce Plan: Fix duplicated "manage your subscriptions" banner.

--- a/store-on-wpcom/class-wc-calypso-bridge.php
+++ b/store-on-wpcom/class-wc-calypso-bridge.php
@@ -80,7 +80,14 @@ class WC_Calypso_Bridge {
 		include_once dirname( __FILE__ ) . '/inc/wc-calypso-bridge-paypal-defaults.php';
 		include_once dirname( __FILE__ ) . '/inc/wc-calypso-bridge-paypal-method-supports.php';
 		include_once dirname( __FILE__ ) . '/inc/wc-calypso-bridge-products.php';
+	}
 
+	/**
+	 * Register REST API routes.
+	 *
+	 * New endpoints/controllers can be added here.
+	 */
+	public function register_routes() {
 		/** API includes */
 		include_once dirname( __FILE__ ) . '/api/class-wc-calypso-bridge-send-invoice-controller.php';
 		include_once dirname( __FILE__ ) . '/api/class-wc-calypso-bridge-settings-email-groups-controller.php';
@@ -91,14 +98,6 @@ class WC_Calypso_Bridge {
 			include_once dirname( __FILE__ ) . '/api/class-wc-calypso-bridge-mailchimp-settings-controller.php';
 		}
 
-	}
-
-	/**
-	 * Register REST API routes.
-	 *
-	 * New endpoints/controllers can be added here.
-	 */
-	public function register_routes() {
 		$controllers = array(
 			'WC_Calypso_Bridge_Send_Invoice_Controller',
 			'WC_Calypso_Bridge_Settings_Email_Groups_Controller',

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 1.0.13
+ * Version: 1.0.14
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4


### PR DESCRIPTION
While trying to recreate the bug logged in https://github.com/Automattic/atomic/issues/770 - I encountered the same bug with 3.6 beta 1 where WC REST classes are no longer being loaded on all requests. ( See https://github.com/woocommerce/wc-api-dev/pull/125 for more details )

The diff here looks a bit odd, but essentially I have moved the includes of all custom REST logic for Store endpoints into the `register_routes()` callback which is hooked into `rest_api_init` to fix the problem.

I will try to recreate the Atomic issue that is only happening on V2 as well, but might fix that in a follow-up PR. I feel we might just need to finally remove all MailChimp logic from this plugin completely.

__To Test__
- Install WooCommerce 3.6 Beta 1, or `master` of Woo
- Add this plugin, verify breakage
- Checkout this branch, verify no more breakage
- Visit `/wp-json/wc/v3` and verify the endpoints added for Store are visible in the context of the REST request

![image](https://user-images.githubusercontent.com/22080/55019353-f5040d80-4fb1-11e9-92c2-811123021cc3.png)
