### PR TITLE
Fix broken importer layout and styles

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2654,3 +2654,33 @@ h3#woocommerce_stripe_connection_status {
 	padding: 8px;
     margin-top: 24px;
 }
+
+.woocommerce-progress-form-wrapper {
+	max-width: 90%;
+}
+
+.woocommerce-progress-form-wrapper .wc-progress-steps li.active,
+.woocommerce-progress-form-wrapper .wc-progress-steps li.done {
+	border-color: #135e96;
+	color: #135e96;
+}
+
+.woocommerce-progress-form-wrapper .wc-progress-steps li.active::before {
+	border-color: #135e96;
+}
+
+.woocommerce-progress-form-wrapper .wc-progress-steps li.done::before {
+	border-color: #135e96;
+	background: #135e96;
+}
+
+.woocommerce-progress-form-wrapper .woocommerce-importer .woocommerce-importer-done::before {
+	color: #135e96;
+}
+
+.woocommerce-exporter-wrapper .woocommerce-exporter progress::-webkit-progress-value,
+.woocommerce-importer-wrapper .woocommerce-importer progress::-webkit-progress-value,
+.woocommerce-progress-form-wrapper .wc-progress-form-content progress::-webkit-progress-value {
+	background: #135e96 !important;
+	background: linear-gradient(to bottom, #135e96, #043959), #135e96 !important;
+}

--- a/includes/connect/core.php
+++ b/includes/connect/core.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Core pages to connect to the Calypsoify layout
+ *
+ * @package WC_Calypso_Bridge/Connect
+ */
+
 wc_calypso_bridge_connect_page(
 	array(
 		'screen_id' => 'edit-shop_coupon',
@@ -68,6 +74,12 @@ wc_calypso_bridge_connect_page(
 		'screen_id' => 'product',
 		'menu'      => 'edit.php?post_type=product',
 		'submenu'   => 'edit.php?post_type=product',
+	)
+);
+
+wc_calypso_bridge_connect_page(
+	array(
+		'screen_id' => 'product_page_product_importer',
 	)
 );
 


### PR DESCRIPTION
Fixes #505.

The importer page was pretty busted on the eCommerce plan. This PR adds a missing connect definition, and adjust some styles to fit in more closely with Calypsoify.

<img width="1371" alt="Screen Shot 2019-12-11 at 6 14 01 AM" src="https://user-images.githubusercontent.com/689165/70619494-1d38a880-1be3-11ea-8ca1-c892623d762b.png">

<img width="867" alt="Screen Shot 2019-12-11 at 6 16 12 AM" src="https://user-images.githubusercontent.com/689165/70619454-0a25d880-1be3-11ea-9bc4-9e07fb1ef5b5.png">

### Testing Directions

* In Calypsoify mode, go to the product import page (either via onboarding task list, the tools menu, or `/wp-admin/edit.php?post_type=product&page=product_importer`.
* Verify things look OK. You can walk through the import steps using [this sample data](https://docs.woocommerce.com/document/product-csv-importer-exporter/dummy-data/).
