### PR TITLE
Prep for release of 1.1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "automattic/wc-calypso-bridge",
-	"version": "v1.1.5",
+	"version": "v1.1.6",
 	"autoload": {
 		"files": [
 			"wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 1.1.5
+Stable tag: 1.1.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,11 @@ This section describes how to install the plugin and get it working.
 1. Activate the plugin through the 'Plugins' screen in WordPress
 
 == Changelog ==
+
+* 1.1.6
+* Add support for global `host` Tracks prop
+* Register TaxJar settings page
+* Register new Marketing Tab for Woo 4.1
 
 * 1.1.5
 * Update Manage Site link to redirect to WordPress.com MySites root.

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 1.1.5
+ * Version: 1.1.6
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4


### PR DESCRIPTION
This build contains 3 fixes:

* Add support for global `host` Tracks prop
* Register TaxJar settings page
* Register new Marketing Tab for Woo 4.1

---
### Add support for global `host` Tracks prop
__To Test__
- **Install the latest version of WooCommerce 4.1** ( RC2 at the time of PR creation )
- Checkout this branch.
- Ensure your test site has opted in to usage tracking `wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`
- Visit the WooCommerce Admin dashboard page with the network tab of your browser console open. Filter the network requests for `t.gif` to see the track events. Verify the `host` prop is included with a value of `ecommplan`:

![test-js-tracks](https://user-images.githubusercontent.com/22080/80655798-6c696380-8a34-11ea-9e16-9982e86e7bc4.png)

Testing the PHP tracks are a bit trickier - I just added some error_log'ing to the `add_tracks_php_filter` in this PR, and viewed the php error log to verify it was being called properly:

![php-tracks](https://user-images.githubusercontent.com/22080/80655864-93c03080-8a34-11ea-853c-06274135359d.png)

---
### Register TaxJar settings page

__Before__
![taxjar-before](https://user-images.githubusercontent.com/22080/80653848-e77c4b00-8a2f-11ea-914b-ca61371e7cd6.png)

__After__
![taxjar-after](https://user-images.githubusercontent.com/22080/80653860-eea35900-8a2f-11ea-9bf1-402e6ed79efe.png)
__To Test__
- Install the TaxJar plugin from the wp.org repo if not already installed.
- On `master` of `wc-calypso-bridge` visit /wp-admin/admin.php?page=wc-settings&tab=taxjar-integration&calypsoify=1`, and verify a calypsoified version of the Woo Settings page is shown, but the sidebar is not showing the Woo Nav.
- Checkout this branch
- Refresh the page and verify it looks like the "after" screenshot above.

---
### Register new Marketing Tab for Woo 4.1
__To Test__
- On `master` of calypso bridge, with 4.1 RC2 ( or final ) installed, visit `wp-admin/admin.php?page=wc-admin&calypsoify=1` and note that the Marketing tab is not shown in the sidebar.
- Apply this branch, refresh, and verify the item is shown. Click on it.
- Verify the Marketing page loads. Note that "recommended extensions" are not shown. This is because [we leverage the filter to not show marketplace suggestions on the ecomm plan](https://github.com/Automattic/wc-calypso-bridge/blob/master/includes/class-wc-calypso-bridge-hide-alerts.php#L42).

__Before__
<img width="1543" alt="marketing-tab-before" src="https://user-images.githubusercontent.com/22080/81093873-9220bd80-8eb7-11ea-8d6c-a964bc74e5dd.png">

__After__
<img width="1543" alt="Marketing ‹ WooCommerce ‹ ecomm woo test — WooCommerce 2020-05-05 09-28-17" src="https://user-images.githubusercontent.com/22080/81093921-a664ba80-8eb7-11ea-9887-bb2f2a537695.png">