### PR TITLE
Prep for 1.1.9 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "automattic/wc-calypso-bridge",
-	"version": "v1.1.8",
+	"version": "v1.1.9",
 	"autoload": {
 		"files": [
 			"wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 1.1.6
+Stable tag: 1.1.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ This section describes how to install the plugin and get it working.
 1. Activate the plugin through the 'Plugins' screen in WordPress
 
 == Changelog ==
+
+= 1.1.9 =
+* Remove redirects to wc-setup-checklist
 
 = 1.1.8 =
 * Make host prop conditional in tracks

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,11 +3,11 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 1.1.8
+ * Version: 1.1.9
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
- * Tested up to: 4.9.8
+ * Tested up to: 5.4.2
  *
  * @package WC_Calypso_bridge
  */
@@ -30,7 +30,7 @@ if ( file_exists( WP_PLUGIN_DIR . '/wc-calypso-bridge/wc-calypso-bridge.php' ) )
 	}
 }
 
-define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.1.8' );
+define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.1.9' );
 define( 'WC_MIN_VERSION', '3.0.0' );
 
 if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_plan' ) ) {


### PR DESCRIPTION
Blocked by #567 

This release includes a single PR:

- #567 Which removes redirects to the new un-supported `wc-setup-checklist`