### PR TITLE
Update docs on how to set up ecommerce plan styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,7 @@ add_filter( 'jetpack_tools_to_include', function( $tools ) {
 To make the bridge work, the site must have the ecommerce plan option set under the `at_options` option:
 
 ```
-add_filter( 'pre_option_at_options', function() {
-	return [ 'plan_slug' => 'ecommerce' ];
-});
+update_option( 'at_options', array( 'plan_slug' => 'ecommerce' ) );
 ```
 
 Clicking the "I'm Done Setting Up" button on the Setup Checklist page will mark the option `atomic-ecommerce-setup-checklist-complete` as true.  If you need to access this page again, you can update this in your database or temporarily add the following to your plugin file:

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ Clicking the "I'm Done Setting Up" button on the Setup Checklist page will mark 
 
 `update_option( 'atomic-ecommerce-setup-checklist-complete', false );`
 
+Note that this checklist can't work simultaneously with the new WooCommerce Admin onboarding experience.  To use the checklist in this plugin, make sure that you opt out of the new onboarding experience:
+
+```
+update_option( 'woocommerce_setup_ab_wc_admin_onboarding', 'a' );
+update_option( 'wc_onboarding_opt_in', 'no' );
+```
+
 If you would like to skip all of the above, [just download this gist](https://gist.github.com/timmyc/72061e99f2e6893a94845ba93e6db6ca) as a plugin and activate it :).
 
 #### Calypsoify Param


### PR DESCRIPTION
Uses `update_option()` instead of a filter in docs so that this solution works in all plugins and themes.

### Testing

1. Run through the docs setup for this plugin on a new site.
1. Make sure you can get the ecommerce plan styles working (not just calypsoify) at `wc-calypso-bridge/assets/css/calypsoify.css`