### PR TITLE
Site Profiler: Remove business extensions

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2776,3 +2776,8 @@ body.woocommerce-page .components-form-toggle.is-checked .components-form-toggle
 	border-color: var( --studio-pink-60 ) !important;
 	background: var( --studio-pink-60 ) !important;
 }
+
+/* Hide business extensions in Profiler > Business Details */
+.woocommerce-profile-wizard__body .woocommerce-profile-wizard__container div .woocommerce-profile-wizard__benefit {
+	display: none;
+}

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -39,6 +39,8 @@ class WC_Calypso_Bridge_Setup {
 			return;
 		}
 
+		add_filter( 'default_option_woocommerce_onboarding_profile', array( $this, 'set_business_extensions_empty' ), 10, 1 );
+
 		// If setup has yet to complete, make sure MailChimp doesn't redirect the flow.
 		$has_finshed_setup = (bool) WC_Calypso_Bridge_Admin_Setup_Checklist::is_checklist_done();
 		if ( ! $has_finshed_setup ) {
@@ -120,6 +122,25 @@ class WC_Calypso_Bridge_Setup {
 		return ! isset( $product_type['product'] );
 	}
 
+	/**
+	 * Store Profiler: Set business_extenstions to empty array.
+	 *
+	 * @param array $option Array of properties for OBW Profile.
+	 * @return array
+	 */
+	public function set_business_extensions_empty( $option ) {
+		// Ensuring the option is an array by default.
+		// By having an empty array of 'business_extensions' all options are toggled off by default in the OBW.
+		if ( ! is_array( $option ) ) {
+			$option = array(
+				'business_extensions' => array(),
+			);
+		} else {
+			$option['business_extensions'] = array();
+		}
+
+		return $option;
+	}
 }
 
 $wc_calypso_bridge_setup = WC_Calypso_Bridge_Setup::get_instance();

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -40,6 +40,7 @@ class WC_Calypso_Bridge_Setup {
 		}
 
 		add_filter( 'default_option_woocommerce_onboarding_profile', array( $this, 'set_business_extensions_empty' ), 10, 1 );
+		add_filter( 'option_woocommerce_onboarding_profile', array( $this, 'set_business_extensions_empty' ), 10, 1 );
 
 		// If setup has yet to complete, make sure MailChimp doesn't redirect the flow.
 		$has_finshed_setup = (bool) WC_Calypso_Bridge_Admin_Setup_Checklist::is_checklist_done();


### PR DESCRIPTION
For #529, branched from #545

This branch seeks to set all of the Business Extension upsells to be toggled _off_ by default in the Site Profiler wizard, and not display them at all in the Business Details step. 

At first I didn't think we had a clean way to make this happen to toggle the extension installs off by default. But I attempted to filter the initial REST API request to `/wc-admin/onboarding-profile` via the [`woocommerce_rest_onboarding_prepare_profile`](https://github.com/woocommerce/woocommerce-admin/blob/5c8a9bddeb4d1bdcab83edc128b5343ded410901/src/API/OnboardingProfile.php#L195) filter, but that did not work out for me.

So instead I opted to go the route of massaging the option value itself for `woocommerce_onboarding_profile`. The component uses the values store in woocommerce_onboarding_profile.business_extensions to render the toggle of the extensions. If the value of `business_extensions` is an empty array, then all extensions will be toggled off in the UI... if the value of the option property is `null`, then the UI toggles the extensions to "on" by default.

Elegant solution? Unsure. Does it work? Appears so, and it doesn't require any changes to wc-admin :)

Longer-term it seems like we need this list of extensions to be powered via a json file so we can easily turn them on/off in the event of an extension getting pulled from the .org repo like we saw this week with Klikken, but for now this will work.

__Before__
<img width="1290" alt="business-details-before" src="https://user-images.githubusercontent.com/22080/81866391-f977e680-9523-11ea-9c74-230394b1901e.png">

__After__
<img width="1293" alt="business-extensions-after" src="https://user-images.githubusercontent.com/22080/81866403-ff6dc780-9523-11ea-9f43-c50a9fbdca0c.png">

__To Test__
- I'd encourage you to delete the `woocommerce_onboarding_profile` option to best match the typical state of the OBW for a user.
- Visit `/wp-admin/admin.php?page=wc-admin&reset_profiler=1` to load the OBW, and force to reset the profiler to run again ( if you have already completed it on your test site ).
- Proceed to the Business Details step, fill out the top form elements, and then note that the extensions are not show ( hidden via css ), but more importantly, there is no paragraph at the bottom saying that extensions will be installed. ✨ You could toggle the `display: none` off to see the individual extension cards, in their toggled off state if you would like as well.

