### PR TITLE
add WooCommerce Admin top level pages to bridge

### DIFF
--- a/includes/connect/woocommerce-admin.php
+++ b/includes/connect/woocommerce-admin.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Register the WooCommerce Admin top level pages with the Calypso bridge.
+ *
+ * @package WC_Calypso_Bridge
+ * @since 1.0.18
+ * @version 1.0.0
+ */
+
+wc_calypso_bridge_connect_page(
+	array(
+		'screen_id' => 'woocommerce_page_wc-admin',
+		'menu'      => 'woocommerce',
+		'submenu'   => 'page=wc-admin',
+	)
+);
+
+wc_calypso_bridge_connect_page(
+	array(
+		'screen_id' => 'woocommerce-revenue',
+		'menu'      => 'wc-admin&path=/analytics/revenue',
+		'submenu'   => 'wc-admin&path=/analytics/revenue',
+	)
+);


### PR DESCRIPTION
This PR registers the two top level WooCommerce Admin pages with the Calypso bridge. The submenu items are loaded via React and are only accessible after clicking the top level menu item.

### Testing

- Switch to Calypso
- Click Store and the WC Admin dashboard should load
- Click Analytics and the WC Admin Revenue page should load
- Click menu items under Analytics and the respective screen should load