### PR TITLE
Add connect logic for WooCommerce Payments.

### DIFF
--- a/includes/connect/woocommerce-payments.php
+++ b/includes/connect/woocommerce-payments.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Register the WooCommerce Payments top level pages with the Calypso bridge.
+ *
+ * @package WC_Calypso_Bridge
+ * @since 1.0.18
+ * @version 1.0.0
+ */
+
+wc_calypso_bridge_connect_page(
+	array(
+		'screen_id' => 'woocommerce-payments',
+		'menu'      => 'wc-admin&path=/payments/deposits',
+		'submenu'   => 'wc-admin&path=/payments/deposits',
+	)
+);
+
+wc_calypso_bridge_connect_page(
+	array(
+		'screen_id' => 'woocommerce-payments-transactions',
+		'menu'      => 'wc-admin&path=/payments/deposits',
+		'submenu'   => 'wc-admin&path=/payments/transactions',
+	)
+);
+
+wc_calypso_bridge_connect_page(
+	array(
+		'screen_id' => 'woocommerce-payments-connect',
+		'menu'      => 'wc-admin&path=/payments/connect',
+		'submenu'   => 'wc-admin&path=/payments/connect',
+	)
+);


### PR DESCRIPTION
This branch adds in calypsoify support for WooCommerce Payments:

<img width="1337" alt="Connect ‹ Payments ‹ i 3 brobee — WooCommerce 2020-06-03 16-38-36" src="https://user-images.githubusercontent.com/22080/83700628-2d42ab00-a5bc-11ea-9086-cd144bd95151.png">

<img width="1331" alt="Deposits ‹ Payments ‹ i 3 brobee — WooCommerce 2020-06-03 16-46-41" src="https://user-images.githubusercontent.com/22080/83700632-329ff580-a5bc-11ea-95b5-b2a05badbaf0.png">

__To Test__
Fully testing this out requires either connecting Jetpack, getting a local development version of wc-pay up and running. If either of those is too much work, I do have a test site running the code that I'd be happy to set you up with access to.

- Load Calypsoify on a site with WooCommerce Payments installed and Jetpack connected
- Visit `/wp-admin/admin.php?page=wc-admin&calypsoify=1` and verify you see Payments in the sidebar like seen above.
