### PR TITLE
Opt ecom sites into tracks by default

### DIFF
--- a/includes/class-wc-calypso-bridge-tracks.php
+++ b/includes/class-wc-calypso-bridge-tracks.php
@@ -37,6 +37,7 @@ class WC_Calypso_Bridge_Tracks {
 	private function __construct() {
 		add_filter( 'admin_footer', array( $this, 'add_tracks_js_filter' ) );
 		add_filter( 'woocommerce_tracks_event_properties', array( $this, 'add_tracks_php_filter' ), 10, 2 );
+		add_filter( 'woocommerce_get_sections_advanced', array( $this, 'hide_woocommerce_com_settings' ), 10, 1 );
 	}
 
 	/**
@@ -61,10 +62,23 @@ class WC_Calypso_Bridge_Tracks {
 
 	/**
 	 * Add filter to PHP-based tracks events.
+	 *
+	 * @param array  $properties Current event properties array.
+	 * @param string $event_name Nmae of the event.
 	 */
 	public function add_tracks_php_filter( $properties, $event_name ) {
 		$properties['host'] = 'ecommplan';
 		return $properties;
+	}
+
+	/**
+	 * Hide the display of the WooCommerce.com settings.
+	 *
+	 * @param array $settings Current settings array.
+	 */
+	public function hide_woocommerce_com_settings( $settings ) {
+		unset( $settings['woocommerce_com'] );
+		return $settings;
 	}
 }
 

--- a/includes/class-wc-calypso-bridge-tracks.php
+++ b/includes/class-wc-calypso-bridge-tracks.php
@@ -38,6 +38,11 @@ class WC_Calypso_Bridge_Tracks {
 		add_filter( 'admin_footer', array( $this, 'add_tracks_js_filter' ) );
 		add_filter( 'woocommerce_tracks_event_properties', array( $this, 'add_tracks_php_filter' ), 10, 2 );
 		add_filter( 'woocommerce_get_sections_advanced', array( $this, 'hide_woocommerce_com_settings' ), 10, 1 );
+
+		// Always opt-in to Tracks, WPCOM user tracks preferences take priority.
+		add_filter( 'woocommerce_apply_tracking', '__return_true' );
+		add_filter( 'woocommerce_apply_user_tracking', '__return_true' );
+		add_filter( 'pre_option_woocommerce_allow_tracking', array( $this, 'always_enable_tracking' ) );
 	}
 
 	/**
@@ -58,6 +63,13 @@ class WC_Calypso_Bridge_Tracks {
 			}
 		</script>
 		<?php
+	}
+
+	/**
+	 * Always make the tracks setting be yes. Users can opt via WordPress.com privacy settings.
+	 */
+	public function always_enable_tracking() {
+		return 'yes';
 	}
 
 	/**


### PR DESCRIPTION
Fixes #534 

This branch does two things:

- Sets `woocommerce_allow_tracking` to always be `yes` on ecom sites. 
- Hides the "WooCommerce.com" tab under Settings > Advanced since both of these settings are managed by wc-calypso-bridge.

Note the select styling bug too, already logged in #519

__Before__
![woocommerce-settings-before](https://user-images.githubusercontent.com/22080/81208873-923abf00-8f84-11ea-9a83-c69add7509c0.png)

__After__
![woocommerce-settings-after](https://user-images.githubusercontent.com/22080/81208887-9961cd00-8f84-11ea-8c7b-458cc4b53fe1.png)

__To Test__
- Visit the WooCommerce > Settings  > Advanced tab and note that the WooCommerce.com tab is no longer displayed.