### PR TITLE
Update styles on the two setup screens for WooCommerce

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -336,11 +336,11 @@ input[type=radio]:checked:before {
 	0% {
 		transform: scale(0.3);
 	}
-	
+
 	60% {
 		transform: scale(1.15);
 	}
-	
+
 	100% {
 		transform: scale(1);
 	}
@@ -1417,7 +1417,7 @@ table.widefat {
 
 /* Onboarding wizard */
 .wc-setup-page {
-	background: #F3F6F8;
+	background: #F6F6F6;
 }
 .wc-setup-page .action-header {
 	display: none;
@@ -1427,6 +1427,8 @@ table.widefat {
 	max-width: 960px;
 }
 .wc-setup-content {
+	border-radius: 3px;
+	box-shadow: 0 2px 2px 0 rgba(0,0,0,.14),0 3px 1px -2px rgba(0,0,0,.12),0 1px 5px 0 rgba(0,0,0,.2);
 	max-width: 500px;
 	padding: 24px;
 	margin: 0 auto 20px;
@@ -1759,52 +1761,36 @@ form[name="cleanup_options"] fieldset label select {
 }
 
 /* Onboarding wizard steps */
-html.wc-setup-page:before,
-html.wc-setup-page:after {
-	content: "";
-	background: #e9eff3;
-	display: block;
-	position: fixed;
-	width: 250px;
-	height: 350px;
-	transform: rotate(-10deg);
-	left: -30px;
-	bottom: -30px;
-	z-index: -1;
-}
-html.wc-setup-page:after {
-	left: auto;
-	bottom: auto;
-	top: -30px;
-	right: -30px;
-	z-index: -1;
-}
 .wc-step-heading {
-	margin-top: 116px;
-	margin-bottom: 30px;
-}
-.wc-step-heading h1 {
-	font-size: 50px;
-	color: #2e4453;
-	line-height: 1;
-	font-weight: 700;
-	margin-top: 0;
-	margin-bottom: 12px;
-	padding-bottom: 0;
-	border-bottom: 0;
-}
-.wc-step-heading h2 {
-	color: #4f748e;
-	font-size: 20px;
-	line-height: 1.5;
-	margin-bottom: 0;
-	padding-bottom: 0;
-	border-bottom: 0;
+	margin: 16px 0;
+	text-align: center
 }
 
-@media screen and (max-width:782px) {
-	.wc-step-heading {
-		margin-top: 71px;
+.wc-step-heading h1 {
+	border: 0;
+	color: #2E4453;
+	font-size: 24px;
+	margin: 0 0 5px;
+	padding: 0;
+}
+
+@media (max-width:480px) {
+	.wc-step-heading h1 {
+		line-height: 1.2em;
+		padding: 0 10px;
+	}
+}
+
+.wc-step-heading h2 {
+	border: 0;
+	color: #2E4453;
+	font-size: 14px;
+	margin: 0;
+}
+
+@media (max-width:480px) {
+	.wc-step-heading h2 {
+		padding: 0 20px;
 	}
 }
 


### PR DESCRIPTION
As part of the #FixtheFlows effort, this PR makes changes to the two 'setup' screens in the plugin, to help them better match the current styles used for the https://wordpress.com/start screens, primarily the header fonts, background colour, and button colours. 

This PR focuses on the fonts, and removing the squares from the background -- at the moment, changing the background colour on these screens would make it blend into the masterbar, and the button colours are coming from Jetpack's Calypsoify code, and are being updated there. 

We can update the background if/when the masterbar is removed to match other sign-up screens. 

Fixes #447.

Steps to test:

1. Review the screens /wp-admin/admin.php?page=wc-setup and wp-admin/admin.php?page=wc-setup&step=payment on a test site.
2. Compare against https://wordpress.com/start, making specific note of the background squares on the WC pages, and the larger, bolder font in the header.
3. Apply the PR.
4. Confirm that the background squares are now gone, and the header font better matches the size and style of https://wordpress.com/start.

**Before:**

<img width="1423" alt="Screen Shot 2019-06-12 at 4 42 29 PM" src="https://user-images.githubusercontent.com/177561/59393605-24b0ef00-8d31-11e9-855a-963213408742.png">
<img width="1423" alt="Screen Shot 2019-06-12 at 4 42 40 PM" src="https://user-images.githubusercontent.com/177561/59393607-27134900-8d31-11e9-904e-8ddfbd94701b.png">

**After:**

<img width="1440" alt="Screen Shot 2019-06-12 at 4 43 47 PM" src="https://user-images.githubusercontent.com/177561/59393645-4b6f2580-8d31-11e9-83fa-debc00bf0064.png">
<img width="1440" alt="Screen Shot 2019-06-12 at 4 43 57 PM" src="https://user-images.githubusercontent.com/177561/59393647-4d38e900-8d31-11e9-8908-3ebfc84d3ee3.png">
