### PR TITLE
[4.1] Register Marketing Tab with ecom controller.

### DIFF
--- a/includes/connect/woocommerce-admin.php
+++ b/includes/connect/woocommerce-admin.php
@@ -22,3 +22,11 @@ wc_calypso_bridge_connect_page(
 		'submenu'   => 'wc-admin&path=/analytics/revenue',
 	)
 );
+
+wc_calypso_bridge_connect_page(
+	array(
+		'screen_id' => 'woocommerce-marketing',
+		'menu'      => 'wc-admin&path=/marketing',
+		'submenu'   => 'wc-admin&path=/marketing',
+	)
+);


### PR DESCRIPTION
In WooCommerce 4.1, the new "Marketing Tab" is being shipped. In order for this tab to work correctly with the Calypsoify/ecomm navigation, we need to register the new page, this branch does that.

__To Test__
- On `master` of calypso bridge, with 4.1 RC2 ( or final ) installed, visit `wp-admin/admin.php?page=wc-admin&calypsoify=1` and note that the Marketing tab is not shown in the sidebar.
- Apply this branch, refresh, and verify the item is shown. Click on it.
- Verify the Marketing page loads. Note that "recommended extensions" are not shown. This is because [we leverage the filter to not show marketplace suggestions on the ecomm plan](https://github.com/Automattic/wc-calypso-bridge/blob/master/includes/class-wc-calypso-bridge-hide-alerts.php#L42).

__Before__
<img width="1543" alt="marketing-tab-before" src="https://user-images.githubusercontent.com/22080/81093873-9220bd80-8eb7-11ea-8d6c-a964bc74e5dd.png">

__After__
<img width="1543" alt="Marketing ‹ WooCommerce ‹ ecomm woo test — WooCommerce 2020-05-05 09-28-17" src="https://user-images.githubusercontent.com/22080/81093921-a664ba80-8eb7-11ea-9887-bb2f2a537695.png">
