### PR TITLE
Update address step in OBW to include 3.8 tracking modal updates.

### DIFF
--- a/includes/class-wc-calypso-bridge-admin-setup-wizard.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-wizard.php
@@ -169,6 +169,7 @@ class WC_Calypso_Bridge_Admin_Setup_Wizard extends WC_Admin_Setup_Wizard {
 		}
 		?>
 		<form method="post" class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>">
+			<input type="hidden" name="save_step" value="store_setup" />
 			<?php wp_nonce_field( 'wc-setup' ); ?>
 			<p class="store-setup"><?php esc_html_e( 'The following wizard will help you configure your store and get you started quickly.', 'wc-calypso-bridge' ); ?></p>
 
@@ -277,9 +278,10 @@ class WC_Calypso_Bridge_Admin_Setup_Wizard extends WC_Admin_Setup_Wizard {
 			<label class="location-prompt" for="woocommerce_sell_in_person">
 				<?php esc_html_e( 'I will also be selling products or services in person.', 'wc-calypso-bridge' ); ?>
 			</label>
-
+			<input type="checkbox" id="wc_tracker_checkbox" name="wc_tracker_checkbox" value="yes" />
+			<?php $this->tracking_modal(); ?>
 			<p class="wc-setup-actions step">
-				<button type="submit" class="button-primary button button-large button-next" value="<?php esc_attr_e( "Let's go!", 'wc-calypso-bridge' ); ?>" name="save_step"><?php esc_html_e( "Let's go!", 'wc-calypso-bridge' ); ?></button>
+				<button class="button-primary button button-large button-next" value="<?php esc_attr_e( "Let's go!", 'wc-calypso-bridge' ); ?>" name="save_step"><?php esc_html_e( "Let's go!", 'wc-calypso-bridge' ); ?></button>
 			</p>
 		</form>
 		<?php


### PR DESCRIPTION
Background: p9F6qB-4ri-p2

In https://github.com/woocommerce/woocommerce/pull/24680 which shipped as part of WooCommerce 3.8, a new modal dialog was added after users click "Continue" on the Address screen of the onboarding wizard:

![image](https://user-images.githubusercontent.com/22080/69826666-02206e80-11c9-11ea-9e04-e6743fc18ffb.png)

The changes to the template in Woo core's `wc_setup_store_setup()` which we extend in Calypso bridge were not ported to the version in use here, and resulted in a JS exception that prevents users from moving past the first step of the OBW.

The proposed fix here is to bring the changes shipped in 3.8 to the method to remove the error, and include the modal dialog in the process.

_sidenote_ Since ecom plan sites are hosted at WPCOM - I believe we can always default tracking to ON, and I feel like we already do so via a filter. But at some point we should omit this step... perhaps this is moot with the new OBW coming soon so end of random sidenote.

__To Test__
- On `master` visit `/wp-admin/index.php?page=wc-setup`, fill out the form, verify that clicking "Continue" throws a backbone modal error.
- Checkout this branch, repeat the first step and confirm you proceed to the second part of the OBW.