### PR TITLE
[4.3] Fix Marketing Menu Display

### DIFF
--- a/includes/connect/woocommerce-admin.php
+++ b/includes/connect/woocommerce-admin.php
@@ -34,7 +34,7 @@ wc_calypso_bridge_connect_page(
 wc_calypso_bridge_connect_page(
 	array(
 		'screen_id' => 'woocommerce-marketing',
-		'menu'      => 'wc-admin&path=/marketing',
+		'menu'      => 'woocommerce-marketing',
 		'submenu'   => 'wc-admin&path=/marketing',
 	)
 );


### PR DESCRIPTION
Fixes #577 

In https://github.com/woocommerce/woocommerce-admin/pull/4526 the logic that registers the menu item for the Marketing tab was changed slightly, which resulted in the Marketing tab not appearing in WooCommerce 4.3 - this branch fixes that.

__To Test__
- Install WooCommerce 4.3
- Activate Calypsoify, definitely recommend using p90Yrv-1O5-p2
- Visit `wp-admin/admin.php?page=wc-admin&calypsoify=1` and note that the Marketing menu is not shown
- Checkout this branch
- Refresh the page and see that the Marketing tab is now there again

![marketing-is-back](https://user-images.githubusercontent.com/22080/87594867-7ea58600-c6a2-11ea-85d4-549bccdc1170.png)
