### PR TITLE
Site Profiler: Remove paid extensions from product types.

### DIFF
--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -56,6 +56,8 @@ class WC_Calypso_Bridge_Setup {
 			add_action( 'admin_enqueue_scripts', array( $jetpack_calypsoify, 'enqueue' ), 20 );
 			add_action( 'admin_print_styles', array( $wc_calypso_bridge, 'enqueue_calypsoify_scripts' ), 11 );
 		}
+
+		add_filter( 'woocommerce_admin_onboarding_product_types', array( $this, 'remove_paid_extension_upsells' ), 10, 2 );
 	}
 
 	/**
@@ -94,6 +96,28 @@ class WC_Calypso_Bridge_Setup {
 		}
 
 		return $location;
+	}
+
+	/**
+	 * Site Profiler OBW: Remove Paid Extensions
+	 *
+	 * @param  array $product_types Array of product types.
+	 * @return array
+	 */
+	public function remove_paid_extension_upsells( $product_types ) {
+		// Product Types are fetched from https://woocommerce.com/wp-json/wccom-extensions/1.0/search?category=product-type .
+		$filtered_product_types = array_filter( $product_types, array( $this, 'filter_product_types' ) );
+		return $filtered_product_types;
+	}
+
+	/**
+	 * Site Profiler OBW: Filter method for product_types to remove items with product.
+	 *
+	 * @param  array $product_type Array of product type data.
+	 * @return boolean
+	 */
+	public function filter_product_types( $product_type ) {
+		return ! isset( $product_type['product'] );
 	}
 
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -75,6 +75,7 @@ class WC_Calypso_Bridge_Unit_Tests_Bootstrap {
 	 */
 	public function load_wc_calypso_bridge() {
 		require_once( $this->plugin_dir . '/class-wc-calypso-bridge.php' );
+		WC_Calypso_Bridge::instance()->initialize();
 	}
 
 	/**

--- a/tests/unit-tests/test-class-wc-calypso-bridge-setup.php
+++ b/tests/unit-tests/test-class-wc-calypso-bridge-setup.php
@@ -23,9 +23,9 @@ class WC_Calypso_Bridge_Setup_Test extends WC_Calypso_Bridge_Test {
 				'product'     => '12345',
 			),
 		);
-		$filtered_products       = $wc_calypso_bridge_setup::remove_paid_extension_upsells( $product_types );
+		$filtered_products       = $wc_calypso_bridge_setup->remove_paid_extension_upsells( $product_types );
 		$this->assertEquals( count( $filtered_products ), 1 );
-		$this->assertEquals( $filtered_products['physical']['label'], 'Physical Products' );
+		$this->assertEquals( $filtered_products['physical']['label'], 'Physical products' );
 	}
 
 }

--- a/tests/unit-tests/test-class-wc-calypso-bridge-setup.php
+++ b/tests/unit-tests/test-class-wc-calypso-bridge-setup.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Tests for WC_Calypso_Bridge_Setup
+ */
+
+class WC_Calypso_Bridge_Setup_Test extends WC_Calypso_Bridge_Test {
+
+	/**
+	 * Test getting a single note.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_remove_paid_extension_upsells() {
+		$wc_calypso_bridge_setup = WC_Calypso_Bridge_Setup::get_instance();
+		$product_types           = array(
+			'physical'      => array(
+				'label'       => 'Physical products',
+				'description' => 'Products you ship to customers.',
+			),
+			'subscriptions' => array(
+				'label'       => 'Physical products',
+				'description' => 'Products you ship to customers.',
+				'product'     => '12345',
+			),
+		);
+		$filtered_products       = $wc_calypso_bridge_setup::remove_paid_extension_upsells( $product_types );
+		$this->assertEquals( count( $filtered_products ), 1 );
+		$this->assertEquals( $filtered_products['physical']['label'], 'Physical Products' );
+	}
+
+}


### PR DESCRIPTION
For #529, branched from #545 

This branch removes the extension upsells in the Product Types section of the OBW:

__Before__
<img width="1200" alt="product-types-before" src="https://user-images.githubusercontent.com/22080/81854841-5b7c2000-9513-11ea-8e9b-970a01d5c5e2.png">

__After__
<img width="1200" alt="product-types-after" src="https://user-images.githubusercontent.com/22080/81854868-620a9780-9513-11ea-962e-e016827f8272.png">

__To Test__
- Visit /wp-admin/admin.php?page=wc-admin&reset_profiler=1 to load the OBW, and force to reset the profiler to run again ( if you have already completed it on your test site ).
- Proceed to the "Product Types" step and verify it looks like the after screenshot above where no paid extensions are shown
