### PR TITLE
Ignore *.swp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ project.properties
 .project
 .settings*
 .idea
+*.swp
 
 # OS X metadata
 .DS_Store


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The Vim editor creates `.swp` files by default when editing files. These files are temporary and shouldn't be mistakenly added to git. This PR updates `.gitignore` so that git will ignore these files.

### How to test the changes in this Pull Request:

1. Run branch
2. Add a `foo.swp` file somewhere in your `wc-calypso-bridge` directory tree
3. Run `git status` and verify that the `foo.swp` file isn't listed
