### PR TITLE
Mark checklist complete if orders exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ To check WPCS and lint errors via CLI, run the following from the root directory
 To automatically fix errors and beautify files, run the following from the root directory.
 `./vendor/bin/phpcbf [filename]`
 
+To turn on development mode for this plugin and prevent the setup checklist from being completed, the following filter can be added:
+
+`add_filter( 'wc_calypso_bridge_development_mode', '__return_true' );`
+
 ### Activating Calypsoify
 
 To Calypsoify the dashboard and test various functionality in this plugin, there are a number of conditions that must be met.

--- a/includes/class-wc-calypso-bridge-admin-setup-checklist.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-checklist.php
@@ -86,12 +86,25 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 	}
 
 	/**
-	 * Returns if the checklist is "done" via the user clicking the "I'm done" button.
+	 * Returns if the checklist is "done" via the user clicking the "I'm done" button
+	 * or if the store already contains any orders.
 	 *
-	 * @return bool True if the done button has been clicked.
+	 * @return bool
 	 */
 	private function is_checklist_done() {
-		return (bool) get_option( 'atomic-ecommerce-setup-checklist-complete', false );
+		if ( apply_filters( 'wc_calypso_bridge_development_mode', false ) ) {
+			return false;
+		}
+
+		global $wpdb;
+		$order_count = (int) $wpdb->get_var(
+			"SELECT COUNT( DISTINCT posts.ID )
+				FROM {$wpdb->posts} as posts
+				WHERE posts.post_type = 'shop_order'
+				LIMIT 1"
+		);
+
+		return $order_count > 0 || (bool) get_option( 'atomic-ecommerce-setup-checklist-complete', false );
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-admin-setup-checklist.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-checklist.php
@@ -72,7 +72,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 
 		// If setup has been completed, redirect to orders page.
 		// TODO Redirect to wc-admin once we launch it on eCommerce plans.
-		if ( $this->is_checklist_done() ) {
+		if ( self::is_checklist_done() ) {
 			wp_safe_redirect( admin_url( 'edit.php?post_type=shop_order' ) );
 			exit;
 		}
@@ -91,7 +91,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 	 *
 	 * @return bool
 	 */
-	private function is_checklist_done() {
+	public static function is_checklist_done() {
 		if ( apply_filters( 'wc_calypso_bridge_development_mode', false ) ) {
 			return false;
 		}
@@ -203,7 +203,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 	 * Adds a new page for the setup checklist.
 	 */
 	public function admin_menu() {
-		if ( $this->is_checklist_done() ) {
+		if ( self::is_checklist_done() ) {
 			return;
 		}
 
@@ -297,7 +297,7 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 	 */
 	public function menu_order_count() {
 		global $menu;
-		if ( $this->is_checklist_done() ) {
+		if ( self::is_checklist_done() ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #457 

If a store has any orders, this PR will mark the setup as complete.

I agree with @timmyc's reasoning in #457 that orders probably mean a store has already been setup, but open to other input here.

Since this would impede development, I've also added a `wc_calypso_bridge_development_mode` filter that prevents the setup from ever being marked complete.

```php
add_filter( 'wc_calypso_bridge_development_mode', '__return_true' );
```

### Testing

1.  Enable calypsoify.
2. If you have no orders and the checklist has not been marked complete with the "I'm done" button, you should still see the checklist.
3. If you have any orders, the setup menu item should be gone and visiting the checklist page manually should redirect to the orders page. `wp-admin/admin.php?page=wc-setup-checklist`
4.  Adding the filter for development mode should once again allow you to access the setup screens. `add_filter( 'wc_calypso_bridge_development_mode', '__return_true' );`