### PR TITLE
Register TaxJar settings page.

### DIFF
--- a/includes/connect/taxjar-simplified-taxes-for-woocommerce.php
+++ b/includes/connect/taxjar-simplified-taxes-for-woocommerce.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Register the TaxJar Settings Page.
+ *
+ * @package WC_Calypso_Bridge
+ * @since 1.1.5
+ * @version 1.0.0
+ */
+
+wc_calypso_bridge_connect_page(
+	array(
+		'screen_id' => 'woocommerce_page_wc-settings-taxjarz-integration',
+		'menu'      => 'woocommerce',
+	)
+);

--- a/includes/connect/taxjar-simplified-taxes-for-woocommerce.php
+++ b/includes/connect/taxjar-simplified-taxes-for-woocommerce.php
@@ -9,7 +9,7 @@
 
 wc_calypso_bridge_connect_page(
 	array(
-		'screen_id' => 'woocommerce_page_wc-settings-taxjarz-integration',
+		'screen_id' => 'woocommerce_page_wc-settings-taxjar-integration',
 		'menu'      => 'woocommerce',
 	)
 );


### PR DESCRIPTION
Fixes #533 

This branch adds in the logic to register the TaxJar settings page so it will properly render the Woo nav in calypsoify mode.

__Before__
![taxjar-before](https://user-images.githubusercontent.com/22080/80653848-e77c4b00-8a2f-11ea-914b-ca61371e7cd6.png)

__After__
![taxjar-after](https://user-images.githubusercontent.com/22080/80653860-eea35900-8a2f-11ea-9bf1-402e6ed79efe.png)

__To Test__
- Install the TaxJar plugin from the wp.org repo if not already installed.
- On `master` of `wc-calypso-bridge` visit /wp-admin/admin.php?page=wc-settings&tab=taxjar-integration&calypsoify=1`, and verify a calypsoified version of the Woo Settings page is shown, but the sidebar is not showing the Woo Nav.
- Checkout this branch
- Refresh the page and verify it looks like the "after" screen shot above.