### PR TITLE
Ecomm: Never show the new setup checklist shipping in 4.0

### DIFF
--- a/includes/class-wc-calypso-bridge-woocommerce-admin.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin.php
@@ -35,6 +35,8 @@ class WC_Calypso_Bridge_WooCommerce_Admin {
 	 */
 	public function init() {
 		add_filter( 'wc_admin_get_feature_config', array( $this, 'maybe_remove_devdocs_menu_item' ) );
+		add_filter( 'pre_option_woocommerce_task_list_hidden', array( $this, 'disable_new_task_list' ) );
+		add_filter( 'pre_option_woocommerce_onboarding_opt_in', array( $this, 'disable_onboarding_opt_in' ) );
 	}
 
 	/**
@@ -48,6 +50,20 @@ class WC_Calypso_Bridge_WooCommerce_Admin {
 		}
 
 		return $features;
+	}
+
+	/**
+	 * Force the woocommerce_task_list_hidden option to always be yes so the new checklist is never shown
+	 */
+	public function disable_new_task_list() {
+		return 'yes';
+	}
+
+	/**
+	 * Force the woocommerce_onboarding_opt_in option to always be no so the new checklist is never shown
+	 */
+	public function disable_onboarding_opt_in() {
+		return 'no';
 	}
 }
 


### PR DESCRIPTION
For #520 

This branch seeks to disable the new setup checklist that is in wc-admin when the Calypsoify view is active. Since the calyspoified version of the ecommerce plan already has its own bespoke setup checklist, we have decided to disable the new one for now.

__Steps to Test__
First it is helpful to create the "issue" of both setup checklists being shown. To do this:

- Visit the orders Listing page `/wp-admin/edit.php?post_type=shop_order` And then go to Help | Setup Wizard and click enable on the setup checklist if shown:

![enable-task-list(1)](https://user-images.githubusercontent.com/22080/75375948-04f03580-5884-11ea-8444-77a21b5ad4f8.png)

- Visit `/wp-admin/admin.php?page=wc-admin&calypsoify=1` to enable calypsoify and view the wc-admin dashboard. Verify the screen looks like so:

![image](https://user-images.githubusercontent.com/22080/75376032-2d782f80-5884-11ea-8203-31c151f20dfd.png)

- Next up, checkout this branch, and refresh the page, and verify the screen now looks like:

![image](https://user-images.githubusercontent.com/22080/75376068-408aff80-5884-11ea-8378-1c24d8869555.png)

__FYI__
Since the file used to filter the options that force the new setup checklist to be hidden is only loaded when Calypsoify is active, if you "break out" of calypsoify by visiting `/wp-admin` and subsequently navigate to the wc-admin dashboard, the setup checklist will be shown there:

![image](https://user-images.githubusercontent.com/22080/75376173-6ca68080-5884-11ea-800c-2c703e19342f.png)

Which I feel is actually a *good* thing since the calypsoify checklist is not shown in the standard wp-admin view.

/cc @pmcpinto @jameskoster 