### PR TITLE
Site Profiler: Remove non installed themes

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2781,3 +2781,7 @@ body.woocommerce-page .components-form-toggle.is-checked .components-form-toggle
 .woocommerce-profile-wizard__body .woocommerce-profile-wizard__container div .woocommerce-profile-wizard__benefit {
 	display: none;
 }
+/* Hides Theme Tabs ( All | Free | Paid ) since we only show installed themes */
+.woocommerce-profile-wizard__body .woocommerce-profile-wizard__themes-tab-panel .components-tab-panel__tabs {
+	display: none;
+}

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -41,6 +41,7 @@ class WC_Calypso_Bridge_Setup {
 
 		add_filter( 'default_option_woocommerce_onboarding_profile', array( $this, 'set_business_extensions_empty' ), 10, 1 );
 		add_filter( 'option_woocommerce_onboarding_profile', array( $this, 'set_business_extensions_empty' ), 10, 1 );
+		add_filter( 'woocommerce_admin_onboarding_themes', array( $this, 'remove_non_installed_themes' ), 10, 1 );
 
 		// If setup has yet to complete, make sure MailChimp doesn't redirect the flow.
 		$has_finshed_setup = (bool) WC_Calypso_Bridge_Admin_Setup_Checklist::is_checklist_done();
@@ -141,6 +142,27 @@ class WC_Calypso_Bridge_Setup {
 		}
 
 		return $option;
+	}
+
+	/**
+	 * Remove non-installed ( paid ) themes from the Onboarding data source.
+	 *
+	 * @param array $themes Array of themes comprised of locally installed themes + marketplace themes.
+	 * @return array
+	 */
+	public function remove_non_installed_themes( $themes ) {
+		$local_themes = array_filter( $themes, array( $this, 'is_theme_installed' ) );
+		return $local_themes;
+	}
+
+	/**
+	 * Conditional method to determine if a theme is installed locally.
+	 *
+	 * @param array $theme Theme attributes.
+	 * @return boolean
+	 */
+	public function is_theme_installed( $theme ) {
+		return isset( $theme['is_installed'] ) && $theme['is_installed'];
 	}
 }
 


### PR DESCRIPTION
For #529, branched from #545

This branch utilizes the `woocommerce_admin_onboarding_themes` to only show themes that are installed locally during the profile wizard. In the context of the ecommerce plan, this will show all the default Storefront + child themes that get installed when the site is provisioned.

__Before__
<img width="1292" alt="themes-before" src="https://user-images.githubusercontent.com/22080/81869374-cbe16c00-9528-11ea-93e3-5e154768d358.png">

__After__
<img width="1292" alt="themes-after" src="https://user-images.githubusercontent.com/22080/81869412-dbf94b80-9528-11ea-9844-c16a4be82300.png">

__To Test__
- I'd encourage you to delete the woocommerce_onboarding_profile option to best match the typical state of the OBW for a user.
- Visit /wp-admin/admin.php?page=wc-admin&reset_profiler=1 to load the OBW, and force to reset the profiler to run again ( if you have already completed it on your test site ).
- Proceed to the Theme step. Note that the tab panel for All | Free | Paid is not shown, and your locally installed themes should be the only ones that appear as options to select ( and theme upload ).