### PR TITLE
Remove wc-setup-checklist redirects.

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -335,11 +335,11 @@ class WC_Calypso_Bridge {
 	public function check_setup_param() {
 		if ( current_user_can( 'manage_woocommerce' )
 			&& isset( $_GET['page'] ) // WPCS: CSRF ok.
-			&& 'wc-setup-checklist' === $_GET['page'] // WPCS: CSRF ok.
+			&& 'wc-setup' === $_GET['page'] // WPCS: CSRF ok.
 		) {
 			if ( 1 !== (int) get_user_meta( get_current_user_id(), 'calypsoify', true ) ) {
 				update_user_meta( get_current_user_id(), 'calypsoify', 1 );
-				wp_safe_redirect( admin_url( 'admin.php?page=wc-setup-checklist' ) );
+				wp_safe_redirect( admin_url( 'admin.php?page=wc-setup' ) );
 				exit;
 			}
 		}

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -57,7 +57,7 @@ class WC_Calypso_Bridge_Setup {
 		if ( 'admin.php?page=mailchimp-woocommerce' === $location ) {
 			// Delete the redirect option so we don't end up here anymore.
 			delete_option( 'mailchimp_woocommerce_plugin_do_activation_redirect' );
-			$location = admin_url( 'admin.php?page=wc-setup-checklist&calypsoify=1' );
+			$location = admin_url( 'admin.php?page=wc-setup&calypsoify=1' );
 		}
 
 		return $location;


### PR DESCRIPTION
This is a follow-up to the last release of wc-calypso-bridge that just was deployed today.

Upon testing new ecom plan sites, both @mattsherman and I were experiencing an odd redirect to the now defunct `wc-setup-checklist` page. Turns out I missed a few instances of this path when enabling the new Woo Core OBW. This PR removes the two remaining redirects that use the old setup checklist page.

This was not caught during testing because the redirect logic is only triggered by us trying to circumvent MailChimp for WooCommerce redirecting new ecommerce plan sites to their setup screen.

__To Test__

- Locally, install wc-calypso-bridge, [activate calypsoif](https://github.com/Automattic/wc-calypso-bridge#activating-calypsoify)
- checkout this branch
- If you have MailChimp for woocommerce installed, deactivate and delete.
- visit `/wp-admin/plugin-install.php?calypsoify=1`
- Search for and install MailChimp for WooCommerce, activate

![image](https://user-images.githubusercontent.com/22080/86181339-add4c880-bae2-11ea-929d-ea47a14af804.png)

- Verify you are not redirected to `?page=wc-setup-checklist`