### PR TITLE
Prep for release of 1.1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "automattic/wc-calypso-bridge",
-	"version": "v1.1.3",
+	"version": "v1.1.4",
 	"autoload": {
 		"files": [
 			"wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,10 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+* 1.1.4
+* Disable new setup checklist to prep for WooCommerce 4.0
+* Added styling to hide WooCommerce Admin nav when in calypsoify view
+
 * 1.1.3
 * Improved compatibility with the new onboarding experience being tested in WooCommerce Core.
 * Fixed search box display on the tax settings page.

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 1.1.3
+ * Version: 1.1.4
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4


### PR DESCRIPTION
This build contains two fixes for WooCommerce 4.0 prep on the ecommerce plan:

- Hides wc-admin navigation bar via CSS to ensure it is not displayed
- Disables the new Setup Task List since the calypsoify version of the ecommerce plan has its own.

__To Test__

Install WooCommerce 4.0 RC2

Test the Nav fix:

- Visit any woo page without calypsoify enabled with wc-admin installed and verify the wc-admin nav bar appears.
- Visit a calypsoified woo page by adding calypsoify=1 url arg to any woo page. Verify the .woocommerce-layout__header element has display: none applied to it.

Test the Setup Task List fix:

- Visit the orders Listing page `/wp-admin/edit.php?post_type=shop_order` And then go to Help | Setup Wizard and click enable on the setup checklist if shown:

![enable-task-list(1)](https://user-images.githubusercontent.com/22080/75375948-04f03580-5884-11ea-8444-77a21b5ad4f8.png)

- Visit `/wp-admin/admin.php?page=wc-admin&calypsoify=1` to enable calypsoify and view the wc-admin dashboard. Verify the screen looks like so:

![image](https://user-images.githubusercontent.com/22080/75376068-408aff80-5884-11ea-8378-1c24d8869555.png)
