### PR TITLE
Correct the menu path for analytics so that it shows in the main menu.

### DIFF
--- a/includes/connect/woocommerce-admin.php
+++ b/includes/connect/woocommerce-admin.php
@@ -18,8 +18,8 @@ wc_calypso_bridge_connect_page(
 wc_calypso_bridge_connect_page(
 	array(
 		'screen_id' => 'woocommerce-revenue',
-		'menu'      => 'wc-admin&path=/analytics/revenue',
-		'submenu'   => 'wc-admin&path=/analytics/revenue',
+		'menu'      => 'wc-admin&path=/analytics/overview',
+		'submenu'   => 'wc-admin&path=/analytics/overview',
 	)
 );
 

--- a/includes/connect/woocommerce-admin.php
+++ b/includes/connect/woocommerce-admin.php
@@ -25,6 +25,14 @@ wc_calypso_bridge_connect_page(
 
 wc_calypso_bridge_connect_page(
 	array(
+		'screen_id' => 'woocommerce-revenue',
+		'menu'      => 'wc-admin&path=/analytics/revenue',
+		'submenu'   => 'wc-admin&path=/analytics/revenue',
+	)
+);
+
+wc_calypso_bridge_connect_page(
+	array(
 		'screen_id' => 'woocommerce-marketing',
 		'menu'      => 'wc-admin&path=/marketing',
 		'submenu'   => 'wc-admin&path=/marketing',


### PR DESCRIPTION
Fixes #569 

### Testing

1. Ensure you have RC4.3 of WooCommerce plugin installed/activated
2. Ensure you have the wc-calypso bridge activated
3. Confirm that the Analytics menu appears and can be navigated to in the side bar
4. opt out of the new home screen via `WooCommerce > Settings > Advanced > features`
5. Confirm that the Analytics menu appears and can be navigated to in the sidebar once more.
