### PR TITLE
Onboarding - Add card border for setup card and fix tax search box

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2649,3 +2649,8 @@ h3#woocommerce_stripe_connection_status {
 	border-left: 1px solid #ccd0d4;
 	border-radius: 0;
 }
+
+.wc-tax-rates-search {
+	padding: 8px;
+    margin-top: 24px;
+}

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2636,3 +2636,16 @@ h3#woocommerce_stripe_connection_status {
 .woocommerce-profile-wizard__body .woocommerce-profile-wizard__checkbox-group .components-checkbox-control__label {
 	font-size: 16px;
 }
+
+.woocommerce-task-dashboard__body .woocommerce-task-card .woocommerce-card__body {
+	border-top: 1px solid #ccd0d4;
+	border-left: 1px solid #ccd0d4;
+	border-right: 1px solid #ccd0d4;
+}
+
+.woocommerce-task-dashboard__body .woocommerce-task-card .woocommerce-card__header {
+	border-top: 1px solid #ccd0d4;
+	border-right: 1px solid #ccd0d4;
+	border-left: 1px solid #ccd0d4;
+	border-radius: 0;
+}


### PR DESCRIPTION
Fixes #506.

This PR adds a different border around the dashboard card (matching the other cards), so that the card looks better against Calypsoify's background color.

It also makes a slight CSS tweak to the search box on the tax page (fixes #507).

<img width="1149" alt="Screen Shot 2019-12-11 at 7 24 32 AM" src="https://user-images.githubusercontent.com/689165/70621318-4a875580-1be7-11ea-84ed-e29706e3b7de.png">

<img width="857" alt="Screen Shot 2019-12-11 at 7 21 33 AM" src="https://user-images.githubusercontent.com/689165/70621277-36435880-1be7-11ea-819a-be236ddfc4a0.png">

To Test:
* Enable the new Onboarding experience (either by running core and opting in, or by running your own version of wc-admin)
* Visit the dashboard and see the card styles
* Visit the tax rates page and verify there is padding around the search box
