### PR TITLE
Fix up card form styling in plugins

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1482,7 +1482,8 @@ table.widefat {
 
 #mainform h2,
 #mainform h3,
-.wp-admin .wrap form[name="cleanup_options"] > h2 {
+.wp-admin .wrap form[name="cleanup_options"] > h2,
+.wp-admin .wrap form[name="cleanup_options"] > h4 {
 	background-color: #fff;
 	border: 1px solid #e4eaef;
 	border-bottom: none;
@@ -1591,10 +1592,14 @@ form[name="cleanup_options"] fieldset label span {
 	order: 0;
 	margin: 5px 0;
 }
-form[name="cleanup_options"] fieldset label input,
+form[name="cleanup_options"] fieldset label input:not([type="radio"]):not([type="checkbox"]),
 form[name="cleanup_options"] fieldset label select {
 	order: 1;
 	width: 100%;
+}
+form[name="cleanup_options"] fieldset label input[type="radio"],
+form[name="cleanup_options"] fieldset label input[type="checkbox"] {
+	margin-top: 0px;
 }
 @media screen and (min-width:601px) {
 	form[name="cleanup_options"] fieldset label {
@@ -1604,7 +1609,7 @@ form[name="cleanup_options"] fieldset label select {
 	form[name="cleanup_options"] fieldset label span {
 		min-width: 250px;
 	}
-	form[name="cleanup_options"] fieldset label input {
+	form[name="cleanup_options"] fieldset label input:not([type="radio"]):not([type="checkbox"]) {
 		width: 400px !important;
 	}
 }


### PR DESCRIPTION
Fixes #444 

* Fixes form styling for checkbox and radio inputs.
* Adds card styling for h4 tags in option panels.

### Before
<img width="783" alt="Screen Shot 2019-07-24 at 2 49 10 PM" src="https://user-images.githubusercontent.com/10561050/61771389-5209b600-ae22-11e9-8a0f-e0bfbda72d4b.png">

### After
<img width="729" alt="Screen Shot 2019-07-24 at 2 48 01 PM" src="https://user-images.githubusercontent.com/10561050/61771385-503ff280-ae22-11e9-8b39-39826d95d4bc.png">

### Testing

1.  Visit `wp-admin/admin.php?page=mailchimp-woocommerce`.
2.  Check that radio inputs are styled appropriately.
3.  Check that h4 headings are displayed correctly.