### PR TITLE
Check for product count instead of click in checklist

### DIFF
--- a/includes/class-wc-calypso-bridge-admin-setup-checklist.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-checklist.php
@@ -330,6 +330,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 		$wc_canada_post_merchant_username = get_option( 'wc_canada_post_merchant_username' );
 		$wc_canada_post_merchant_password = get_option( 'wc_canada_post_merchant_password' );
 		$has_starter_content_imported     = get_option( 'wpcom_ec_plan_starter_content_imported', false );
+		$products                         = wp_count_posts( 'product' );
 
 		if ( ! $has_starter_content_imported ) {
 			$sf_nonce               = wp_create_nonce( 'storefront_ecommerce_plan_starter_content' );
@@ -347,7 +348,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 				'description'     => __( 'Start by adding your first product to your store.', 'wc-calypso-bridge' ),
 				'estimate'        => '2',
 				'link'            => 'post-new.php?post_type=product&wc-setup-step=product',
-				'condition'       => isset( $click_settings['product'] ) && true === (bool) $click_settings['product'],
+				'condition'       => (int) $products->publish > 0 || (int) $products->draft > 0,
 			),
 
 			array(


### PR DESCRIPTION
Checks for any products and marks complete if they exist instead of checking for a click.

### Screenshot
<img width="1297" alt="Screen Shot 2019-07-22 at 10 45 53 PM" src="https://user-images.githubusercontent.com/10561050/61641977-b453a100-acd2-11e9-9e9b-bb785e0faddc.png">


### Testing

1.  Visit `wp-admin/admin.php?page=wc-setup-checklist`
2. Make sure the item is not marked completed for stores with no products.
3. Make sure the item is marked completed as soon as any products are added.