### PR TITLE
Fix version bump in constant

### DIFF
--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -30,7 +30,7 @@ if ( file_exists( WP_PLUGIN_DIR . '/wc-calypso-bridge/wc-calypso-bridge.php' ) )
 	}
 }
 
-define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.0.17' );
+define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.1.0' );
 define( 'WC_MIN_VERSION', '3.0.0' );
 
 /**


### PR DESCRIPTION
I jumped the gun on https://github.com/Automattic/wc-calypso-bridge/pull/499 because I forgot to bump the version of `WC_CALYPSO_BRIDGE_CURRENT_VERSION` constant.

A new tag and release will need to be made.