### PR TITLE
Update Manage Site link to redirect to WordPress.com MySites root

### DIFF
--- a/includes/class-wc-calypso-bridge-menus.php
+++ b/includes/class-wc-calypso-bridge-menus.php
@@ -66,7 +66,7 @@ class WC_Calypso_Bridge_Menus {
 		$site_slug  = preg_replace( $strip_http, '', get_home_url() );
 		$site_slug  = str_replace( '/', '::', $site_slug );
 
-		$redirect_url = 'https://wordpress.com/stats/day/' . $site_slug;
+		$redirect_url = 'https://wordpress.com/sites/' . $site_slug;
 
 		wp_redirect( $redirect_url );
 		exit;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/38321

This PR changes the Manage site link to redirect to WordPress.com MySites root. (Currently, should redirect to WordPress.com/home over WordPress.com/stats).

To verify changes, starting from a site with an ecommerce plan:

1. Click on Store
<img width="687" alt="Screen Shot 2020-03-11 at 1 34 50 PM" src="https://user-images.githubusercontent.com/1270189/76461450-29c4cc80-639d-11ea-8917-868b9262ac42.png">

2. Click on Manage Site
<img width="688" alt="Screen Shot 2020-03-11 at 1 32 58 PM" src="https://user-images.githubusercontent.com/1270189/76461295-e1a5aa00-639c-11ea-9cf1-4173037957f3.png">

3. We should redirect to My Home:
<img width="1024" alt="Screen Shot 2020-03-11 at 1 35 32 PM" src="https://user-images.githubusercontent.com/1270189/76461487-3b0dd900-639d-11ea-9d00-6a321a386b0c.png">

Let me know if I'm missing anything 👍

