### PR TITLE
Enable new Site Profile Wizard

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2781,3 +2781,7 @@ body.woocommerce-page .components-form-toggle.is-checked .components-form-toggle
 .woocommerce-profile-wizard__body .woocommerce-profile-wizard__container div .woocommerce-profile-wizard__benefit {
 	display: none;
 }
+/* Hides Theme Tabs ( All | Free | Paid ) since we only show installed themes */
+.woocommerce-profile-wizard__body .woocommerce-profile-wizard__themes-tab-panel .components-tab-panel__tabs {
+	display: none;
+}

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2776,3 +2776,8 @@ body.woocommerce-page .components-form-toggle.is-checked .components-form-toggle
 	border-color: var( --studio-pink-60 ) !important;
 	background: var( --studio-pink-60 ) !important;
 }
+
+/* Hide business extensions in Profiler > Business Details */
+.woocommerce-profile-wizard__body .woocommerce-profile-wizard__container div .woocommerce-profile-wizard__benefit {
+	display: none;
+}

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -39,6 +39,9 @@ class WC_Calypso_Bridge {
 		add_action( 'plugins_loaded', array( $this, 'initialize' ), 2 );
 	}
 
+	/**
+	 * Initialize only if WC is present.
+	 */
 	public function initialize() {
 		// if woo is not active, then bail.
 		if ( ! function_exists( 'WC' ) ) {

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -195,7 +195,7 @@ class WC_Calypso_Bridge {
 	 * Updates required UI elements for calypso bridge pages only.
 	 */
 	public function load_ui_elements() {
-		if ( is_wc_calypso_bridge_page() || ( isset( $_GET['page'] ) && 'wc-setup' === $_GET['page'] ) ) {
+		if ( is_wc_calypso_bridge_page() ) {
 			add_action( 'admin_print_styles', array( $this, 'enqueue_calypsoify_scripts' ), 11 );
 
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-breadcrumbs.php';

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -39,6 +39,9 @@ class WC_Calypso_Bridge_Setup {
 			return;
 		}
 
+		add_filter( 'default_option_woocommerce_onboarding_profile', array( $this, 'set_business_extensions_empty' ), 10, 1 );
+		add_filter( 'option_woocommerce_onboarding_profile', array( $this, 'set_business_extensions_empty' ), 10, 1 );
+
 		// If setup has yet to complete, make sure MailChimp doesn't redirect the flow.
 		$has_finshed_setup = (bool) WC_Calypso_Bridge_Admin_Setup_Checklist::is_checklist_done();
 		if ( ! $has_finshed_setup ) {
@@ -120,6 +123,25 @@ class WC_Calypso_Bridge_Setup {
 		return ! isset( $product_type['product'] );
 	}
 
+	/**
+	 * Store Profiler: Set business_extenstions to empty array.
+	 *
+	 * @param array $option Array of properties for OBW Profile.
+	 * @return array
+	 */
+	public function set_business_extensions_empty( $option ) {
+		// Ensuring the option is an array by default.
+		// By having an empty array of 'business_extensions' all options are toggled off by default in the OBW.
+		if ( ! is_array( $option ) ) {
+			$option = array(
+				'business_extensions' => array(),
+			);
+		} else {
+			$option['business_extensions'] = array();
+		}
+
+		return $option;
+	}
 }
 
 $wc_calypso_bridge_setup = WC_Calypso_Bridge_Setup::get_instance();

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -41,6 +41,7 @@ class WC_Calypso_Bridge_Setup {
 
 		add_filter( 'default_option_woocommerce_onboarding_profile', array( $this, 'set_business_extensions_empty' ), 10, 1 );
 		add_filter( 'option_woocommerce_onboarding_profile', array( $this, 'set_business_extensions_empty' ), 10, 1 );
+		add_filter( 'woocommerce_admin_onboarding_themes', array( $this, 'remove_non_installed_themes' ), 10, 1 );
 
 		// If setup has yet to complete, make sure MailChimp doesn't redirect the flow.
 		$has_finshed_setup = (bool) WC_Calypso_Bridge_Admin_Setup_Checklist::is_checklist_done();
@@ -141,6 +142,27 @@ class WC_Calypso_Bridge_Setup {
 		}
 
 		return $option;
+	}
+
+	/**
+	 * Remove non-installed ( paid ) themes from the Onboarding data source.
+	 *
+	 * @param array $themes Array of themes comprised of locally installed themes + marketplace themes.
+	 * @return array
+	 */
+	public function remove_non_installed_themes( $themes ) {
+		$local_themes = array_filter( $themes, array( $this, 'is_theme_installed' ) );
+		return $local_themes;
+	}
+
+	/**
+	 * Conditional method to determine if a theme is installed locally.
+	 *
+	 * @param array $theme Theme attributes.
+	 * @return boolean
+	 */
+	public function is_theme_installed( $theme ) {
+		return isset( $theme['is_installed'] ) && $theme['is_installed'];
 	}
 }
 

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -56,6 +56,8 @@ class WC_Calypso_Bridge_Setup {
 			add_action( 'admin_enqueue_scripts', array( $jetpack_calypsoify, 'enqueue' ), 20 );
 			add_action( 'admin_print_styles', array( $wc_calypso_bridge, 'enqueue_calypsoify_scripts' ), 11 );
 		}
+
+		add_filter( 'woocommerce_admin_onboarding_product_types', array( $this, 'remove_paid_extension_upsells' ), 10, 2 );
 	}
 
 	/**
@@ -94,6 +96,28 @@ class WC_Calypso_Bridge_Setup {
 		}
 
 		return $location;
+	}
+
+	/**
+	 * Site Profiler OBW: Remove Paid Extensions
+	 *
+	 * @param  array $product_types Array of product types.
+	 * @return array
+	 */
+	public function remove_paid_extension_upsells( $product_types ) {
+		// Product Types are fetched from https://woocommerce.com/wp-json/wccom-extensions/1.0/search?category=product-type .
+		$filtered_product_types = array_filter( $product_types, array( $this, 'filter_product_types' ) );
+		return $filtered_product_types;
+	}
+
+	/**
+	 * Site Profiler OBW: Filter method for product_types to remove items with product.
+	 *
+	 * @param  array $product_type Array of product type data.
+	 * @return boolean
+	 */
+	public function filter_product_types( $product_type ) {
+		return ! isset( $product_type['product'] );
 	}
 
 }

--- a/includes/class-wc-calypso-bridge-woocommerce-admin.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin.php
@@ -36,7 +36,6 @@ class WC_Calypso_Bridge_WooCommerce_Admin {
 	public function init() {
 		add_filter( 'wc_admin_get_feature_config', array( $this, 'maybe_remove_devdocs_menu_item' ) );
 		add_filter( 'pre_option_woocommerce_task_list_hidden', array( $this, 'disable_new_task_list' ) );
-		add_filter( 'pre_option_woocommerce_onboarding_opt_in', array( $this, 'disable_onboarding_opt_in' ) );
 	}
 
 	/**
@@ -59,12 +58,6 @@ class WC_Calypso_Bridge_WooCommerce_Admin {
 		return 'yes';
 	}
 
-	/**
-	 * Force the woocommerce_onboarding_opt_in option to always be no so the new checklist is never shown
-	 */
-	public function disable_onboarding_opt_in() {
-		return 'no';
-	}
 }
 
 WC_Calypso_Bridge_WooCommerce_Admin::factory()->init();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -75,6 +75,7 @@ class WC_Calypso_Bridge_Unit_Tests_Bootstrap {
 	 */
 	public function load_wc_calypso_bridge() {
 		require_once( $this->plugin_dir . '/class-wc-calypso-bridge.php' );
+		WC_Calypso_Bridge::instance()->initialize();
 	}
 
 	/**

--- a/tests/unit-tests/test-class-wc-calypso-bridge-setup.php
+++ b/tests/unit-tests/test-class-wc-calypso-bridge-setup.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Tests for WC_Calypso_Bridge_Setup
+ */
+
+class WC_Calypso_Bridge_Setup_Test extends WC_Calypso_Bridge_Test {
+
+	/**
+	 * Test getting a single note.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_remove_paid_extension_upsells() {
+		$wc_calypso_bridge_setup = WC_Calypso_Bridge_Setup::get_instance();
+		$product_types           = array(
+			'physical'      => array(
+				'label'       => 'Physical products',
+				'description' => 'Products you ship to customers.',
+			),
+			'subscriptions' => array(
+				'label'       => 'Physical products',
+				'description' => 'Products you ship to customers.',
+				'product'     => '12345',
+			),
+		);
+		$filtered_products       = $wc_calypso_bridge_setup->remove_paid_extension_upsells( $product_types );
+		$this->assertEquals( count( $filtered_products ), 1 );
+		$this->assertEquals( $filtered_products['physical']['label'], 'Physical products' );
+	}
+
+}


### PR DESCRIPTION
For #529 

I'm going to treat this as a feature branch for all the issues around enabling the new OBW, and starting off with the bare minimum of enabling the new OBW in the ecomm plan. 

__Before__
<img width="1200" alt="before-ecomm-obw" src="https://user-images.githubusercontent.com/22080/81844103-70e94e00-9503-11ea-830d-7706c9cf6eb8.png">

__After__
<img width="1200" alt="new-obw" src="https://user-images.githubusercontent.com/22080/81844128-79da1f80-9503-11ea-8545-104c86351b15.png">

__Testing__
- Visit `/wp-admin/admin.php?page=wc-admin&reset_profiler=1` to load the OBW, and force to reset the profiler to run again ( if you have already completed it on your test site ).
- Verify it looks like the above, the standard Woo Core OBW experience.
