### PR TITLE
Allow the onboarding split-testing implementation to work with the eCommerce Plan

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2585,3 +2585,34 @@ h3#woocommerce_stripe_connection_status {
 .woocommerce-layout .woocommerce-layout__main {
 	padding-right: 0;
 }
+
+.wc-setup-step__new_onboarding .wc-setup-step__new_onboarding-wrapper .wc-logo {
+	display: block;
+}
+
+.wc-setup-step__new_onboarding .wc-setup-step__new_onboarding-wrapper p {
+	text-align: center;
+}
+
+.wc-setup-step__new_onboarding .wc-setup-step__new_onboarding-wrapper .wc-setup-step__new_onboarding-welcome,
+.wc-setup-step__new_onboarding .wc-setup-step__new_onboarding-wrapper .wc-setup-step__new_onboarding-plugin-info {
+	color: #7c7c7c;
+	font-size: 12px;
+}
+
+.wc-setup-step__new_onboarding .wc-setup-actions {
+	display: block;
+}
+
+.wc-setup-step__new_onboarding .wc-setup-actions .button-primary {
+	background: #007cba;
+	border-color: #007cba;
+	text-shadow: none;
+}
+
+.wc-setup-step__new_onboarding .wc-setup-actions .button-primary:hover,
+.wc-setup-step__new_onboarding .wc-setup-actions .button-primary:active,
+.wc-setup-step__new_onboarding .wc-setup-actions .button-primary:focus {
+	background-color: #3582c4;
+	border-color: #007cba;
+}

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2616,3 +2616,23 @@ h3#woocommerce_stripe_connection_status {
 	background-color: #3582c4;
 	border-color: #007cba;
 }
+
+/* New WooCommerce Onboarding resets to play nicely with Calypsoify */
+.woocommerce-profile-wizard__body label, .woocommerce-task-dashboard__container label {
+	font-weight: normal;
+}
+
+.woocommerce-profile-wizard__body .woocommerce-profile-wizard__checkbox-group svg.dashicon.components-checkbox-control__checked {
+	left: 0px;
+	top: -2px;
+}
+
+
+.woocommerce-profile-wizard__body input[type=checkbox] {
+	vertical-align: top;
+	margin-top: 0;
+}
+
+.woocommerce-profile-wizard__body .woocommerce-profile-wizard__checkbox-group .components-checkbox-control__label {
+	font-size: 16px;
+}

--- a/assets/js/calypsoify-obw.js
+++ b/assets/js/calypsoify-obw.js
@@ -10,7 +10,7 @@ var pagenow = 'wc-setup';
         e.preventDefault();
         $( '.wc-setup .button-next' ).click();
 
-        var form = $( '.wc-setup .button-next' ).parents( 'form' ).get( 0 );
+        var form = $( '.wc-setup-step__new_onboarding .button-primary, .wc-setup .button-next' ).parents( 'form' ).get( 0 );
 		if ( ( 'function' !== typeof form.checkValidity ) || form.checkValidity() ) {
 			$( this ).attr( 'disabled', true );
 		}

--- a/includes/class-wc-calypso-bridge-admin-setup-checklist.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-checklist.php
@@ -35,6 +35,17 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 	 * Hooks into WordPress to add our new setup checklist.
 	 */
 	private function __construct() {
+		// If the user opted into the new WooCommerce Onboarding wizard, don't show this task list.
+		$onboarding_ab_test = get_option( 'woocommerce_setup_ab_wc_admin_onboarding' );
+		$onboarding_opt_in  = get_option( 'wc_onboarding_opt_in', 'no' );
+		if ( 'b' === $onboarding_ab_test && 'yes' === $onboarding_opt_in ) {
+			if ( isset( $_GET['page'] ) && 'wc-setup-checklist' === $_GET['page'] ) {
+				wp_safe_redirect( admin_url( 'admin.php?page=wc-admin' ) );
+				exit;
+			}
+			return;
+		}
+
 		$this->handle_redirects();
 
 		add_action( 'admin_menu', array( $this, 'admin_menu' ) );

--- a/includes/class-wc-calypso-bridge-admin-setup-wizard.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-wizard.php
@@ -108,6 +108,11 @@ class WC_Calypso_Bridge_Admin_Setup_Wizard extends WC_Admin_Setup_Wizard {
 			),
 		);
 
+		// Hide the new/improved onboarding experience screen if the user is not part of the a/b test.
+		if ( ! method_exists( $this, 'should_show_wc_admin_onboarding' ) || ! $this->should_show_wc_admin_onboarding() ) {
+			unset( $default_steps['new_onboarding'] );
+		}
+
 		$this->steps = apply_filters( 'wc_calypso_bridge_setup_wizard_steps', $default_steps );
 		$this->step  = isset( $_GET['step'] ) ? sanitize_key( $_GET['step'] ) : current( array_keys( $this->steps ) ); // WPCS: CSRF ok, input var ok.
 

--- a/includes/class-wc-calypso-bridge-admin-setup-wizard.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-wizard.php
@@ -61,7 +61,7 @@ class WC_Calypso_Bridge_Admin_Setup_Wizard extends WC_Admin_Setup_Wizard {
 			<?php do_action( 'admin_print_scripts' ); ?>
 			<?php do_action( 'admin_head' ); ?>
 		</head>
-		<body class="wc-setup wp-core-ui">
+		<body class="wc-setup wp-core-ui <?php echo esc_attr( 'wc-setup-step__' . $this->step ); ?>">
 			<?php wp_admin_bar_render(); ?>
 		<?php
 	}
@@ -89,6 +89,11 @@ class WC_Calypso_Bridge_Admin_Setup_Wizard extends WC_Admin_Setup_Wizard {
 			return;
 		}
 		$default_steps = array(
+			'new_onboarding' => array(
+				'name'       => '',
+				'view'       => array( $this, 'wc_setup_new_onboarding' ),
+				'handler'    => array( $this, 'wc_setup_new_onboarding_save' ),
+			),
 			'store_setup' => array(
 				'name'       => __( 'Let\'s start setting up.', 'wc-calypso-bridge' ),
 				'subheading' => __( 'First we need to determine some basic information about your store.', 'wc-calypso-bridge' ),
@@ -133,7 +138,11 @@ class WC_Calypso_Bridge_Admin_Setup_Wizard extends WC_Admin_Setup_Wizard {
 	public function setup_wizard_footer() {
 		?>
 			<div class="wc-setup-footer">
-				<button class="button-primary button button-large" value="<?php esc_attr_e( "Let's go!", 'wc-calypso-bridge' ); ?>" name="save_step"><?php esc_html_e( 'Continue', 'wc-calypso-bridge' ); ?></button>
+				<?php if ( 'new_onboarding' === $this->step ) : ?>
+					<a class="wc-setup-footer-links" href="<?php echo esc_url( $this->get_next_step_link() ); ?>"><?php esc_html_e( 'Continue with the old setup wizard', 'wc-calypso-bridge' ); ?></a>
+				<?php else : ?>
+					<button class="button-primary button button-large" value="<?php esc_attr_e( "Let's go!", 'wc-calypso-bridge' ); ?>" name="save_step"><?php esc_html_e( 'Continue', 'wc-calypso-bridge' ); ?></button>
+				<?php endif; ?>
 			</div>
 			<?php do_action( 'admin_footer', '' ); ?>
 			<?php do_action( 'admin_print_footer_scripts' ); ?>

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -74,7 +74,7 @@ class WC_Calypso_Bridge_Setup {
 	 * @return array
 	 */
 	public function remove_unused_steps( $default_steps ) {
-		$whitelist = array( 'store_setup', 'payment' );
+		$whitelist = array( 'new_onboarding', 'store_setup', 'payment' );
 		$steps     = array_intersect_key( $default_steps, array_flip( $whitelist ) );
 		return $steps;
 	}


### PR DESCRIPTION
Now that https://github.com/woocommerce/woocommerce/pull/24991 has been merged, 3.9 will display the new onboarding wizard experience to a portion of users.

A few changes are necessary to make this work with the eCommerce Plan as well. This PR also fixes a couple minor display issues. Also, to avoid two setup task lists displaying (the eCommerce Plan & the new onboarding task list), I've opted to only show the new task list if the user has opted in via core. All the steps from the eCommerce Plan setup are present in our new wizard (and better).

<img width="1035" alt="Screen Shot 2019-12-04 at 1 00 32 PM" src="https://user-images.githubusercontent.com/689165/70171381-9ba1c180-169c-11ea-8e0f-6a355ef23ff8.png">

To Test:
* Run `woocommerce` master
* Disable WooCommerce Admin
* Add/update the `woocommerce_setup_ab_wc_admin_onboarding` option to contain the value `b`. This puts you in the onboarding test group.
* Go to `/wp-admin/admin.php?page=wc-setup` and you should see the new onboarding experience offered to you. You can install WooCommerce Admin and start the profile wizard from here, or continue to the normal setup flow.
* Verify the eCommerce Plan setup list doesn't display, even with `update_option( 'atomic-ecommerce-setup-checklist-complete', false );` set.
* Run `woocommerce` 3.8 and notice that you get the normal onboarding wizard.
