### PR TITLE
add WC Admin feature filters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,58 +1,53 @@
 {
-	"name": "automattic/wc-calypso-bridge",
-	"version": "v1.1.6",
-	"autoload": {
-		"files": [
-			"wc-calypso-bridge.php"
-		]
-	},
-	"repositories": [
-		{
-			"type": "package",
-			"package": {
-				"name": "automattic/gridicons",
-				"version": "3.1.1",
-				"source": {
-					"url": "https://github.com/Automattic/gridicons",
-					"type": "git",
-					"reference": "master"
-				}
-			}
-		}
-	],
-	"require": {
-		"composer/installers": "~1.2"
-	},
-	"require-dev": {
-		"phpunit/phpunit": "7.5.20",
-		"squizlabs/php_codesniffer": "*",
-		"wp-coding-standards/wpcs": "1.1.0",
-		"woocommerce/woocommerce-sniffs": "*",
-		"wimg/php-compatibility": "9.0.0",
-		"dealerdirect/phpcodesniffer-composer-installer": "0.4.4",
-		"bjornjohansen/wp-pre-commit-hook": "^0.2.2"
-	},
-	"config": {
-		"platform": {
-			"php": "7.1"
-		}
-	},
-	"scripts": {
-		"test": [
-			"phpunit"
-		],
-		"phpcs": [
-			"phpcs -s -p"
-		],
-		"phpcbf": [
-			"phpcbf -p"
-		]
-	},
-	"extra": {
-		"scripts-description": {
-			"test": "Run unit tests",
-			"phpcs": "Analyze code against the WordPress coding standards with PHP_CodeSniffer",
-			"phpcbf": "Fix coding standards warnings/errors automatically with PHP Code Beautifier"
-		}
-	}
+  "name": "automattic/wc-calypso-bridge",
+  "version": "v1.2.0",
+  "autoload": {
+    "files": [
+      "wc-calypso-bridge.php"
+    ]
+  },
+  "repositories": [
+    {
+      "type": "package",
+      "package": {
+        "name": "automattic/gridicons",
+        "version": "3.1.1",
+        "source": {
+          "url": "https://github.com/Automattic/gridicons",
+          "type": "git",
+          "reference": "master"
+        }
+      }
+    }
+  ],
+  "require": {
+    "composer/installers": "~1.2"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "7.5.20",
+    "squizlabs/php_codesniffer": "*",
+    "wp-coding-standards/wpcs": "1.1.0",
+    "woocommerce/woocommerce-sniffs": "*",
+    "wimg/php-compatibility": "9.0.0",
+    "dealerdirect/phpcodesniffer-composer-installer": "0.4.4",
+    "bjornjohansen/wp-pre-commit-hook": "^0.2.2"
+  },
+  "scripts": {
+    "test": [
+      "phpunit"
+    ],
+    "phpcs": [
+      "phpcs -s -p"
+    ],
+    "phpcbf": [
+      "phpcbf -p"
+    ]
+  },
+  "extra": {
+    "scripts-description": {
+      "test": "Run unit tests",
+      "phpcs": "Analyze code against the WordPress coding standards with PHP_CodeSniffer",
+      "phpcbf": "Fix coding standards warnings/errors automatically with PHP Code Beautifier"
+    }
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,11 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "0.4.4",
 		"bjornjohansen/wp-pre-commit-hook": "^0.2.2"
 	},
+	"config": {
+		"platform": {
+			"php": "7.1"
+		}
+	},
 	"scripts": {
 		"test": [
 			"phpunit"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "556acc76120d6714cde3ab809c1c0c2b",
+    "content-hash": "f5b7f80d714ec54ed8d30089bb70d3c8",
     "packages": [
         {
             "name": "composer/installers",
@@ -501,38 +501,41 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.1.0",
+            "version": "4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e"
+                "reference": "da3fd972d6bafd628114f7e7e036f45944b62e9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
-                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/da3fd972d6bafd628114f7e7e036f45944b62e9c",
+                "reference": "da3fd972d6bafd628114f7e7e036f45944b62e9c",
                 "shasum": ""
             },
             "require": {
-                "ext-filter": "^7.1",
-                "php": "^7.2",
-                "phpdocumentor/reflection-common": "^2.0",
-                "phpdocumentor/type-resolver": "^1.0",
-                "webmozart/assert": "^1"
+                "php": "^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0 || ^2.0.0",
+                "phpdocumentor/type-resolver": "~0.4 || ^1.0.0",
+                "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "doctrine/instantiator": "^1",
-                "mockery/mockery": "^1"
+                "doctrine/instantiator": "^1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpdocumentor/type-resolver": "0.4.*",
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.x-dev"
+                    "dev-master": "4.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -543,36 +546,33 @@
                 {
                     "name": "Mike van Riel",
                     "email": "me@mikevanriel.com"
-                },
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "account@ijaap.nl"
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2020-02-22T12:28:44+00:00"
+            "time": "2019-12-28T18:55:12+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.1.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95"
+                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/7462d5f123dfc080dfdf26897032a6513644fc95",
-                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
+                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2",
+                "php": "^7.1",
                 "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "ext-tokenizer": "^7.2",
-                "mockery/mockery": "~1"
+                "ext-tokenizer": "^7.1",
+                "mockery/mockery": "~1",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
@@ -596,7 +596,7 @@
                 }
             ],
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "time": "2020-02-18T18:59:58+00:00"
+            "time": "2019-08-22T18:11:29+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -1616,16 +1616,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.15.0",
+            "version": "v1.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14"
+                "reference": "e94c8b1bbe2bc77507a1056cdb06451c75b427f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
-                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e94c8b1bbe2bc77507a1056cdb06451c75b427f9",
+                "reference": "e94c8b1bbe2bc77507a1056cdb06451c75b427f9",
                 "shasum": ""
             },
             "require": {
@@ -1637,7 +1637,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.15-dev"
+                    "dev-master": "1.17-dev"
                 }
             },
             "autoload": {
@@ -1670,7 +1670,7 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2020-02-27T09:26:54+00:00"
+            "time": "2020-05-12T16:14:59+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -1816,6 +1816,7 @@
                 "phpcs",
                 "standards"
             ],
+            "abandoned": "phpcompatibility/php-compatibility",
             "time": "2018-10-07T17:38:02+00:00"
         },
         {
@@ -1864,12 +1865,12 @@
             "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
                 "reference": "46d42828ce7355d8b3776e3171f2bda892d179b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/46d42828ce7355d8b3776e3171f2bda892d179b4",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/46d42828ce7355d8b3776e3171f2bda892d179b4",
                 "reference": "46d42828ce7355d8b3776e3171f2bda892d179b4",
                 "shasum": ""
             },
@@ -1909,5 +1910,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.1"
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f5b7f80d714ec54ed8d30089bb70d3c8",
+    "content-hash": "556acc76120d6714cde3ab809c1c0c2b",
     "packages": [
         {
             "name": "composer/installers",
@@ -501,41 +501,38 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.4",
+            "version": "5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "da3fd972d6bafd628114f7e7e036f45944b62e9c"
+                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/da3fd972d6bafd628114f7e7e036f45944b62e9c",
-                "reference": "da3fd972d6bafd628114f7e7e036f45944b62e9c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
+                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0.0 || ^2.0.0",
-                "phpdocumentor/type-resolver": "~0.4 || ^1.0.0",
-                "webmozart/assert": "^1.0"
+                "ext-filter": "^7.1",
+                "php": "^7.2",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpdocumentor/type-resolver": "^1.0",
+                "webmozart/assert": "^1"
             },
             "require-dev": {
-                "doctrine/instantiator": "^1.0.5",
-                "mockery/mockery": "^1.0",
-                "phpdocumentor/type-resolver": "0.4.*",
-                "phpunit/phpunit": "^6.4"
+                "doctrine/instantiator": "^1",
+                "mockery/mockery": "^1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.x-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -546,33 +543,36 @@
                 {
                     "name": "Mike van Riel",
                     "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "account@ijaap.nl"
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2019-12-28T18:55:12+00:00"
+            "time": "2020-02-22T12:28:44+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.0.1",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9"
+                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
-                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/7462d5f123dfc080dfdf26897032a6513644fc95",
+                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1",
+                "php": "^7.2",
                 "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "ext-tokenizer": "^7.1",
-                "mockery/mockery": "~1",
-                "phpunit/phpunit": "^7.0"
+                "ext-tokenizer": "^7.2",
+                "mockery/mockery": "~1"
             },
             "type": "library",
             "extra": {
@@ -596,7 +596,7 @@
                 }
             ],
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "time": "2019-08-22T18:11:29+00:00"
+            "time": "2020-02-18T18:59:58+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -1616,16 +1616,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.17.0",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "e94c8b1bbe2bc77507a1056cdb06451c75b427f9"
+                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e94c8b1bbe2bc77507a1056cdb06451c75b427f9",
-                "reference": "e94c8b1bbe2bc77507a1056cdb06451c75b427f9",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
+                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
                 "shasum": ""
             },
             "require": {
@@ -1637,7 +1637,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.17-dev"
+                    "dev-master": "1.15-dev"
                 }
             },
             "autoload": {
@@ -1670,7 +1670,7 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2020-05-12T16:14:59+00:00"
+            "time": "2020-02-27T09:26:54+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -1816,7 +1816,6 @@
                 "phpcs",
                 "standards"
             ],
-            "abandoned": "phpcompatibility/php-compatibility",
             "time": "2018-10-07T17:38:02+00:00"
         },
         {
@@ -1865,12 +1864,12 @@
             "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
                 "reference": "46d42828ce7355d8b3776e3171f2bda892d179b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/46d42828ce7355d8b3776e3171f2bda892d179b4",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/46d42828ce7355d8b3776e3171f2bda892d179b4",
                 "reference": "46d42828ce7355d8b3776e3171f2bda892d179b4",
                 "shasum": ""
             },
@@ -1910,8 +1909,5 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": [],
-    "platform-overrides": {
-        "php": "7.1"
-    }
+    "platform-dev": []
 }

--- a/includes/class-wc-ecomm-bridge.php
+++ b/includes/class-wc-ecomm-bridge.php
@@ -37,7 +37,6 @@ class WC_EComm_Bridge {
 		}
 
 		add_filter( 'woocommerce_admin_features_to_enable_disable', array( $this, 'filter_wc_admin_enabled_features' ) );
-		add_filter( 'woocommerce_admin_features', array( $this, 'filter_wc_admin_enabled_features' ) );
 	}
 
 	/**
@@ -49,16 +48,6 @@ class WC_EComm_Bridge {
 	public function filter_wc_admin_enabled_features( $features ) {
 		$features['homepage']  = false;
 
-		return $features;
-	}
-
-	/**
-	 * Set feature list for WooCommerce Admin backend at run time.
-	 *
-	 * @param array $features List of feature names.
-	 * @return array
-	 */
-	public function filter_wc_admin_features( $features ) {
 		return $features;
 	}
 

--- a/includes/class-wc-ecomm-bridge.php
+++ b/includes/class-wc-ecomm-bridge.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Adds the functionality needed to bridge WooCommerce.
+ *
+ * @package WC_Calypso_Bridge/Classes
+ * @since   1.1.7
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+class WC_EComm_Bridge {
+
+	/**
+	 * Class Instance.
+	 *
+	 * @var WC_EComm_Bridge instance
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'plugins_loaded', array( $this, 'initialize' ), 2 );
+	}
+
+	/**
+	 * Add hooks and filters if WooCommerce is active.
+	 */
+	public function initialize() {
+		if ( ! function_exists( 'WC' ) ) {
+			return;
+		}
+
+		add_filter( 'woocommerce_admin_features_to_enable_disable', array( $this, 'filter_wc_admin_enabled_features' ) );
+		add_filter( 'woocommerce_admin_features', array( $this, 'filter_wc_admin_enabled_features' ) );
+	}
+
+	/**
+	 * Set feature flags for WooCommerce Admin front end at run time.
+	 *
+	 * @param array $features List of features 'feature' => bool indicating whether the feature is enabled.
+	 * @return array
+	 */
+	public function filter_wc_admin_enabled_features( $features ) {
+		$features[ 'homepage' ]  = false;
+
+		return $features;
+	}
+
+	/**
+	 * Set feature list for WooCommerce Admin backend at run time.
+	 *
+	 * @param array $features List of feature names.
+	 * @return array
+	 */
+	public function filter_wc_admin_features( $features ) {
+		return $features;
+	}
+
+	/**
+	 * Get class instance
+	 */
+	public static function get_instance() {
+		if ( ! static::$instance ) {
+			static::$instance = new static();
+		}
+		return static::$instance;
+	}
+}
+
+WC_EComm_Bridge::get_instance();

--- a/includes/class-wc-ecomm-bridge.php
+++ b/includes/class-wc-ecomm-bridge.php
@@ -9,6 +9,9 @@
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * WC EComm Bridge
+ */
 class WC_EComm_Bridge {
 
 	/**
@@ -44,7 +47,7 @@ class WC_EComm_Bridge {
 	 * @return array
 	 */
 	public function filter_wc_admin_enabled_features( $features ) {
-		$features[ 'homepage' ]  = false;
+		$features['homepage']  = false;
 
 		return $features;
 	}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,7 +12,7 @@
 
 	<!-- Configs -->
 	<config name="minimum_supported_wp_version" value="4.7" />
-	<config name="testVersion" value="5.2-"/>
+	<config name="testVersion" value="7.0-"/>
 
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core" />

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -70,3 +70,5 @@ add_action( 'plugins_loaded', 'wc_calypso_bridge_init' );
 require_once dirname( __FILE__ ) . '/class-wc-calypso-bridge.php';
 
 require_once dirname( __FILE__ ) . '/class-wc-calypso-bridge-frontend.php';
+
+require_once __DIR__ . '/includes/class-wc-ecomm-bridge.php';


### PR DESCRIPTION
Closes #532 

This is a companion PR to https://github.com/woocommerce/woocommerce-admin/pull/4418 which will allow enabling features hidden behind feature flags in the ecomm plan. This PR explicitly turns off the home page. Once this is merged, features will be able to be flipped using the two filters in the PR.

I added this as a new class to start working toward the eventual removal of Calypsoify. Code going in this class would be continue to be used on the ecomm plan.

### Testing

- Checkout https://github.com/woocommerce/woocommerce-admin/pull/4418 if not merged
- Enable WP_DEBUG (which normally turns on the home page)
- Store page should show the dashboard
- Edit this PR to make the same changes as outlined in 4418
- You should see the same results as outlined in that PR