### PR TITLE
Enable Remote Inbox Notifications

### DIFF
--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -42,7 +42,7 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 	/**
 	 * Set feature flags for WooCommerce Admin front end at run time.
 	 *
-	 * @param array $features List of features 'feature' => bool indicating whether the feature is enabled.
+	 * @param array $features Array of woocommerce-admin features that are enabled by default for the current env.
 	 * @return array
 	 */
 	public function filter_wc_admin_enabled_features( $features ) {

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Control wc-admin features in the eCommerce Plan.
+ *
+ * @package WC_Calypso_Bridge/Classes
+ * @since   1.3.0
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC EComm Bridge
+ */
+class WC_Calypso_Bridge_WooCommerce_Admin_Features {
+
+	/**
+	 * Class Instance.
+	 *
+	 * @var WC_Calypso_Bridge_WooCommerce_Admin_Features instance
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'plugins_loaded', array( $this, 'initialize' ), 2 );
+	}
+
+	/**
+	 * Add hooks and filters if WooCommerce is active.
+	 */
+	public function initialize() {
+		if ( ! function_exists( 'WC' ) ) {
+			return;
+		}
+
+		add_filter( 'woocommerce_admin_features', array( $this, 'filter_wc_admin_enabled_features' ) );
+	}
+
+	/**
+	 * Set feature flags for WooCommerce Admin front end at run time.
+	 *
+	 * @param array $features List of features 'feature' => bool indicating whether the feature is enabled.
+	 * @return array
+	 */
+	public function filter_wc_admin_enabled_features( $features ) {
+		if ( ! array_key_exists( 'remote-inbox-notifications', $features ) ) {
+			$features[] = 'remote-inbox-notifications';
+		}
+
+		return $features;
+	}
+
+	/**
+	 * Get class instance
+	 */
+	public static function get_instance() {
+		if ( ! static::$instance ) {
+			static::$instance = new static();
+		}
+		return static::$instance;
+	}
+}
+
+WC_Calypso_Bridge_WooCommerce_Admin_Features::get_instance();

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,7 +12,7 @@
 
 	<!-- Configs -->
 	<config name="minimum_supported_wp_version" value="4.7" />
-	<config name="testVersion" value="5.2-"/>
+	<config name="testVersion" value="7.0-"/>
 
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core" />

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -78,3 +78,5 @@ add_action( 'plugins_loaded', 'wc_calypso_bridge_init' );
 require_once dirname( __FILE__ ) . '/class-wc-calypso-bridge.php';
 
 require_once dirname( __FILE__ ) . '/class-wc-calypso-bridge-frontend.php';
+
+require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-woocommerce-admin-features.php';


### PR DESCRIPTION
Props to @rrennick for the original PR #549 which this is based off of. I just figured creating a fresh PR would be easier then backing out the composer changes in the prior one.

This branch enables the remote inbox functionality that is included in WooCommerce Admin.

__Things to Note__
- This approach allows for enabling wc-admin features "globally" on Atomic. So we can turn on/off features for all sites on Atomic that are running WooCommerce.
- In the future, if we want to target features to ecomm vs biz plan, we can still do so, but for now the one remote inbox notification is quite targeted at a unique mix of Woo extensions that a normal site would not have installed.
- Coming in WooCommerce 4.4, we will have a [remote inbox rule](https://github.com/woocommerce/woocommerce-admin/blob/main/src/RemoteInboxNotifications/IsEcommerceRuleProcessor.php) to specifically target ecomm sites.

__Testing Prep__
To properly test out this branch, you will need to gather a few items:

- Install and activate [Crontrol](https://wordpress.org/plugins/wp-crontrol/) from the WPORG repository.
- You will also need to grab the aforementioned unique mix of shipping extensions that are currently used to conditionally display the "Quickstart Session" note. The extensions are Australia Post, Canada Post, and Royal mail. You can either purchase these from woocommerce.com, or i've done that and uploaded them to pastebin: 155119-pb, 155120-pb, 155121-pb
- Install those 3 mail extensions, **but do not activate them yet**
- Also have at least version 4.3.x of WooCommerce installed since that is when the Remote Inbox landed, and that is what is installed on Atomic sites currently.

__Now Time to Test__
With all the setup steps satisfied, and those postal extensions installed but not active

- Open up crontrol via `wp-admin/tools.php?page=crontrol_admin_manage_page`
- Find and run the `wc_admin_daily` job
- If you have access to phpmyadmin, you can then inspect the notes table for your site, and you should see something like so:

<img width="1106" alt="image" src="https://user-images.githubusercontent.com/22080/88969076-24d9ba00-d265-11ea-86af-ffeb9eff6493.png">

- But yours _should_ say `pending` in the status column. This verifies that the remote inbox system is enabled ( woot, that is the whole point of this PR! ) but also shows that it reached out to the REST API endpoint on woocommerce.com and fetched the notes.
- Now go enable the shipping extensions you installed above. After activating each one, you could refresh your sql query, and verify the note is still `pending` until you activate the last one, at which point in time, the status should then be `unactioned`
- Additionally visit the woo home screen, or open the inbox activity panel, and verify the note is now shown:

<img width="524" alt="Home ‹ WooCommerce ‹ ecomm woo test — WooCommerce 2020-07-30 12-46-44" src="https://user-images.githubusercontent.com/22080/88969280-7124fa00-d265-11ea-88d7-7f5aba94ce02.png">
