### PR TITLE
Prep for release of 1.1.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "automattic/wc-calypso-bridge",
-	"version": "v1.1.4",
+	"version": "v1.1.5",
 	"autoload": {
 		"files": [
 			"wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 1.1.3
+Stable tag: 1.1.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,10 @@ This section describes how to install the plugin and get it working.
 1. Activate the plugin through the 'Plugins' screen in WordPress
 
 == Changelog ==
+
+* 1.1.5
+* Update Manage Site link to redirect to WordPress.com MySites root.
+* Force use of legacy obw to ensure woo pages are setup.
 
 * 1.1.4
 * Disable new setup checklist to prep for WooCommerce 4.0

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 1.1.4
+ * Version: 1.1.5
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4


### PR DESCRIPTION
This build contains two fixes:
* Update Manage Site link to redirect to WordPress.com MySites root.
* Force use of legacy obw to ensure woo pages are setup.

__To Test__
Starting from a site with an ecommerce plan:

1. Click on Store
<img width="687" alt="Screen Shot 2020-03-11 at 1 34 50 PM" src="https://user-images.githubusercontent.com/1270189/76461450-29c4cc80-639d-11ea-8917-868b9262ac42.png">

2. Click on Manage Site
<img width="688" alt="Screen Shot 2020-03-11 at 1 32 58 PM" src="https://user-images.githubusercontent.com/1270189/76461295-e1a5aa00-639c-11ea-9cf1-4173037957f3.png">

3. We should redirect to My Home:
<img width="1024" alt="Screen Shot 2020-03-11 at 1 35 32 PM" src="https://user-images.githubusercontent.com/1270189/76461487-3b0dd900-639d-11ea-9d00-6a321a386b0c.png">



__To Test__
On `master` of calypso-bridge

- Install WooCommerce 4.0
- Opt in to the new onboarding experience by `update_option( 'woocommerce_setup_ab_wc_admin_onboarding', 'b' )`
- Also handy to add this filter to always ensure the calypsoify setup checklist is shown `add_filter( 'wc_calypso_bridge_development_mode', '__return_true' );`
- Visit `wp-admin?page=wc-setup` verify that you are shown the option to use the new onboarding experience with the "YES PLEASE" button.

Install this branch

- Visit `wp-admin?page=wc-setup`, and verify you see the following flow:

<img width="1566" alt="wc-calypso-bridge1" src="https://user-images.githubusercontent.com/22080/76564753-71635b00-6466-11ea-8b62-12d19fbeb666.png">
<img width="1566" alt="WooCommerce › Setup Wizard - Mozilla Firefox 2020-03-12 13-26-40" src="https://user-images.githubusercontent.com/22080/76564759-758f7880-6466-11ea-8c63-42d2af608654.png">
<img width="1566" alt="Setup ‹ ecomm woo test — WordPress - Mozilla Firefox 2020-03-12 13-26-59" src="https://user-images.githubusercontent.com/22080/76564765-79bb9600-6466-11ea-8597-8bce053281d7.png">