### PR TITLE
Ecomm: Enable Woo Core setup checklist

### DIFF
--- a/includes/class-wc-calypso-bridge-woocommerce-admin.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin.php
@@ -35,7 +35,6 @@ class WC_Calypso_Bridge_WooCommerce_Admin {
 	 */
 	public function init() {
 		add_filter( 'wc_admin_get_feature_config', array( $this, 'maybe_remove_devdocs_menu_item' ) );
-		add_filter( 'pre_option_woocommerce_task_list_hidden', array( $this, 'disable_new_task_list' ) );
 	}
 
 	/**
@@ -50,14 +49,6 @@ class WC_Calypso_Bridge_WooCommerce_Admin {
 
 		return $features;
 	}
-
-	/**
-	 * Force the woocommerce_task_list_hidden option to always be yes so the new checklist is never shown
-	 */
-	public function disable_new_task_list() {
-		return 'yes';
-	}
-
 }
 
 WC_Calypso_Bridge_WooCommerce_Admin::factory()->init();


### PR DESCRIPTION
Fixes #564 

This PR removes the disabling of the Woo Core setup checklist. 

It enables the Woo Core setup checklist to appear in the following places:

- WooCommerce v4.2:
    - Analytics Dashboard
- WooCommerce v4.3 RC1 or above:
    - Analytics Dashboard (if new WooCommerce Home Screen is not enabled)
    - WooCommerce Home Screen (if new WooCommerce Home Screen is enabled)
    - See [v4.3 release testing instructions](https://github.com/woocommerce/woocommerce/wiki/Release-Testing-Instructions-WooCommerce-4.3#new-woocommerce-home-screen) for details on how to enable the Home Screen

### Before 


![](https://user-images.githubusercontent.com/22080/75376068-408aff80-5884-11ea-8378-1c24d8869555.png)


### After

With Home Screen disabled:

<img width="1188" alt="ScreenCapture at Fri Jun 26 11:29:05 EDT 2020" src="https://user-images.githubusercontent.com/2098816/85881684-0424cd00-b7ac-11ea-8cca-9dde6e174927.png">

With Home Screen enabled:

<img width="1189" alt="ScreenCapture at Fri Jun 26 12:36:24 EDT 2020" src="https://user-images.githubusercontent.com/2098816/85881719-1272e900-b7ac-11ea-9048-5ba2a59b3b12.png">


### Testing instructions

Test with both WooCommerce v4.2 and WooCommerce v4.3 RC.

1. Install and activate this branch's version of the wc-calypso-bridge plugin
2. Make sure the task list is enabled. Go to `/wp-admin/edit.php?post_type=shop_coupon` > Help > Setup Wizard

<img width="1188" alt="ScreenCapture at Fri Jun 26 12:58:07 EDT 2020" src="https://user-images.githubusercontent.com/2098816/85882130-bbb9df00-b7ac-11ea-8735-f323fc70493d.png">

3. Visit the wc-admin Dashboard/Home Screen with Calypsoify enabled (see above for link on how to enable new Home Screen in v4.3 RC) `/wp-admin/admin.php?page=wc-admin&calypsoify=1`
4. Verify that task list appears