### PR TITLE
Calypsoify: Hide wc-admin navigation bar

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2600,6 +2600,10 @@ h3#woocommerce_stripe_connection_status {
 }
 
 /* WooCommerce Admin */
+.woocommerce-layout__header {
+	display: none;
+}
+
 .woocommerce-embed-page .woocommerce-layout__primary {
 	padding: 0;
 }


### PR DESCRIPTION
Fixes: #513

From 3.9 testing, we had reports of the wc-admin navigation bar appearing on calypsoified pages. While I was not able to reproduce this myself, I figured it wouldn't hurt to add some css to prevent it from happening.

__To Test__
- Visit any woo page _without_ calypsoify enabled with wc-admin installed and verify the wc-admin nav bar appears.
- Visit a calypsoified woo page by adding `calypsoify=1` url arg to any woo page. Verify the `.woocommerce-layout__header` element has `display: none` applied to it.