### PR TITLE
Make host prop conditional in tracks.

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -33,6 +33,13 @@ class WC_Calypso_Bridge {
 	protected static $instance = null;
 
 	/**
+	 * Plugin host attribute for tracks.
+	 *
+	 * @var string
+	 */
+	public static $tracks_host_value = 'ecommplan-wp-admin';
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -132,7 +139,12 @@ class WC_Calypso_Bridge {
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-admin-setup-checklist.php';
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-setup.php';
 
+		// We want to adjust tracks settings regardless of if in Calypsoify UI or not.
+		require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-tracks.php';
+
 		if ( $this->dependencies_satisfied() ) {
+			// Set the host prop specific to calypsoified views for tracks.
+			self::$tracks_host_value = 'ecommplan';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-helper-functions.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-hide-alerts.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-themes-setup.php';
@@ -143,7 +155,6 @@ class WC_Calypso_Bridge {
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-addons-screen.php';
 			include_once dirname( __FILE__ ) . '/includes/gutenberg.php';
 			require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-woocommerce-admin.php';
-			require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-tracks.php';
 
 			// Shared with store-on-wpcom.
 			include_once dirname( __FILE__ ) . '/store-on-wpcom/inc/wc-calypso-bridge-mailchimp-no-redirect.php';

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -33,13 +33,6 @@ class WC_Calypso_Bridge {
 	protected static $instance = null;
 
 	/**
-	 * Plugin host attribute for tracks.
-	 *
-	 * @var string
-	 */
-	public static $tracks_host_value = 'ecommplan-wp-admin';
-
-	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -139,12 +132,7 @@ class WC_Calypso_Bridge {
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-admin-setup-checklist.php';
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-setup.php';
 
-		// We want to adjust tracks settings regardless of if in Calypsoify UI or not.
-		require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-tracks.php';
-
 		if ( $this->dependencies_satisfied() ) {
-			// Set the host prop specific to calypsoified views for tracks.
-			self::$tracks_host_value = 'ecommplan';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-helper-functions.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-hide-alerts.php';
 			include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-themes-setup.php';

--- a/includes/class-wc-calypso-bridge-tracks.php
+++ b/includes/class-wc-calypso-bridge-tracks.php
@@ -122,5 +122,3 @@ class WC_Calypso_Bridge_Tracks {
 		return $settings;
 	}
 }
-
-$wc_calypso_bridge_setup = WC_Calypso_Bridge_Tracks::get_instance();

--- a/includes/class-wc-calypso-bridge-tracks.php
+++ b/includes/class-wc-calypso-bridge-tracks.php
@@ -22,6 +22,14 @@ class WC_Calypso_Bridge_Tracks {
 	protected static $instance = false;
 
 	/**
+	 * Plugin host attribute for tracks.
+	 *
+	 * @var string
+	 */
+	public static $tracks_host_value = '';
+
+
+	/**
 	 * Get class instance
 	 */
 	public static function get_instance() {
@@ -35,6 +43,7 @@ class WC_Calypso_Bridge_Tracks {
 	 * Constructor.
 	 */
 	private function __construct() {
+		$this->set_tracks_host_value();
 		add_filter( 'admin_footer', array( $this, 'add_tracks_js_filter' ) );
 		add_filter( 'woocommerce_tracks_event_properties', array( $this, 'add_tracks_php_filter' ), 10, 2 );
 		add_filter( 'woocommerce_get_sections_advanced', array( $this, 'hide_woocommerce_com_settings' ), 10, 1 );
@@ -46,6 +55,26 @@ class WC_Calypso_Bridge_Tracks {
 	}
 
 	/**
+	 * Set's the value for the tracks host property.
+	 */
+	public function set_tracks_host_value() {
+		// Default value assumes business plan, inside wp-admin.
+		$host_value = 'bizplan-wp-admin';
+
+		// If an ecomm plan site, update host value.
+		if ( wc_calypso_bridge_is_ecommerce_plan() ) {
+			if ( 1 === (int) get_user_meta( get_current_user_id(), 'calypsoify', true ) ) {
+				// Calypsoify UI.
+				$host_value = 'ecommplan';
+			} else {
+				// wp-admin view.
+				$host_value = 'ecommplan-wp-admin';
+			}
+		}
+		self::$tracks_host_value = $host_value;
+	}
+
+	/**
 	 * Add filter to js-based tracks events. This will add the host prop on all admin page tracks.
 	 */
 	public function add_tracks_js_filter() {
@@ -54,7 +83,7 @@ class WC_Calypso_Bridge_Tracks {
 		<script type="text/javascript">
 			woocommerceTracksFilterProperties = function( properties, eventName ) {
 				// let's add a host prop for all events.
-				properties.host = '<?php echo esc_attr( WC_Calypso_Bridge::$tracks_host_value ); ?>';
+				properties.host = '<?php echo esc_attr( self::$tracks_host_value ); ?>';
 				return properties;
 			}
 	
@@ -79,7 +108,7 @@ class WC_Calypso_Bridge_Tracks {
 	 * @param string $event_name Nmae of the event.
 	 */
 	public function add_tracks_php_filter( $properties, $event_name ) {
-		$properties['host'] = WC_Calypso_Bridge::$tracks_host_value;
+		$properties['host'] = self::$tracks_host_value;
 		return $properties;
 	}
 

--- a/includes/class-wc-calypso-bridge-tracks.php
+++ b/includes/class-wc-calypso-bridge-tracks.php
@@ -54,7 +54,7 @@ class WC_Calypso_Bridge_Tracks {
 		<script type="text/javascript">
 			woocommerceTracksFilterProperties = function( properties, eventName ) {
 				// let's add a host prop for all events.
-				properties.host = 'ecommplan';
+				properties.host = '<?php echo esc_attr( WC_Calypso_Bridge::$tracks_host_value ); ?>';
 				return properties;
 			}
 	
@@ -79,7 +79,7 @@ class WC_Calypso_Bridge_Tracks {
 	 * @param string $event_name Nmae of the event.
 	 */
 	public function add_tracks_php_filter( $properties, $event_name ) {
-		$properties['host'] = 'ecommplan';
+		$properties['host'] = WC_Calypso_Bridge::$tracks_host_value;
 		return $properties;
 	}
 

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -50,6 +50,9 @@ function wc_calypso_bridge_is_ecommerce_plan() {
 	return false;
 }
 
+// We want to adjust tracks settings for business, ecomm, in calypsoified and wp-admin views.
+require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-tracks.php';
+
 if ( ! wc_calypso_bridge_is_ecommerce_plan() ) {
 	include_once dirname( __FILE__ ) . '/store-on-wpcom/class-wc-calypso-bridge.php';
 	return;

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -52,6 +52,7 @@ function wc_calypso_bridge_is_ecommerce_plan() {
 
 // We want to adjust tracks settings for business, ecomm, in calypsoified and wp-admin views.
 require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-tracks.php';
+add_action( 'init', array( 'WC_Calypso_Bridge_Tracks', 'get_instance' ) );
 
 if ( ! wc_calypso_bridge_is_ecommerce_plan() ) {
 	include_once dirname( __FILE__ ) . '/store-on-wpcom/class-wc-calypso-bridge.php';


### PR DESCRIPTION
Fixes #542

Follow-up to #536

Currently, we only apply the `host` global tracks prop on calypsoified views on the ecommerce plan. This PR allows that `host` attribute to be added to *all* tracks on the ecommerce plan, **and** business plan woo sites regardless of wether the UI is calypsoified or not.

## Tracks Host Prop
The value of the `host` prop is set as following:

| Plan | `wp-admin` | `calypsoify` |
| ----- | ----------- | ------------- |
Business | `bizplan-wp-admin` | NA |
eComm | `ecommplan-wp-admin` | `ecommplan` | 

## To Test eComm Plan
These steps assume you already have the site [activated for calypsoify].

Just like in #536, testing out the PHP tracks events is made much easier by adding some `error_log` statements to the [add_tracks_filter()](https://github.com/Automattic/wc-calypso-bridge/compare/add/host-to-non-calypsoify?expand=1#diff-d7cab93a89457a8bba491f0285021c99L81) method - so something like:

```
public function add_tracks_php_filter( $properties, $event_name ) {
    $properties['host'] = self::$tracks_host_value;
    error_log( 'recording event: ' . $event_name );
    error_log( print_r( $properties, true ) );
    return $properties;
}
```

With that in place, then test the following:

- I find the coupons page is easy since a track is recorded in both JS and PHP, so open up coupons in a *non calypsoified* view: `/wp-admin/edit.php?post_type=shop_coupon`
-  Inspect the network tab on that page load, and filter by `t.gif` - view the request query string and verify the `host` prop is `ecommplan-wp-admin`:

<img width="707" alt="wp-admin-js-track" src="https://user-images.githubusercontent.com/22080/84942970-87ea0580-b098-11ea-82b7-8251175212d6.png">

- Also inspect your php error log, and if you used the example code above, you should see something like:

<img width="477" alt="coupon-view-wp-admin" src="https://user-images.githubusercontent.com/22080/84943018-97694e80-b098-11ea-93ce-0b585f8ffe9c.png">

- Now adjust the url of the page to force the calypsoify ui: `/wp-admin/edit.php?post_type=shop_coupon&calypsoify=1`
- Inspect the same t.gif request params like above, and note the different `host` value:

![image](https://user-images.githubusercontent.com/22080/84943169-d39caf00-b098-11ea-9420-045aa8fb538f.png)

- Again return to your php error log, and you should see the following:

<img width="461" alt="coupon-view-calypsoify" src="https://user-images.githubusercontent.com/22080/84943207-e31bf800-b098-11ea-9e1e-ebab30c7b717.png">

## To Test Biz Plan
For this test case, you need to either undo the [activate calypsoify steps](https://github.com/Automattic/wc-calypso-bridge#activating-calypsoify) - or more simply, modify `wc_calypso_bridge_is_ecommerce_plan` [here](https://github.com/Automattic/wc-calypso-bridge/blob/master/wc-calypso-bridge.php#L43-L51) to `return false;` right away. This effectively mimics how the `wc-calypso-bridge` plugin operates on sites running WooCommerce on the WordPress.com business plan.

The repeat the steps above, loading the Coupons page, and looking at the error log and validating that the `host` property in those tracks events are using the `bizplan-wp-admin` value.

Worth noting that this change also implements the hiding of the tracks opt-out on biz plan sites, and opts them in my by default too.
