### PR TITLE
Header: fix pass by reference PHP error

### DIFF
--- a/includes/class-wc-calypso-bridge-action-header.php
+++ b/includes/class-wc-calypso-bridge-action-header.php
@@ -176,7 +176,8 @@ class WC_Calypso_Bridge_Action_Header {
 		global $submenu;
 		$submenu_items = $submenu[ $parent_menu_slug ];
 		if ( $submenu_items ) {
-			$first_menu_item = array_pop( array_reverse( $submenu_items ) );
+			$reversed_items  = array_reverse( $submenu_items );
+			$first_menu_item = array_pop( $reversed_items );
 			$menu_hook       = get_plugin_page_hook( $first_menu_item[2], $parent_menu_slug );
 
 			if ( ! empty( $menu_hook ) ) {


### PR DESCRIPTION
The Orders page gives a PHP error:

![Screen Shot 2019-07-22 at 12 15 24 PM](https://user-images.githubusercontent.com/1922453/61599226-f81abc00-ac7a-11e9-970c-20b41bd9334a.png)

```
Notice: Only variables should be passed by reference in /srv/www/tangaroa/public_html/wp-content/plugins/wc-calypso-bridge/includes/class-wc-calypso-bridge-action-header.php on line 179
```

This PR assigns the output of `array_reverse` to a variable before passing it on to `array_pop`

### Test

1. `/wp-admin/edit.php?post_type=shop_order`.
2. Ensure no error is shown in the header.