### PR TITLE
Disable marketplace suggestions.

### DIFF
--- a/includes/class-wc-calypso-bridge-hide-alerts.php
+++ b/includes/class-wc-calypso-bridge-hide-alerts.php
@@ -39,6 +39,7 @@ class WC_Calypso_Bridge_Hide_Alerts {
 		add_action( 'admin_head', array( $this, 'suppress_admin_notices' ) );
 		add_filter( 'woocommerce_helper_suppress_connect_notice', '__return_true' );
 		add_filter( 'woocommerce_show_admin_notice', '__return_false' );
+		add_filter( 'woocommerce_allow_marketplace_suggestions', '__return_false' );
 
 		add_action( 'admin_head', array( $this, 'hide_alerts_on_non_settings_pages' ) );
 	}


### PR DESCRIPTION
This branch adds in a filter to disable Marketplace Suggestions on sites running WooCommerce 3.6

__Before__
![sugestions-before](https://user-images.githubusercontent.com/22080/55992756-28a58f80-5c62-11e9-943c-cc97e9a6f761.png)

__After__
![after-suggestions](https://user-images.githubusercontent.com/22080/55992765-2e9b7080-5c62-11e9-9b75-1a00d244a51d.png)

__To Test__
- Install WooCommerce 3.6 or checkout `master`
- Apply this branch
- Go to add or edit a product, and verify suggestions are not being shown.