### PR TITLE
move the activity panel header down and hide breadcrumbs

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2520,3 +2520,14 @@ h3#woocommerce_stripe_connection_status {
 .woocommerce-help-text {
 	text-align: center;
 }
+
+/**
+ * Styles for WooCommerce Admin
+ */
+.calypsoify-active .woocommerce-layout__header {
+	top: 93px;
+}
+
+.calypsoify-active .woocommerce-layout__header-breadcrumbs {
+	display: none;
+}


### PR DESCRIPTION
See #462 

This PR moves the WC Admin `.woocommerce-layout__header` down and hides the breadcrumbs (which are being copied to the Calypso activity bar).

### Testing

1. Activity header should be visible directly below the Calypso header
1. WC Admin breadcrumbs should not be visible
1. Activity panels should function