### PR TITLE
Add support for wc-admin layout

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2554,3 +2554,20 @@ h3#woocommerce_stripe_connection_status {
 .woocommerce-help-text {
 	text-align: center;
 }
+
+/* WooCommerce Admin */
+.woocommerce-embed-page .woocommerce-layout__primary {
+	padding: 0;
+}
+.woocommerce-embed-page .wrap {
+	padding: 0;
+}
+.woocommerce-layout__primary {
+	margin: 0;
+}
+.woocommerce_page_wc-admin .wrap {
+	max-width: 100%;
+}
+.woocommerce-layout .woocommerce-layout__main {
+	padding-right: 0;
+}

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -141,6 +141,7 @@ class WC_Calypso_Bridge {
 				include_once $connect_file;
 			}
 
+			add_action( 'admin_body_class', array( $this, 'add_calypsoify_class' ) );
 			add_action( 'current_screen', array( $this, 'load_ui_elements' ) );
 		}
 	}
@@ -197,6 +198,17 @@ class WC_Calypso_Bridge {
 			add_action( 'admin_init', array( $this, 'remove_woocommerce_core_footer_text' ) );
 			add_filter( 'admin_footer_text', array( $this, 'update_woocommerce_footer' ) );
 		}
+	}
+
+	/**
+	 * Add the calypsoify classes to the body tag.
+	 *
+	 * @param string $classes Space separated string of body classes.
+	 * @return string
+	 */
+	public static function add_calypsoify_class( $classes ) {
+		$classes .= ' calypsoify-active';
+		return $classes;
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -88,7 +88,12 @@ class WC_Calypso_Bridge_Setup {
 	 * @return string
 	 */
 	public static function add_calypsoify_class( $classes ) {
-		$classes .= ' calypsoify-active';
+		include_once dirname( __FILE__ ) . '/class-wc-calypso-bridge-page-controller.php';
+
+		if ( function_exists( 'is_wc_calypso_bridge_page' ) && is_wc_calypso_bridge_page() ) {
+			$classes .= ' calypsoify-active';
+		}
+
 		return $classes;
 	}
 
@@ -101,7 +106,7 @@ class WC_Calypso_Bridge_Setup {
 	 */
 	public function prevent_mailchimp_redirect( $location, $status ) {
 		if ( 'admin.php?page=mailchimp-woocommerce' === $location ) {
-			// Delete the redirect option so we don't end up here anymore
+			// Delete the redirect option so we don't end up here anymore.
 			delete_option( 'mailchimp_woocommerce_plugin_do_activation_redirect' );
 			$location = admin_url( 'admin.php?page=wc-setup-checklist&calypsoify=1' );
 		}

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -39,8 +39,6 @@ class WC_Calypso_Bridge_Setup {
 			return;
 		}
 
-		add_filter( 'admin_body_class', array( $this, 'add_calypsoify_class' ) );
-
 		// If setup has yet to complete, make sure MailChimp doesn't redirect the flow.
 		$has_finshed_setup = (bool) WC_Calypso_Bridge_Admin_Setup_Checklist::is_checklist_done();
 		if ( ! $has_finshed_setup ) {
@@ -79,22 +77,6 @@ class WC_Calypso_Bridge_Setup {
 		$whitelist = array( 'store_setup', 'payment' );
 		$steps     = array_intersect_key( $default_steps, array_flip( $whitelist ) );
 		return $steps;
-	}
-
-	/**
-	 * Add the calypsoify classes to the body tag.
-	 *
-	 * @param string $classes Space separated string of body classes.
-	 * @return string
-	 */
-	public static function add_calypsoify_class( $classes ) {
-		include_once dirname( __FILE__ ) . '/class-wc-calypso-bridge-page-controller.php';
-
-		if ( function_exists( 'is_wc_calypso_bridge_page' ) && is_wc_calypso_bridge_page() ) {
-			$classes .= ' calypsoify-active';
-		}
-
-		return $classes;
 	}
 
 	/**


### PR DESCRIPTION
Fixes (part of) #462 

Removes padding on layout elements not needed when Calypsoify is turned on.  Also makes wc-admin pages full width since the analytics need room to breathe.

### Before

<img width="1632" alt="Screen Shot 2019-07-26 at 3 32 08 PM" src="https://user-images.githubusercontent.com/10561050/61935511-430b3b00-afbd-11e9-9d17-880c8b9aea23.png">
<img width="1623" alt="Screen Shot 2019-07-26 at 3 31 46 PM" src="https://user-images.githubusercontent.com/10561050/61935513-430b3b00-afbd-11e9-97e0-2b75d2d74c3a.png">

### After
<img width="1626" alt="Screen Shot 2019-07-26 at 3 49 21 PM" src="https://user-images.githubusercontent.com/10561050/61935520-46062b80-afbd-11e9-8820-df11d7363724.png">
<img width="1634" alt="Screen Shot 2019-07-26 at 3 52 10 PM" src="https://user-images.githubusercontent.com/10561050/61935566-59b19200-afbd-11e9-990c-03de0c58436b.png">

### Testing
1.  Enable calypsoify.
2.  Visit various pages and make sure layout looks the same as when wc-admin is deactivated.
3.  Visit wc-admin pages with calypsoify turned on.
4.  Make sure wc-admin pages match other calypsoify page padding and are full width.