### PR TITLE
Enable home screen on always.

### DIFF
--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -44,6 +44,26 @@ class WC_Calypso_Bridge_Setup {
 		add_filter( 'woocommerce_admin_onboarding_themes', array( $this, 'remove_non_installed_themes' ), 10, 1 );
 		add_filter( 'wp_redirect', array( $this, 'prevent_mailchimp_redirect' ), 10, 2 );
 		add_filter( 'woocommerce_admin_onboarding_product_types', array( $this, 'remove_paid_extension_upsells' ), 10, 2 );
+		add_filter( 'pre_option_woocommerce_homescreen_enabled', array( $this, 'always_enable_homescreen' ) );
+		add_filter( 'woocommerce_get_sections_advanced', array( $this, 'remove_features_settings' ) );
+	}
+
+	/**
+	 * Opt all sites into using WooCommerec Home Screen.
+	 */
+	public function always_enable_homescreen() {
+		return 'yes';
+	}
+
+	/**
+	 * Remove the Features Settings Panel.
+	 *
+	 * @param array $sections Array of Settings Panel Sections.
+	 * @return array
+	 */
+	public function remove_features_settings( $sections ) {
+		unset( $sections['features'] );
+		return $sections;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #593 

This branch ensures all ecomm plan sites are using the new home screen in WooCommerce Admin. Since we are turning the feature on by default, we also remove the display of the "Advanced > Features" panel where the current opt in/out of the home screen feature is shown.

__To Test__
- on the `master` branch of calypso bridge, visit `wp-admin/admin.php?page=wc-settings&tab=advanced&section=features` and turn the home screen feature **off**
- Load up wp-admin now, and verify the WooCommerce menu item points you at the analytics dashboard.
- Check out this branch, and refresh the page and note the home screen is now the page linked on the WooCommerce menu item
- Visit the `wp-admin/admin.php?page=wc-settings&tab=advanced` advanced settings page, and note the "Features" sub-menu tab no longer is shown.

__Before__
<img width="980" alt="features-tab-shown" src="https://user-images.githubusercontent.com/22080/90714857-7cb08300-e25d-11ea-87f9-86344a3569e0.png">

__After__
<img width="980" alt="WooCommerce settings ‹ ecomm woo test — WordPress 2020-08-19 20-30-07" src="https://user-images.githubusercontent.com/22080/90714885-8d60f900-e25d-11ea-902a-174dfb83da2a.png">

