### PR TITLE
Force use of legacy obw to ensure woo pages are setup.

### DIFF
--- a/includes/class-wc-calypso-bridge-admin-setup-checklist.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-checklist.php
@@ -35,17 +35,6 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 	 * Hooks into WordPress to add our new setup checklist.
 	 */
 	private function __construct() {
-		// If the user opted into the new WooCommerce Onboarding wizard, don't show this task list.
-		$onboarding_ab_test = get_option( 'woocommerce_setup_ab_wc_admin_onboarding' );
-		$onboarding_opt_in  = get_option( 'wc_onboarding_opt_in', 'no' );
-		if ( 'b' === $onboarding_ab_test && 'yes' === $onboarding_opt_in ) {
-			if ( isset( $_GET['page'] ) && 'wc-setup-checklist' === $_GET['page'] ) {
-				wp_safe_redirect( admin_url( 'admin.php?page=wc-admin' ) );
-				exit;
-			}
-			return;
-		}
-
 		$this->handle_redirects();
 
 		add_action( 'admin_menu', array( $this, 'admin_menu' ) );

--- a/includes/class-wc-calypso-bridge-admin-setup-wizard.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-wizard.php
@@ -133,11 +133,7 @@ class WC_Calypso_Bridge_Admin_Setup_Wizard extends WC_Admin_Setup_Wizard {
 	public function setup_wizard_footer() {
 		?>
 			<div class="wc-setup-footer">
-				<?php if ( 'new_onboarding' === $this->step ) : ?>
-					<a class="wc-setup-footer-links" href="<?php echo esc_url( $this->get_next_step_link() ); ?>"><?php esc_html_e( 'Continue with the old setup wizard', 'wc-calypso-bridge' ); ?></a>
-				<?php else : ?>
-					<button class="button-primary button button-large" value="<?php esc_attr_e( "Let's go!", 'wc-calypso-bridge' ); ?>" name="save_step"><?php esc_html_e( 'Continue', 'wc-calypso-bridge' ); ?></button>
-				<?php endif; ?>
+				<button class="button-primary button button-large" value="<?php esc_attr_e( "Let's go!", 'wc-calypso-bridge' ); ?>" name="save_step"><?php esc_html_e( 'Continue', 'wc-calypso-bridge' ); ?></button>
 			</div>
 			<?php do_action( 'admin_footer', '' ); ?>
 			<?php do_action( 'admin_print_footer_scripts' ); ?>

--- a/includes/class-wc-calypso-bridge-admin-setup-wizard.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-wizard.php
@@ -89,11 +89,6 @@ class WC_Calypso_Bridge_Admin_Setup_Wizard extends WC_Admin_Setup_Wizard {
 			return;
 		}
 		$default_steps = array(
-			'new_onboarding' => array(
-				'name'       => '',
-				'view'       => array( $this, 'wc_setup_new_onboarding' ),
-				'handler'    => array( $this, 'wc_setup_new_onboarding_save' ),
-			),
 			'store_setup' => array(
 				'name'       => __( 'Let\'s start setting up.', 'wc-calypso-bridge' ),
 				'subheading' => __( 'First we need to determine some basic information about your store.', 'wc-calypso-bridge' ),
@@ -107,11 +102,6 @@ class WC_Calypso_Bridge_Admin_Setup_Wizard extends WC_Admin_Setup_Wizard {
 				'handler'    => array( $this, 'wc_setup_payment_save' ),
 			),
 		);
-
-		// Hide the new/improved onboarding experience screen if the user is not part of the a/b test.
-		if ( ! method_exists( $this, 'should_show_wc_admin_onboarding' ) || ! $this->should_show_wc_admin_onboarding() ) {
-			unset( $default_steps['new_onboarding'] );
-		}
 
 		$this->steps = apply_filters( 'wc_calypso_bridge_setup_wizard_steps', $default_steps );
 		$this->step  = isset( $_GET['step'] ) ? sanitize_key( $_GET['step'] ) : current( array_keys( $this->steps ) ); // WPCS: CSRF ok, input var ok.

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -74,7 +74,7 @@ class WC_Calypso_Bridge_Setup {
 	 * @return array
 	 */
 	public function remove_unused_steps( $default_steps ) {
-		$whitelist = array( 'new_onboarding', 'store_setup', 'payment' );
+		$whitelist = array( 'store_setup', 'payment' );
 		$steps     = array_intersect_key( $default_steps, array_flip( $whitelist ) );
 		return $steps;
 	}

--- a/includes/class-wc-calypso-bridge-woocommerce-admin.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin.php
@@ -37,7 +37,6 @@ class WC_Calypso_Bridge_WooCommerce_Admin {
 		add_filter( 'wc_admin_get_feature_config', array( $this, 'maybe_remove_devdocs_menu_item' ) );
 		add_filter( 'pre_option_woocommerce_task_list_hidden', array( $this, 'disable_new_task_list' ) );
 		add_filter( 'pre_option_woocommerce_onboarding_opt_in', array( $this, 'disable_onboarding_opt_in' ) );
-		add_filter( 'pre_option_woocommerce_setup_ab_wc_admin_onboarding', array( $this, 'disable_onboarding_a_b_test' ) );
 	}
 
 	/**
@@ -65,13 +64,6 @@ class WC_Calypso_Bridge_WooCommerce_Admin {
 	 */
 	public function disable_onboarding_opt_in() {
 		return 'no';
-	}
-
-	/**
-	 * Always disable the new onboarding opt-in.
-	 */
-	public function disable_onboarding_a_b_test() {
-		return 'a';
 	}
 }
 

--- a/includes/class-wc-calypso-bridge-woocommerce-admin.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin.php
@@ -37,6 +37,7 @@ class WC_Calypso_Bridge_WooCommerce_Admin {
 		add_filter( 'wc_admin_get_feature_config', array( $this, 'maybe_remove_devdocs_menu_item' ) );
 		add_filter( 'pre_option_woocommerce_task_list_hidden', array( $this, 'disable_new_task_list' ) );
 		add_filter( 'pre_option_woocommerce_onboarding_opt_in', array( $this, 'disable_onboarding_opt_in' ) );
+		add_filter( 'pre_option_woocommerce_setup_ab_wc_admin_onboarding', array( $this, 'disable_onboarding_a_b_test' ) );
 	}
 
 	/**
@@ -64,6 +65,13 @@ class WC_Calypso_Bridge_WooCommerce_Admin {
 	 */
 	public function disable_onboarding_opt_in() {
 		return 'no';
+	}
+
+	/**
+	 * Always disable the new onboarding opt-in.
+	 */
+	public function disable_onboarding_a_b_test() {
+		return 'a';
 	}
 }
 


### PR DESCRIPTION
Fixes #522 
Fixes https://github.com/Automattic/wp-calypso/issues/39850

Currently new users coming through from the calypso setup flow to the ecommerce plan can get opted-in to the new store profiler experience, but a shortened one. This can result in a site being "setup" without the default Woo pages ( shop, cart, checkout ) from ever being created.

This branch seeks to fix that bug by forcing e-comm users to use the modified "legacy" OBW that originally shipped with the project. The legacy OBW [creates the pages](https://github.com/woocommerce/woocommerce/blob/master/includes/admin/class-wc-admin-setup-wizard.php#L770) during this flow, and thus fixes the bug reported in Calypso.

Additionally in this PR I removed other code that @joshuatf pointed out that no longer is needed since we are forcing users to go through the legacy OBW and Calypsoify checklist.

Lastly, note that all of this code will go away when we remove Calypsoify from the ecomm plan woo side of things :)

__To Test__
On `master` of calypso-bridge

- Install WooCommerce 4.0
- Opt in to the new onboarding experience by `update_option( 'woocommerce_setup_ab_wc_admin_onboarding', 'b' )`
- Also handy to add this filter to always ensure the calypsoify setup checklist is shown `add_filter( 'wc_calypso_bridge_development_mode', '__return_true' );`
- Visit `wp-admin?page=wc-setup` verify that you are shown the option to use the new onboarding experience with the "YES PLEASE" button.

Install this branch

- Visit `wp-admin?page=wc-setup`, and verify you see the following flow:

<img width="1566" alt="wc-calypso-bridge1" src="https://user-images.githubusercontent.com/22080/76564753-71635b00-6466-11ea-8b62-12d19fbeb666.png">
<img width="1566" alt="WooCommerce › Setup Wizard - Mozilla Firefox 2020-03-12 13-26-40" src="https://user-images.githubusercontent.com/22080/76564759-758f7880-6466-11ea-8c63-42d2af608654.png">
<img width="1566" alt="Setup ‹ ecomm woo test — WordPress - Mozilla Firefox 2020-03-12 13-26-59" src="https://user-images.githubusercontent.com/22080/76564765-79bb9600-6466-11ea-8597-8bce053281d7.png">

