### PR TITLE
add todo note to remove CSS after merged into JP

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2115,6 +2115,7 @@ div.jitm-card  .jitm-banner__info .jitm-banner__title, div.jitm-card  .jitm-bann
 	content: '\f335';
 }
 
+/* TODO remove after https://github.com/Automattic/jetpack/pull/13126 is released */
 .wp-admin .wrap div.hidden {
 	display: none;
 }
@@ -2247,6 +2248,7 @@ div.jitm-card  .jitm-banner__info .jitm-banner__title, div.jitm-card  .jitm-bann
 .wp-admin div.error + br.clear {
 	display: none;
 }
+/* End TODO */
 
 /* Akismet notices */
 #akismet-privacy-notice-admin-notice .notice-dismiss {

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2042,6 +2042,7 @@ form[name="cleanup_options"] fieldset label select {
 	color: #00a0d2;
 }
 
+/* TODO remove after https://github.com/Automattic/jetpack/pull/13126 is released */
 /* Notices and Jetpack JITM */
 div.notice,
 div.updated,
@@ -2115,7 +2116,6 @@ div.jitm-card  .jitm-banner__info .jitm-banner__title, div.jitm-card  .jitm-bann
 	content: '\f335';
 }
 
-/* TODO remove after https://github.com/Automattic/jetpack/pull/13126 is released */
 .wp-admin .wrap div.hidden {
 	display: none;
 }

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2042,7 +2042,7 @@ form[name="cleanup_options"] fieldset label select {
 	color: #00a0d2;
 }
 
-/* TODO remove after https://github.com/Automattic/jetpack/pull/13126 is released */
+/* @todo remove after https://github.com/Automattic/jetpack/pull/13126 is released */
 /* Notices and Jetpack JITM */
 div.notice,
 div.updated,
@@ -2248,7 +2248,7 @@ div.jitm-card  .jitm-banner__info .jitm-banner__title, div.jitm-card  .jitm-bann
 .wp-admin div.error + br.clear {
 	display: none;
 }
-/* End TODO */
+/* End @todo */
 
 /* Akismet notices */
 #akismet-privacy-notice-admin-notice .notice-dismiss {

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -11,10 +11,15 @@
         }
     } );
 
+// TODO Remove the notice handlers after https://github.com/Automattic/jetpack/pull/13126 has been released.
     /**
      * Append icons to notices
      */
     $( 'div.notice, div.error, div.updated, div.warning' ).each( function() {
+	if ( $( this ).children( '.wc-calypso-bridge-notice-content' ).length ) {
+		return;
+	}
+
         var icon = icons.info;
         if ( $( this ).hasClass( 'notice-success') ) {
             icon = icons.checkmark;
@@ -37,10 +42,15 @@
      * Used to prevent side by side content in flexbox when multiple paragraphs exist.
      */
     $( 'div.notice, div.error, div.updated, div.warning' ).each( function() {
-        var $noticeContent = $( '<div class="wc-calypso-bridge-notice-content"></div>' );
-        $( this ).find( '.wc-calypso-bridge-notice-icon-wrapper' ).after( $noticeContent );
-        $( this ).find( 'p:not(.submit)' ).appendTo( $noticeContent );
+	if ( $( this ).children( '.wc-calypso-bridge-notice-content' ).length ) {
+		return;
+	}
+
+	var $noticeContent = $( '<div class="wc-calypso-bridge-notice-content"></div>' );
+	$( this ).find( '.wc-calypso-bridge-notice-icon-wrapper' ).after( $noticeContent );
+	$( this ).find( 'p:not(.submit)' ).appendTo( $noticeContent );
     } );
+// TODO End
 
     /**
      * Move page actions to action header

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -46,7 +46,7 @@
 			return;
 		}
 
-	var $noticeContent = $( '<div class="wc-calypso-bridge-notice-content"></div>' );
+		var $noticeContent = $( '<div class="wc-calypso-bridge-notice-content"></div>' );
 		$( this ).find( '.wc-calypso-bridge-notice-icon-wrapper' ).after( $noticeContent );
 		$( this ).find( 'p:not(.submit)' ).appendTo( $noticeContent );
 	} );

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -1,356 +1,354 @@
 ( function( $ ) {
-    'use strict';
+	'use strict';
 
-    /**
-     * Action header mobile navigation
-     */
-    $( document ).on( 'click', '.action-header:not(.action-header-sidebar) .action-header__ground-control-back', function( e ) {
-        if ( $( window ).width() < 661 ) {
-            e.preventDefault();
-            $( '#wp-admin-bar-menu-toggle .ab-item' ).click();
-        }
-    } );
+	/**
+	 * Action header mobile navigation.
+	 */
+	$( document ).on( 'click', '.action-header:not(.action-header-sidebar) .action-header__ground-control-back', function( e ) {
+		if ( $( window ).width() < 661 ) {
+			e.preventDefault();
+			$( '#wp-admin-bar-menu-toggle .ab-item' ).click();
+		}
+	} );
 
-// TODO Remove the notice handlers after https://github.com/Automattic/jetpack/pull/13126 has been released.
-    /**
-     * Append icons to notices
-     */
-    $( 'div.notice, div.error, div.updated, div.warning' ).each( function() {
-	if ( $( this ).children( '.wc-calypso-bridge-notice-content' ).length ) {
-		return;
-	}
+// @todo Remove the notice handlers after https://github.com/Automattic/jetpack/pull/13126 has been released.
+	/**
+	 * Prepend icons to notices.
+	 */
+	$( 'div.notice, div.error, div.updated, div.warning' ).each( function() {
+		if ( $( this ).children( '.wc-calypso-bridge-notice-content' ).length ) {
+			return;
+		}
 
-        var icon = icons.info;
-        if ( $( this ).hasClass( 'notice-success') ) {
-            icon = icons.checkmark;
-        } else if ( $( this ).hasClass( 'error' ) || $( this ).hasClass( 'notice-warning' ) ) {
-            icon = icons.notice;
-        }
-        $( this ).prepend( '<span class="wc-calypso-bridge-notice-icon-wrapper">' + icon + '</span>' );
-    } );
+		var icon = icons.info;
+		if ( $( this ).hasClass( 'notice-success' ) ) {
+			icon = icons.checkmark;
+		} else if ( $( this ).hasClass( 'error' ) || $( this ).hasClass( 'notice-warning' ) ) {
+			icon = icons.notice;
+		}
+		$( this ).prepend( '<span class="wc-calypso-bridge-notice-icon-wrapper">' + icon + '</span>' );
+	} );
 
-    /**
-     * Replace dismissal buttons in notices
-     */
-    $( document ).ready( function() {
-        $( '.notice-dismiss' ).html( icons.cross );
-    } );
+	/**
+	 * Replace dismissal buttons in notices.
+	 */
+	$( document ).ready( function() {
+		$( '.notice-dismiss' ).html( icons.cross );
+	} );
 
-    /**
-     * Place notice content inside it's own tag
-     * 
-     * Used to prevent side by side content in flexbox when multiple paragraphs exist.
-     */
-    $( 'div.notice, div.error, div.updated, div.warning' ).each( function() {
-	if ( $( this ).children( '.wc-calypso-bridge-notice-content' ).length ) {
-		return;
-	}
+	/**
+	 * Place notice content inside it's own tag.
+	 *
+	 * Used to prevent side by side content in flexbox when multiple paragraphs exist.
+	 */
+	$( 'div.notice, div.error, div.updated, div.warning' ).each( function() {
+		if ( $( this ).children( '.wc-calypso-bridge-notice-content' ).length ) {
+			return;
+		}
 
 	var $noticeContent = $( '<div class="wc-calypso-bridge-notice-content"></div>' );
-	$( this ).find( '.wc-calypso-bridge-notice-icon-wrapper' ).after( $noticeContent );
-	$( this ).find( 'p:not(.submit)' ).appendTo( $noticeContent );
-    } );
-// TODO End
+		$( this ).find( '.wc-calypso-bridge-notice-icon-wrapper' ).after( $noticeContent );
+		$( this ).find( 'p:not(.submit)' ).appendTo( $noticeContent );
+	} );
+// @todo End
 
-    /**
-     * Move page actions to action header
-     */
-    $( '.page-title-action, .add-new-h2' ).appendTo( '#action-header .action-header__actions' );
+	/**
+	 * Move page actions to action header.
+	 */
+	$( '.page-title-action, .add-new-h2' ).appendTo( '#action-header .action-header__actions' );
 
-    /** 
-     * Move notices on pages with sub navigation
-     * 
-     * WP Core moves notices with jQuery so this is needed to move them again since
-     * we can't control their position.
-     */
-    $( document ).ready(function() {
-        var $subNavigation = $( '.wrap .subsubsub' );
-        if ( $subNavigation.length ) {
-			$( 'div.notice, div.error, div.updated, div.warning' ).insertAfter( $subNavigation.first() );
+	/**
+	 * Move notices on pages with sub navigation.
+	 *
+	 * WP Core moves notices with jQuery so this is needed to move them again since
+	 * we can't control their position.
+	 */
+	$( document ).ready( function() {
+		var $subNavigation = $( '.wrap .subsubsub' );
+		if ( $subNavigation.length ) {
+		$( 'div.notice, div.error, div.updated, div.warning' ).insertAfter( $subNavigation.first() );
 			$( '.jetpack-jitm-message, .jitm-card' ).insertAfter( $subNavigation.first() );
-        }
-    } );
+		}
+	} );
 
+	/**
+	 * Append subnav dropdown for mobile.
+	 */
+	$( document ).ready( function() {
+		$( '#wpbody-content .subsubsub, #wpbody-content .nav-tab-wrapper' ).each( function() {
+			const currentText = $( this ).find( 'a.current, .nav-tab-active' ).text();
+			const $toggle = $( '<div class="nav-tab-toggle"><span class="nav-tab-toggle__current-page">' + currentText + '</span>' + icons.chevronDown + '</div>' );
+			$( this ).wrap( '<div class="nav-tab-container"></div>' );
+			$( this ).before( $toggle );
+		} );
+	} );
 
-    /**
-     * Append subnav dropdown for mobile
-     */
-    $( document ).ready(function() {
-        $( '#wpbody-content .subsubsub, #wpbody-content .nav-tab-wrapper' ).each( function() {
-            const currentText = $( this ).find( 'a.current, .nav-tab-active' ).text();
-            const $toggle = $( '<div class="nav-tab-toggle"><span class="nav-tab-toggle__current-page">' + currentText + '</span>' + icons.chevronDown + '</div>' );
-            $( this ).wrap( '<div class="nav-tab-container"></div>' );
-            $( this ).before( $toggle );
-        } );
-    } );
+	/**
+	 * Append subnav dropdown for mobile.
+	 */
+	$( document ).on( 'click', '.nav-tab-toggle', function() {
+		$( this ).parent().toggleClass( 'is-open' );
+	} );
 
-    /**
-     * Append subnav dropdown for mobile
-     */
-    $( document ).on( 'click', '.nav-tab-toggle', function() {
-        $( this ).parent().toggleClass( 'is-open' );
-    } );
+	/**
+	 * Toggle taxonomy form.
+	 */
+	function toggleTaxonomyForm() {
+		$( '#col-container > #col-left' ).toggle();
+		$( '#col-container > #col-right' ).toggle();
+		$( '.taxonomy-form-toggle' ).toggle();
+		$( '.wrap .search-form' ).toggle();
+		$( '.form-wrap h2:first' ).hide();
+		const formTitle = $( '.form-wrap h2:first' ).text();
+		if ( ! $( '#breadcrumb-taxonomy' ).length ) {
+			$( '.action-header__breadcrumbs' ).append(
+				'<span id="breadcrumb-taxonomy" style="display: none;">' + formTitle + '</span>'
+			);
+		}
+		$( '#breadcrumb-taxonomy' ).toggle();
+	}
 
-    /**
-     * Toggle taxonomy form
-     */
-    function toggleTaxonomyForm() {
-        $( '#col-container > #col-left' ).toggle();
-        $( '#col-container > #col-right' ).toggle();
-        $( '.taxonomy-form-toggle' ).toggle();
-        $( '.wrap .search-form' ).toggle();
-        $( '.form-wrap h2:first' ).hide();
-        const formTitle = $( '.form-wrap h2:first' ).text();
-        if ( ! $( '#breadcrumb-taxonomy' ).length ) {
-            $( '.action-header__breadcrumbs' ).append(
-                '<span id="breadcrumb-taxonomy" style="display: none;">' + formTitle + '</span>'
-            );
-        }
-        $( '#breadcrumb-taxonomy' ).toggle();
-    }
+	/**
+	 * Click handler for taxonomy add new/cancel buttons.
+	 */
+	$( '.taxonomy-form-toggle' ).click( function( e ) {
+		e.preventDefault();
+		toggleTaxonomyForm();
+		history.pushState( {}, $( '.action-header__breadcrumbs span:last' ).text(), window.location );
+	} );
 
-    /**
-     * Click handler for taxonomy add new/cancel buttons
-     */
-    $( '.taxonomy-form-toggle' ).click( function(e) {
-        e.preventDefault();
-        toggleTaxonomyForm();
-        history.pushState( {}, $( '.action-header__breadcrumbs span:last' ).text(), window.location );
-    } );
+	/**
+	 * Toggle form on back button.
+	 */
+	$( window ).on( 'popstate', function( e ) {
+		toggleTaxonomyForm();
+	} );
 
-    /**
-     * Toggle form on back button
-     */
-    $( window ).on( 'popstate', function( e ) {
-        toggleTaxonomyForm();
-    });
+	/**
+	 * Move cancel button.
+	 */
+	$( '.taxonomy-form-cancel-button' ).appendTo( 'p.submit' );
 
-    /**
-     * Move cancel button
-     */
-    $( '.taxonomy-form-cancel-button' ).appendTo( 'p.submit' );
+	/**
+	 * Product attributes form is not AJAX'ed so toggle back if any errors.
+	 */
+	if ( $( '#woocommerce_errors' ).length ) {
+		toggleTaxonomyForm();
+	}
 
-    /**
-     * Product attributes form is not AJAX'ed so toggle back if any errors
-     */
-    if ( $( '#woocommerce_errors' ).length ) {
-        toggleTaxonomyForm();
-    }
+	/**
+	 * Add cancel button to taxonomy edit forms.
+	 */
+	$( '.edit-tag-actions .button:first' ).after(
+		'<a href="' + ( 'undefined' !== typeof taxonomy ? taxonomy.listUrl : '#' ) + '" class="button button-secondary button-large taxonomy-edit-cancel-button">' + translations.cancel + '</a>'
+	);
 
-    /**
-     * Add cancel button to taxonomy edit forms
-     */
-    $( '.edit-tag-actions .button:first' ).after(
-        '<a href="' + ( 'undefined' !== typeof taxonomy ? taxonomy.listUrl : '#' ) + '" class="button button-secondary button-large taxonomy-edit-cancel-button">' + translations.cancel + '</a>'
-    );
+	/**
+	 * Move search box to subnav.
+	 */
+	var $subNav = $( '.subsubsub' );
+	if ( $subNav.length ) {
+		var $searchBoxListItem = $( '<li class="subsubsub__search-item"></li>' ).appendTo( $subNav );
+		var $searchBox = $( '#posts-filter .search-box' );
+		var $searchInput = $searchBox.find( 'input[type=search]' );
+		var $searchLabel = $searchInput.siblings( 'label' );
+		var uniqueId = Math.floor( Math.random() * 26 ) + Date.now();
 
-    /**
-     * Move search box to subnav
-     */
-    var $subNav = $( '.subsubsub' );
-    if ( $subNav.length ) {
-        var $searchBoxListItem = $( '<li class="subsubsub__search-item"></li>').appendTo( $subNav );
-        var $searchBox = $( '#posts-filter .search-box' );
-        var $searchInput = $searchBox.find( 'input[type=search]' );
-        var $searchLabel = $searchInput.siblings( 'label' );
-        var uniqueId = Math.floor(Math.random() * 26) + Date.now();
+		$searchInput.attr( 'placeholder', $searchLabel.text().replace( /\:$/, '' ) );
+		$searchBox.closest( 'form' ).attr( 'data-form-id', uniqueId );
+		$searchBox.attr( 'data-target-form-id', uniqueId );
+		$searchBox.appendTo( $searchBoxListItem );
+		$subNav.addClass( 'has-search' );
+		if ( $searchInput.val() && $searchInput.val().length ) {
+			$searchBox.addClass( 'is-expanded' );
+		}
+	}
 
-        $searchInput.attr( 'placeholder', $searchLabel.text().replace(/\:$/, '') );
-        $searchBox.closest( 'form' ).attr( 'data-form-id', uniqueId );
-        $searchBox.attr( 'data-target-form-id', uniqueId );
-        $searchBox.appendTo( $searchBoxListItem );
-        $subNav.addClass( 'has-search' );
-        if ( $searchInput.val() && $searchInput.val().length ) {
-            $searchBox.addClass( 'is-expanded' );
-        }
-    }
+	/**
+	 * Add icons to search boxes.
+	 */
+	$( '.search-box' ).prepend( '<button class="search-box__search-icon" aria-label="' + translations.openSearch + '">' + icons.search + '</button>' );
+	$( '.search-box' ).append( '<button class="search-box__close-icon" aria-label="' + translations.closeSearch + '">' + icons.cross + '</button>' );
 
-    /**
-     * Add icons to search boxes
-     */
-    $( '.search-box' ).prepend( '<button class="search-box__search-icon" aria-label="' + translations.openSearch + '">' + icons.search + '</button>' );
-    $( '.search-box' ).append( '<button class="search-box__close-icon" aria-label="' + translations.closeSearch + '">' + icons.cross + '</button>' );
+	/**
+	 * Focus search input on open icon click.
+	 */
+	$( document ).on( 'click', '.search-box__search-icon', function( e ) {
+		e.preventDefault();
+		$( this ).closest( '.search-box' ).addClass( 'has-focus' );
+		// Defer focus when expanding since input is not displayed
+		var $searchInput = $( this ).siblings( 'input[name="s"]' );
+		setTimeout( function() {
+			$searchInput.focus();
+		}, 0 );
+	} );
 
-    /**
-     * Focus search input on open icon click
-     */
-    $( document ).on( 'click', '.search-box__search-icon', function(e) {
-        e.preventDefault();
-        $( this ).closest( '.search-box' ).addClass( 'has-focus' );
-        // Defer focus when expanding since input is not displayed
-        var $searchInput = $( this ).siblings( 'input[name="s"]' );
-        setTimeout( function() {
-            $searchInput.focus();
-        }, 0 );
-    } );
+	/**
+	 * Open search when inside nav.
+	 */
+	$( document ).on( 'click', '.subsubsub .search-box__search-icon', function( e ) {
+		$( this ).closest( '.search-box' ).addClass( 'is-expanded' );
+	} );
 
-    /**
-     * Open search when inside nav
-     */
-    $( document ).on( 'click', '.subsubsub .search-box__search-icon', function(e) {
-        $( this ).closest( '.search-box' ).addClass( 'is-expanded' );
-    } );
+	/**
+	 * Close search when inside nav.
+	 */
+	$( document ).on( 'click', '.subsubsub .search-box__close-icon', function( e ) {
+		e.preventDefault();
+		$( this ).closest( '.search-box' ).removeClass( 'is-expanded' );
+	} );
 
-    /**
-     * Close search when inside nav
-     */
-    $( document ).on( 'click', '.subsubsub .search-box__close-icon', function(e) {
-        e.preventDefault();
-        $( this ).closest( '.search-box' ).removeClass( 'is-expanded' );
-    } );
+	/**
+	 * Add focus class to search box wrapper on focus.
+	 */
+	$( document ).on( 'focus', 'input[name="s"]', function() {
+		$( this ).closest( '.search-box' ).addClass( 'has-focus' );
+	} );
 
-    /**
-     * Add focus class to search box wrapper on focus
-     */
-    $( document ).on( 'focus', 'input[name="s"]', function() {
-        $( this ).closest( '.search-box' ).addClass( 'has-focus' );
-    } );
+	/**
+	 * Remove focus on blur.
+	 */
+	$( document ).on( 'blur', 'input[name="s"]', function() {
+		$( this ).closest( '.search-box' ).removeClass( 'has-focus' );
+	} );
 
-    /**
-     * Remove focus on blur
-     */
-    $( document ).on( 'blur', 'input[name="s"]', function() {
-        $( this ).closest( '.search-box' ).removeClass( 'has-focus' );
-    } );
+	/**
+	 * Fix search for inputs outside of forms by appending inputs on enter/click.
+	 */
+	function appendInputsToForm( e ) {
+		if ( e.type === 'click' || e.which === 13 ) {
+			e.preventDefault();
+			const formId = $( this ).closest( '.search-box' ).data( 'target-form-id' );
+			const $form = $( 'form[data-form-id="' + formId + '"' );
+			const $searchInput = $( this ).closest( '.search-box' ).find( 'input[type="search"]' );
+			$( '<input>' ).attr( {
+					type: 'hidden',
+					id: $searchInput.attr( 'id' ),
+					name: $searchInput.attr( 'name' ),
+					value: $searchInput.val(),
+				}
+			).appendTo( $form );
+			$form.submit();
+		}
+	}
+	$( document ).on( 'click', '.subsubsub .search-box input[type=submit]', appendInputsToForm );
+	$( document ).on( 'keypress', '.subsubsub .search-box input[type=search]', appendInputsToForm );
 
-    /**
-     * Fix search for inputs outside of forms by appending inputs on enter/click
-     */
-    function appendInputsToForm( e ) {
-        if ( e.type === 'click' || e.which === 13 ) {
-            e.preventDefault();
-            const formId = $( this ).closest( '.search-box' ).data( 'target-form-id' );
-            const $form = $( 'form[data-form-id="' + formId + '"' );
-            const $searchInput = $( this ).closest( '.search-box' ).find( 'input[type="search"]' );
-            $( '<input>' ).attr(
-                {
-                    type: 'hidden',
-                    id: $searchInput.attr( 'id' ),
-                    name: $searchInput.attr( 'name' ),
-                    value: $searchInput.val(),
-                }
-            ).appendTo( $form );
-            $form.submit();
-        }
-    }
-    $( document ).on( 'click', '.subsubsub .search-box input[type=submit]', appendInputsToForm );
-    $( document ).on( 'keypress', '.subsubsub .search-box input[type=search]', appendInputsToForm );
+	/**
+	 * Submit regular search forms on enter.
+	 */
+	$( document ).on( 'keypress', 'div:not(.subsubsub) .search-box input[type=search]', function( e ) {
+		if ( e.which === 13 ) {
+			e.preventDefault();
+			$( this ).closest( 'form' ).submit();
+		}
+	} );
 
-    /**
-     * Submit regular search forms on enter
-     */
-    $( document ).on( 'keypress', 'div:not(.subsubsub) .search-box input[type=search]', function( e ) {
-        if ( e.which === 13 ) {
-            e.preventDefault();
-            $( this ).closest( 'form' ).submit();
-        }
-    } );
+	/**
+	 * Disable autocomplete for search inputs.
+	 */
+	$( document ).on( 'focus', 'input[type=search]', function() {
+		$( this ).attr( 'autocomplete', 'off' );
+	} );
 
-    /** 
-     * Disable autocomplete for search inputs
-     */
-    $( document ).on( 'focus', 'input[type=search]', function() {
-        $( this ).attr( 'autocomplete', 'off' );
-    } );
+	/**
+	 * Clear the search query when clicking the close icon not inside subnav.
+	 */
+	$( document ).on( 'click', 'div:not(.subsubsub) .search-box__close-icon', function( e ) {
+		e.preventDefault();
+		$( this ).closest( '.search-box' ).find( 'input[type=search]' ).val( '' );
+		$( this ).closest( '.search-box' ).removeClass( 'has-value' );
+	} );
 
-    /**
-     * Clear the search query when clicking the close icon not inside subnav
-     */
-    $( document ).on( 'click', 'div:not(.subsubsub) .search-box__close-icon', function(e) {
-        e.preventDefault();
-        $( this ).closest( '.search-box' ).find( 'input[type=search]' ).val( '' );
-        $( this ).closest( '.search-box' ).removeClass( 'has-value' );
-    } );
+	/**
+	 * Add has-value class on type.
+	 */
+	$( document ).on( 'keyup', '.search-box input[type="search"]', function( e ) {
+		if ( $( this ).val() ) {
+			$( this ).closest( '.search-box' ).addClass( 'has-value' );
+		} else {
+			$( this ).closest( '.search-box' ).removeClass( 'has-value' );
+		}
+	} );
 
-    /**
-     * Add has-value class on type
-     */
-    $( document ).on( 'keyup', '.search-box input[type="search"]', function(e) {
-        if ( $( this ).val() ) {
-            $( this ).closest( '.search-box' ).addClass( 'has-value' );
-        } else {
-            $( this ).closest( '.search-box' ).removeClass( 'has-value' );
-        }
-    } );
+	/**
+	 * Remove auto-fold for admin sidebar menu.
+	 */
+	function removeAutoFold() {
+		if ( $( this ).width() > 660 && $( this ).width() <= 960 ) {
+			$( 'body' ).removeClass( 'auto-fold' );
+		} else {
+			$( 'body' ).addClass( 'auto-fold' );
+		}
+	}
+	$( window ).on( 'resize', removeAutoFold );
+	$( document ).on( 'ready', removeAutoFold );
 
-    /**
-     * Remove auto-fold for admin sidebar menu
-     */
-    function removeAutoFold() {
-        if ( $(this).width() > 660 && $(this).width() <= 960 ) {
-            $( 'body' ).removeClass('auto-fold');
-        } else {
-            $( 'body' ).addClass('auto-fold');
-        }
-    }
-    $( window ).on( 'resize', removeAutoFold );
-    $( document ).on( 'ready', removeAutoFold );
+	/**
+	 * Table scrolling shadow.
+	 */
+	function checkTableScroll() {
+		const scrolledToEnd = $( this )[0].scrollWidth - $( this )[0].scrollLeft <= $( this )[0].offsetWidth;
+		if ( ! scrolledToEnd ) {
+			$( this ).parent().addClass( 'is-scrollable' )
+		} else {
+			$( this ).parent().removeClass( 'is-scrollable' );
+		}
+	}
+	$( '.wp-list-table-wrapper__inner' ).scroll( checkTableScroll );
+	$( '.wp-list-table-wrapper__inner' ).scroll();
+	$( window ).resize( function() {
+		$( '.wp-list-table-wrapper__inner' ).scroll();
+	} );
 
-    /**
-     * Table scrolling shadow
-     */
-    function checkTableScroll() {
-        const scrolledToEnd = $( this )[0].scrollWidth - $( this )[0].scrollLeft <= $( this )[0].offsetWidth;
-        if ( ! scrolledToEnd ) {
-            $( this ).parent().addClass( 'is-scrollable' )
-        } else {
-            $( this ).parent().removeClass( 'is-scrollable' );
-        }
-    }
-    $( '.wp-list-table-wrapper__inner' ).scroll( checkTableScroll );
-    $( '.wp-list-table-wrapper__inner' ).scroll();
-    $( window ).resize( function() {
-        $( '.wp-list-table-wrapper__inner' ).scroll();
-    } );
+	/**
+	 * Detect changes to tag/category table.
+	 */
+	var addedTags = [];
+	$( '#the-list[data-wp-lists="list:tag"] tr .name .row-title' ).each( function() {
+		addedTags.push( $( this ).text() );
+	} );
+	$( window ).load( function() {
+		$( 'body' ).on( 'DOMSubtreeModified', '#the-list[data-wp-lists="list:tag"]', function() {
+			var tagName = $( this ).find( 'tr:first .name .row-title' ).text();
+			if ( $.inArray( tagName, addedTags ) === -1 ) {
+				addedTags.push( tagName );
+				toggleTaxonomyForm();
+				appendNotice( translations.taxonomySuccess.replace( '{name}', tagName ), 'success' );
+			}
+		} );
+	} );
 
-    /**
-     * Detect changes to tag/category table
-     */
-    var addedTags = [];
-    $( '#the-list[data-wp-lists="list:tag"] tr .name .row-title' ).each( function() {
-        addedTags.push( $( this ).text() );
-    } );
-    $( window ).load( function() {
-        $( 'body' ).on( 'DOMSubtreeModified', '#the-list[data-wp-lists="list:tag"]', function() {
-            var tagName = $( this ).find( 'tr:first .name .row-title' ).text();
-            if ( $.inArray( tagName, addedTags ) === -1 ) {
-                addedTags.push( tagName );
-                toggleTaxonomyForm();
-                appendNotice( translations.taxonomySuccess.replace( '{name}', tagName ), 'success' );
-            }
-        } );
-    } );
+	/**
+	 * Append notice.
+	 */
+	function appendNotice( content, type ) {
+		var html = '';
+		var icon = icons.info;
+		var classes = [ 'notice' ];
+		if ( 'success' === type ) {
+			icon = icons.checkmark;
+			classes.push( 'notice-success' );
+		} else if ( 'error' === type ) {
+			icon = icons.notice;
+			classes.push( 'error' );
+		}
+		html += '<div class="' + classes.join( ' ' ) + '">';
+		html += '<span class="wc-calypso-bridge-notice-icon-wrapper">';
+		html += icon;
+		html += '</span>';
+		html += '<div class="wc-calypso-bridge-notice-content"><p>' + content + '</p></div>'
+		html += '</div>';
+		$( html ).insertAfter( 'h1.wp-heading-inline:first' );
+	}
 
-    /**
-     * Append notice
-     */
-    function appendNotice( content, type ) {
-        var html = '';
-        var icon = icons.info;
-        var classes = [ 'notice' ];
-        if ( 'success' === type ) {
-            icon = icons.checkmark;
-            classes.push( 'notice-success' );
-        } else if ( 'error' === type ) {
-            icon = icons.notice;
-            classes.push( 'error' );
-        }
-        html += '<div class="' + classes.join( ' ' ) + '">';
-        html += '<span class="wc-calypso-bridge-notice-icon-wrapper">';
-        html += icon;
-        html += '</span>';
-        html += '<div class="wc-calypso-bridge-notice-content"><p>' + content + '</p></div>'
-        html += '</div>';
-        $( html ).insertAfter( 'h1.wp-heading-inline:first' );
-    }
-
-    /**
-     * Focus select2 input on click
-     */
-    $( document ).on( 'click', '.select2', function() {
-        setTimeout( function() {
-            $( '.select2-container--open .select2-search__field' ).focus();
-        }, 0 );
+	/**
+	 * Focus select2 input on click.
+	 */
+	$( document ).on( 'click', '.select2', function() {
+		setTimeout( function() {
+			$( '.select2-container--open .select2-search__field' ).focus();
+		}, 0 );
 	} );
 
 	$( document ).ready( function() {
@@ -358,16 +356,16 @@
 	} );
 
 	/**
-	 * Support link click event
+	 * Support link click event.
 	 */
-	$( '.wc-support-link' ).unbind("click").click( function( e ) {
+	$( '.wc-support-link' ).unbind( 'click' ).click( function( e ) {
 		const source = $( this ).data( 'source' )
-		const href = $( this ).attr('href');
+		const href = $( this ).attr( 'href' );
 		trackSupportClick( source, href );
 	} );
 
 	/**
-	 * Track support link clicks in Jetpack if enabled
+	 * Track support link clicks in Jetpack if enabled.
 	 *
 	 * @param {string} source Source of click (footer or sidebar)
 	 * @param {string} href Link location


### PR DESCRIPTION
See #306 

This adds a todo to remove the notice CSS and jQuery once it's been released in Jetpack.

It also updates the jQuery handling of notices so that only one of the two implementations of the handlers will process the notices.

### Testing
- Add a notice to the dashboard
- Activate the Calypso bridge
- Visually check the notice on a WooCommerce page (eg. orders list)
- Visually check the notice on the Plugins page
- Switch Jetpack to the `calypsoify-notices` branch
- build the scripts/CSS
- Visually check the notice on a WooCommerce page (eg. orders list)
- Visually check the notice on the Plugins page
