### PR TITLE
Add tracks filters and host prop.

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -140,6 +140,7 @@ class WC_Calypso_Bridge {
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-addons-screen.php';
 			include_once dirname( __FILE__ ) . '/includes/gutenberg.php';
 			require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-woocommerce-admin.php';
+			require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-tracks.php';
 
 			// Shared with store-on-wpcom.
 			include_once dirname( __FILE__ ) . '/store-on-wpcom/inc/wc-calypso-bridge-mailchimp-no-redirect.php';

--- a/includes/class-wc-calypso-bridge-tracks.php
+++ b/includes/class-wc-calypso-bridge-tracks.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Tracks modifications for the ecommerce plan.
+ *
+ * @package WC_Calypso_Bridge/Classes
+ * @since   1.1.6
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC Calypso Bridge Tracks
+ */
+class WC_Calypso_Bridge_Tracks {
+
+	/**
+	 * Class instance.
+	 *
+	 * @var WC_Calypso_Tracks instance
+	 */
+	protected static $instance = false;
+
+	/**
+	 * Get class instance
+	 */
+	public static function get_instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	private function __construct() {
+		add_filter( 'admin_footer', array( $this, 'add_tracks_js_filter' ) );
+		add_filter( 'woocommerce_tracks_event_properties', array( $this, 'add_tracks_php_filter' ), 10, 2 );
+	}
+
+	/**
+	 * Add filter to js-based tracks events. This will add the host prop on all admin page tracks.
+	 */
+	public function add_tracks_js_filter() {
+		?>
+		<!-- WooCommerce JS Tracks Filter -->
+		<script type="text/javascript">
+			woocommerceTracksFilterProperties = function( properties, eventName ) {
+				// let's add a host prop for all events.
+				properties.host = 'ecommplan';
+				return properties;
+			}
+	
+			if ( window.wp && window.wp.hooks && window.wp.hooks.addFilter ) {
+				window.wp.hooks.addFilter( "woocommerce_tracks_client_event_properties", "woocommerce", woocommerceTracksFilterProperties );
+			}
+		</script>
+		<?php
+	}
+
+	/**
+	 * Add filter to PHP-based tracks events.
+	 */
+	public function add_tracks_php_filter( $properties, $event_name ) {
+		$properties['host'] = 'ecommplan';
+		return $properties;
+	}
+}
+
+$wc_calypso_bridge_setup = WC_Calypso_Bridge_Tracks::get_instance();


### PR DESCRIPTION
Fixes #527 

This branch implements usage of two new filters that are shipping in WooCommerce 4.1 that allow us to add in "global" event properties to tracks. This branch adds in a `host` prop for both PHP and JS triggered events with a value of `ecommplan'

__To Test__
- **Install the latest version of WooCommerce 4.1** ( RC2 at the time of PR creation )
- Checkout this branch.
- Ensure your test site has opted in to usage tracking `wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`
- Visit the WooCommerce Admin dashboard page with the network tab of your browser console open. Filter the network requests for `t.gif` to see the track events. Verify the `host` prop is included with a value of `ecommplan`:

![test-js-tracks](https://user-images.githubusercontent.com/22080/80655798-6c696380-8a34-11ea-9e16-9982e86e7bc4.png)

Testing the PHP tracks are a bit trickier - I just added some error_log'ing to the `add_tracks_php_filter` in this PR, and viewed the php error log to verify it was being called properly:

![php-tracks](https://user-images.githubusercontent.com/22080/80655864-93c03080-8a34-11ea-853c-06274135359d.png)
