### PR TITLE
Bail early if Woo is not active or present

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -36,10 +36,18 @@ class WC_Calypso_Bridge {
 	 * Constructor.
 	 */
 	public function __construct() {
+		add_action( 'plugins_loaded', array( $this, 'initialize' ), 2 );
+	}
+
+	public function initialize() {
+		// if woo is not active, then bail.
+		if ( ! function_exists( 'WC' ) ) {
+			return;
+		}
 		add_action( 'init', array( $this, 'check_calypsoify_param' ), 1 );
 		add_action( 'init', array( $this, 'check_setup_param' ) );
 		add_action( 'init', array( $this, 'possibly_load_calypsoify' ), 2 );
-		add_action( 'plugins_loaded', array( $this, 'disable_powerpack_features' ), 2 );
+		$this->disable_powerpack_features();
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "automattic/wc-calypso-bridge",
-	"version": "v1.1.0",
+	"version": "v1.1.1",
 	"autoload": {
 		"files": [
 			"wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 1.1.0
+Stable tag: 1.1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ This section describes how to install the plugin and get it working.
 1. Activate the plugin through the 'Plugins' screen in WordPress
 
 == Changelog ==
+
+* 1.1.1
+* Bail early if Woo is not active or present
 
 * 1.1.0
 * decrease padding on table per page select in Calypso

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 1.1.0
+ * Version: 1.1.1
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -30,7 +30,7 @@ if ( file_exists( WP_PLUGIN_DIR . '/wc-calypso-bridge/wc-calypso-bridge.php' ) )
 	}
 }
 
-define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.1.0' );
+define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.1.1' );
 define( 'WC_MIN_VERSION', '3.0.0' );
 
 /**


### PR DESCRIPTION
See p9F6qB-477-p2 for original report.

The previous check just looked for if woocommerce.php existed but not if WooCommerce itself is active (included!). 