### PR TITLE
Override default WP navspan class styles

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -132,7 +132,7 @@ div.woocommerce-message, .wc-helper .start-container {
 	margin-top: 16px;
 }
 .wp-admin .tablenav-pages a,
-.tablenav-pages-navspan,
+.wp-admin .tablenav .tablenav-pages-navspan,
 .tablenav-pages span.current,
 .wp-admin .dots {
 	padding: 8px 12px;
@@ -145,15 +145,17 @@ div.woocommerce-message, .wc-helper .start-container {
 	float: left;
 	font-weight: 500;
 	min-width: 0;
+	min-height: auto;
 	display: flex;
 	align-content: center;
 	height: auto;
 	text-decoration: none;
 }
+.wp-admin .tablenav .tablenav-pages-navspan:hover,
 .wp-admin .tablenav-pages a:hover,
 .wp-admin .tablenav-pages a:focus {
 	color: #2e4453;
-	background: #fff;
+	background: #f6f6f6;
 	border-color: #C8D7E1;
 	box-shadow: none;
 }
@@ -167,8 +169,8 @@ div.woocommerce-message, .wc-helper .start-container {
 	fill: #2e4453;
 }
 .tablenav-pages span.current {
-	border-color: #00aadc;
-	background-color: #00aadc;
+	border-color: #016087;
+	background-color: #016087;
 	color: #fff;
 }
 .wp-admin .tablenav-pages > *:first-child {


### PR DESCRIPTION
Fixes #485 

Fixes the styling specificity for pagination by overriding newly added styles in WP core.

### Before
<img width="416" alt="Screen Shot 2019-07-24 at 4 04 54 PM" src="https://user-images.githubusercontent.com/10561050/61777166-10cbd300-ae2f-11e9-8631-1ae2e154b6d5.png">


### After
<img width="370" alt="Screen Shot 2019-07-24 at 4 19 31 PM" src="https://user-images.githubusercontent.com/10561050/61777162-0f9aa600-ae2f-11e9-97cf-c1bae80fa01f.png">


### Testing
1.  Visit any page with pagination (e.g., products)
2. Check that pagination styling matches Calypso's.