### PR TITLE
fix debug warnings in admin checklist setup

### DIFF
--- a/includes/class-wc-calypso-bridge-admin-setup-checklist.php
+++ b/includes/class-wc-calypso-bridge-admin-setup-checklist.php
@@ -466,7 +466,9 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 				'estimate'        => '2',
 				'link'            => 'admin.php?page=wc-settings&tab=checkout&section=klarna_payments',
 				'learn_more'      => 'https://woocommerce.com/products/klarna-payments/',
-				'condition'       => 'yes' === $klarna_payments_settings['enabled'],
+				'condition'       => ! empty( $klarna_payments_settings ) &&
+								! empty( $klarna_payments_settings['enabled'] ) &&
+								'yes' === $klarna_payments_settings['enabled'],
 				'extension'       => 'klarna-payments-for-woocommerce/klarna-payments-for-woocommerce.php',
 				'type'            => 'payment',
 			),
@@ -479,7 +481,9 @@ class WC_Calypso_Bridge_Admin_Setup_Checklist {
 				'estimate'        => '2',
 				'link'            => 'admin.php?page=wc-settings&tab=checkout&section=kco',
 				'learn_more'      => 'https://woocommerce.com/products/klarna-checkout/',
-				'condition'       => 'yes' === $kco_settings['enabled'],
+				'condition'       => ! empty( $kco_settings ) &&
+								! empty( $kco_settings['enabled'] ) &&
+								'yes' === $kco_settings['enabled'],
 				'extension'       => 'klarna-checkout-for-woocommerce/klarna-checkout-for-woocommerce.php',
 				'type'            => 'payment',
 			),


### PR DESCRIPTION
This PR fixes two warnings in the setup checklist for payment gateways that have not been configured.

### Testing

- Delete the `woocommerce_klarna_payments_settings` and `woocommerce_kco_settings` settings.
- I found these warnings were being logged on any WC calypsoified page. Browse a few of those pages to check that the warnings are eliminated.