### PR TITLE
Make sure obw scripts are printed in wizard

### DIFF
--- a/includes/class-wc-calypso-bridge-admin-setup-wizard.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-wizard.php
@@ -56,7 +56,7 @@ class WC_Calypso_Bridge_Admin_Setup_Wizard extends WC_Admin_Setup_Wizard {
 			<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 			<title><?php esc_html_e( 'WooCommerce &rsaquo; Setup Wizard', 'wc-calypso-bridge' ); ?></title>
 			<?php do_action( 'admin_enqueue_scripts' ); ?>
-			<?php wp_print_scripts( 'wc-setup' ); ?>
+			<?php wp_print_scripts( array( 'wc-setup', 'wc-calypso-bridge-calypsoify-obw' ) ); ?>
 			<?php do_action( 'admin_print_styles' ); ?>
 			<?php do_action( 'admin_print_scripts' ); ?>
 			<?php do_action( 'admin_head' ); ?>
@@ -290,7 +290,7 @@ class WC_Calypso_Bridge_Admin_Setup_Wizard extends WC_Admin_Setup_Wizard {
 	 */
 	public function enqueue_calypsoify_scripts() {
 		$asset_path = WC_Calypso_Bridge::$plugin_asset_path ? WC_Calypso_Bridge::$plugin_asset_path : WC_Calypso_Bridge::MU_PLUGIN_ASSET_PATH;
-		wp_enqueue_script( 'wc-calypso-bridge-calypsoify-obw', $asset_path . 'assets/js/calypsoify-obw.js', array( 'jquery' ), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
+		wp_register_script( 'wc-calypso-bridge-calypsoify-obw', $asset_path . 'assets/js/calypsoify-obw.js', array( 'jquery' ), WC_CALYPSO_BRIDGE_CURRENT_VERSION, true );
 	}
 
 	/**


### PR DESCRIPTION
Explicitly prints the `calypsoify-obw.js` script in the header during the wizard.

### Screenshot
<img width="586" alt="Screen Shot 2019-06-11 at 4 34 26 PM" src="https://user-images.githubusercontent.com/10561050/59256563-cc151f80-8c66-11e9-8f00-1efaef8a1d9c.png">
<img width="595" alt="Screen Shot 2019-06-11 at 4 04 55 PM" src="https://user-images.githubusercontent.com/10561050/59256564-ccadb600-8c66-11e9-8c9d-771b3b2d1674.png">

### Testing
1.  Visit `wp-admin/index.php?page=wc-setup`.
2. Note that `calypsoify-obw.js` is loaded on the page.
3. Note that the "Continue" button is now working.