### PR TITLE
Ensures woo mailchimp plugin does not redirect during woo setup

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -131,6 +131,10 @@ class WC_Calypso_Bridge {
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-addons.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-addons-screen.php';
 			include_once dirname( __FILE__ ) . '/includes/gutenberg.php';
+
+			// Shared with store-on-wpcom.
+			include_once dirname( __FILE__ ) . '/store-on-wpcom/inc/wc-calypso-bridge-mailchimp-no-redirect.php';
+
 			$connect_files = glob( dirname( __FILE__ ) . '/includes/connect/*.php' );
 			foreach ( $connect_files as $connect_file ) {
 				include_once $connect_file;

--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -35,18 +35,10 @@ class WC_Calypso_Bridge_Plugins {
 	 * Constructor
 	 */
 	private function __construct() {
-		add_action( 'admin_init', array( $this, 'remove_mailchimp_redirect' ), 5 );
 		add_filter( 'plugin_action_links', array( $this, 'remove_woocommerce_deactivation_link' ), 10, 2 );
 		add_action( 'update_option_active_plugins', array( $this, 'prevent_woocommerce_deactivation' ), 10, 2 );
 		add_action( 'current_screen', array( $this, 'prevent_woocommerce_deactiation_route' ), 10, 2 );
 		add_action( 'admin_notices', array( $this, 'prevent_woocommerce_deactiation_notice' ), 10, 2 );
-	}
-
-	/**
-	 * Remove Mailchimp redirect
-	 */
-	public function remove_mailchimp_redirect() {
-		update_option( 'mailchimp_woocommerce_plugin_do_activation_redirect', false );
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -46,7 +46,7 @@ class WC_Calypso_Bridge_Plugins {
 	 * Remove Mailchimp redirect
 	 */
 	public function remove_mailchimp_redirect() {
-		delete_option( 'mailchimp_woocommerce_plugin_do_activation_redirect' );
+		update_option( 'mailchimp_woocommerce_plugin_do_activation_redirect', false );
 	}
 
 	/**


### PR DESCRIPTION
Attempted fix for https://github.com/Automattic/wp-calypso/issues/32884

Given

- You have an Atomic site with an ecommerce plan that's just been provisioned
- You haven't visited wp-admin before
- You try to visit `/wp-admin/admin.php?page=wc-setup&calypsoify=1`

Then this happens

- Calypsoify is turned on for the user (and removes `calypsoify=1` query parameter)
- A series of Jetpack redirects happen to give you authorization to access wp-admin (using your existing WordPress.com auth
- Jetpack redirects end taking you back to `/wp-admin/admin.php?page=wc-setup`
- A final redirect happens taking you away from wc-setup to `/wp-admin/admin.php?page=mailchimp-woocommerce` (we don't want this!)

Working theory: for an unknown reason, the [woo mailchimp plugin activation code](https://github.com/mailchimp/mc-woocommerce/blob/73350654672e9bcdc38a4545a398cde1a385aa02/includes/class-mailchimp-woocommerce-options.php#L29) that sets a redirect runs after [wc-calypso-bridge deletes the redirect option](https://github.com/Automattic/wc-calypso-bridge/blob/d79d994f4157a1bbd4f86715082e09000b1b4838/includes/class-wc-calypso-bridge-plugins.php#L48).

This change uses a filter to override the `mailchimp_woocommerce_plugin_do_activation_redirect` option to prevent the redirect from happening.

#### Testing instructions

Because @jonathansadowski and I haven't been able to replicate the issue on any development environments, there isn't a way to directly test that the original issue is fixed.

However, you can test that the filter works:

##### Test site requirements

- Jetpack installed, active, and connected to WordPress.com
- WooCommerce installed and active
- Mailchimp for WooCommerce installed and active
- wpcomsh running with this branch of wc-calypso-bridge ([studio](https://github.com/franzliedke/studio) is one way to run a local composer package with wpcomsh)
- wc-calypso-bridge active (`update_option( 'at_options', array( 'plan_slug' => 'ecommerce' ) );`)

##### Steps

First verify the redirect is a problem

1. Comment out [the filter](https://github.com/Automattic/wc-calypso-bridge/pull/453/files#diff-dbe57b8e3ca0d9eed017183779913fedR136) so it doesn't load .
1. Deactivate Mailchimp for Woo using wp-cli `wp plugin deactivate mailchimp-for-woocommerce`.
1. Delete the plugin options so the activate code runs again `wp option delete mailchimp-woocommerce`.
1. Reactivate the plugin (it's important to not visit wp-admin to do this, because the redirect is only triggered once) `wp plugin activate mailchimp-for-woocommerce`.
1. Visit `/wp-admin/admin.php?page=wc-setup&calypsoify=1`. You should be redirected to Mailchimp for Woo plugin settings.

Then remove the comment so that the redirect filter is loaded and repeat the exact same steps--you should not be redirected this time.