### PR TITLE
Setup: Ensure MailChimp does not redirect

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -118,13 +118,13 @@ class WC_Calypso_Bridge {
 		}
 
 		// We always want the Calypso branded OBW to run on eCommerce plan sites.
+		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-admin-setup-checklist.php';
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-setup.php';
 
 		if ( $this->dependencies_satisfied() ) {
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-helper-functions.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-hide-alerts.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-themes-setup.php';
-			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-admin-setup-checklist.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-page-controller.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-menus.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-plugins.php';

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -42,7 +42,7 @@ class WC_Calypso_Bridge_Setup {
 		add_filter( 'admin_body_class', array( $this, 'add_calypsoify_class' ) );
 
 		// If setup has yet to complete, make sure MailChimp doesn't redirect the flow.
-		$has_finshed_setup = get_option( 'atomic-ecommerce-setup-checklist-complete', false );
+		$has_finshed_setup = (bool) get_option( 'atomic-ecommerce-setup-checklist-complete' );
 		if ( ! $has_finshed_setup ) {
 			add_filter( 'wp_redirect', array( $this, 'prevent_mailchimp_redirect' ), 10, 2 );
 		}

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -41,6 +41,12 @@ class WC_Calypso_Bridge_Setup {
 
 		add_filter( 'admin_body_class', array( $this, 'add_calypsoify_class' ) );
 
+		// If setup has yet to complete, make sure MailChimp doesn't redirect the flow.
+		$has_finshed_setup = get_option( 'atomic-ecommerce-setup-checklist-complete', false );
+		if ( ! $has_finshed_setup ) {
+			add_filter( 'wp_redirect', array( $this, 'prevent_mailchimp_redirect' ), 10, 2 );
+		}
+
 		if ( isset( $_GET['page'] ) && 'wc-setup' === $_GET['page'] ) {
 			add_filter( 'woocommerce_setup_wizard_steps', array( $this, 'remove_unused_steps' ) );
 			add_filter( 'woocommerce_enable_setup_wizard', '__return_false' );
@@ -85,6 +91,24 @@ class WC_Calypso_Bridge_Setup {
 		$classes .= ' calypsoify-active';
 		return $classes;
 	}
+
+	/**
+	 * Prevent MailChimp redirect on initial setup.
+	 *
+	 * @param string $location Redirect location.
+	 * @param string $status Status code.
+	 * @return string
+	 */
+	public function prevent_mailchimp_redirect( $location, $status ) {
+		if ( 'admin.php?page=mailchimp-woocommerce' === $location ) {
+			// Delete the redirect option so we don't end up here anymore
+			delete_option( 'mailchimp_woocommerce_plugin_do_activation_redirect' );
+			$location = '/wp-admin/admin.php?page=wc-setup-checklist&calypsoify=1';
+		}
+
+		return $location;
+	}
+
 }
 
 $wc_calypso_bridge_setup = WC_Calypso_Bridge_Setup::get_instance();

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -42,7 +42,7 @@ class WC_Calypso_Bridge_Setup {
 		add_filter( 'admin_body_class', array( $this, 'add_calypsoify_class' ) );
 
 		// If setup has yet to complete, make sure MailChimp doesn't redirect the flow.
-		$has_finshed_setup = (bool) get_option( 'atomic-ecommerce-setup-checklist-complete' );
+		$has_finshed_setup = (bool) WC_Calypso_Bridge_Admin_Setup_Checklist::is_checklist_done();
 		if ( ! $has_finshed_setup ) {
 			add_filter( 'wp_redirect', array( $this, 'prevent_mailchimp_redirect' ), 10, 2 );
 		}
@@ -103,7 +103,7 @@ class WC_Calypso_Bridge_Setup {
 		if ( 'admin.php?page=mailchimp-woocommerce' === $location ) {
 			// Delete the redirect option so we don't end up here anymore
 			delete_option( 'mailchimp_woocommerce_plugin_do_activation_redirect' );
-			$location = '/wp-admin/admin.php?page=wc-setup-checklist&calypsoify=1';
+			$location = admin_url( 'admin.php?page=wc-setup-checklist&calypsoify=1' );
 		}
 
 		return $location;


### PR DESCRIPTION
This branch seeks to fix https://github.com/Automattic/wp-calypso/issues/32884

The current approach that was performed in that PR was to delete an option used by the MailChimp plugin to determine if they should redirect to their settings page upon activation. In multiple tests lately, the bug is still present.

Since the plugin itself doesn't offer a filter to determine if a redirect should happen, and apparently some code loading order shenanigans are happening with the current approach, I have opted to hook into the redirect logic itself. While this approach is working in my testing, I still might open a PR with MailChimp to add in a filter that we could use instead. But for now, here it goes!

__To Test__
To reproduce the redirect locally, all one must do is install and activate the MailChimp for WooCommerce plugin. It might be good to do this once before you test this branch. Then deactivate/delete the plugin.

1. Check out this branch
2. Install MC plugin again, activate
3. Note that you end up on the Setup dashboard instead of the mailchimp settings page.

For bonus points, you can mark your setup checklist as complete, and repeat steps above ( uninstall MC, reinstall ) and note that you are redirected to the MC settings page as this logic only loads when the setup checklist has yet to be completed.