### PR TITLE
Check Jetpack dependencies before modifying the WooCommerce setup wizard.

### DIFF
--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -35,6 +35,10 @@ class WC_Calypso_Bridge_Setup {
 	 * Constructor.
 	 */
 	private function __construct() {
+		if ( ! class_exists( 'Jetpack_Calypsoify', false ) ) {
+			return;
+		}
+
 		if ( isset( $_GET['page'] ) && 'wc-setup' === $_GET['page'] ) {
 			add_filter( 'woocommerce_setup_wizard_steps', array( $this, 'remove_unused_steps' ) );
 			add_filter( 'woocommerce_enable_setup_wizard', '__return_false' );


### PR DESCRIPTION
Fixes #452.

To test:
- Disconnect Jetpack and remove any Jetpack dev filters.
- Go to `wp-admin/admin.php?page=wc-setup`
- Verify the lack of a PHP Fatal for missing classes
- Verify that the standard WooCommerce Setup Wizard displays
