### PR TITLE
Prep for 1.1.7 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "automattic/wc-calypso-bridge",
-	"version": "v1.1.6",
+	"version": "v1.1.7",
 	"autoload": {
 		"files": [
 			"wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,16 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+* 1.1.7
+* Add connect logic for WooCommerce Payments
+* Site Profiler: Remove non installed themes
+* Site Profiler: Remove business extensions
+* Enable new Site Profile Wizard
+* Tweak address 2 toggle margins
+* Add Travis configuration
+* Opt ecom sites into tracks by default
+* Fix debug warnings in admin checklist setup
+
 * 1.1.6
 * Add support for global `host` Tracks prop
 * Register TaxJar settings page

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 1.1.6
+ * Version: 1.1.7
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4


### PR DESCRIPTION
This build contains 9 fixes:

- Add connect logic for WooCommerce Payments
- Site Profiler: Remove non installed themes
- Site Profiler: Remove business extensions
- Enable new Site Profile Wizard
- Tweak address 2 toggle margins
- Add Travis configuration
- Opt ecom sites into tracks by default
- Fix debug warnings in admin checklist setup

## Testing

### Add connect logic for WooCommerce Payments

- Load Calypsoify on a site with WooCommerce Payments installed and Jetpack connected
- Visit /wp-admin/admin.php?page=wc-admin&calypsoify=1 and verify you see Payments in the sidebar

![image](https://user-images.githubusercontent.com/224531/83825529-eddfa000-a71c-11ea-9283-4a674d9310d8.png)

### Site Profiler: Remove non installed themes

- I'd encourage you to delete the woocommerce_onboarding_profile option to best match the typical state of the OBW for a user.
- Visit /wp-admin/admin.php?page=wc-admin&reset_profiler=1 to load the OBW, and force to reset the profiler to run again ( if you have already completed it on your test site ).
- Proceed to the Theme step. Note that the tab panel for All | Free | Paid is not shown, and your locally installed themes should be the only ones that appear as options to select ( and theme upload ).

### Site Profiler: Remove business extensions

- I'd encourage you to delete the woocommerce_onboarding_profile option to best match the typical state of the OBW for a user.
- Visit /wp-admin/admin.php?page=wc-admin&reset_profiler=1 to load the OBW, and force to reset the profiler to run again ( if you have already completed it on your test site ).
- Proceed to the Business Details step, fill out the top form elements, and then note that the extensions are not show ( hidden via css ), but more importantly, there is no paragraph at the bottom saying that extensions will be installed. ✨ You could toggle the display: none off to see the individual extension cards, in their toggled off state if you would like as well.

### Enable new Site Profile Wizard

- Visit /wp-admin/admin.php?page=wc-admin&reset_profiler=1 to load the OBW, and force to reset the profiler to run again ( if you have already completed it on your test site ).
- Verify it looks like the below, the standard Woo Core OBW experience.

![image](https://user-images.githubusercontent.com/224531/83825703-7a8a5e00-a71d-11ea-8e96-d8a43260ee69.png)

### Opt ecom sites into tracks by default

- Visit the WooCommerce > Settings > Advanced tab and note that the WooCommerce.com tab is no longer displayed.

![image](https://user-images.githubusercontent.com/224531/83825821-c76e3480-a71d-11ea-81b0-84476b192e65.png)

### Fix debug warnings in admin checklist setup

- Delete the woocommerce_klarna_payments_settings and woocommerce_kco_settings settings.
- I found these warnings were being logged on any WC calypsoified page. Browse a few of those pages to check that the warnings are eliminated.