### PR TITLE
Disable Crowdsignal Redirect

### DIFF
--- a/includes/class-wc-calypso-bridge-crowdsignal-redirect.php
+++ b/includes/class-wc-calypso-bridge-crowdsignal-redirect.php
@@ -8,7 +8,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * WC Calypso Bridge Hide Alerts
+ * WC Calypso Bridge Crowdsignal Redirect
  */
 class WC_Calypso_Bridge_Crowdsignal_Redirect {
 

--- a/includes/class-wc-calypso-bridge-crowdsignal-redirect.php
+++ b/includes/class-wc-calypso-bridge-crowdsignal-redirect.php
@@ -44,10 +44,10 @@ class WC_Calypso_Bridge_Crowdsignal_Redirect {
 	}
 
 	/**
-	 * When the option to redirect is added, update to false.
+	 * When the option to redirect is added, delete the option.
 	 */
 	public function disable_crowdsignal_redirect() {
-		update_option( 'crowdsignal_forms_do_activation_redirect', false );
+		delete_option( 'crowdsignal_forms_do_activation_redirect' );
 	}
 
 

--- a/includes/class-wc-calypso-bridge-crowdsignal-redirect.php
+++ b/includes/class-wc-calypso-bridge-crowdsignal-redirect.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Prevents Crowdsignal Forms plugin from doing a redirect.
+ *
+ * @package WC_Calypso_Bridge/Classes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC Calypso Bridge Hide Alerts
+ */
+class WC_Calypso_Bridge_Crowdsignal_Redirect {
+
+	/**
+	 * Class instance.
+	 *
+	 * @var WC_Calypso_Bridge_Crowdsignal_Redirect instance
+	 */
+	protected static $instance = false;
+
+	/**
+	 * Get class instance
+	 */
+	public static function get_instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor
+	 */
+	private function __construct() {
+		add_action( 'admin_init', array( $this, 'add_crowdsignal_redirect_filter' ) );
+	}
+
+	/**
+	 * Hook into add_option to disable the redirect.
+	 */
+	public function add_crowdsignal_redirect_filter() {
+		add_action( 'add_option_crowdsignal_forms_do_activation_redirect', array( $this, 'disable_crowdsignal_redirect' ) );
+	}
+
+	/**
+	 * When the option to redirect is added, update to false.
+	 */
+	public function disable_crowdsignal_redirect() {
+		update_option( 'crowdsignal_forms_do_activation_redirect', false );
+	}
+
+
+}
+$wc_calypso_bridge_crowdsignal_redirect = WC_Calypso_Bridge_Crowdsignal_Redirect::get_instance();

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -56,6 +56,9 @@ if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_plan' ) ) {
 require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-tracks.php';
 add_action( 'init', array( 'WC_Calypso_Bridge_Tracks', 'get_instance' ) );
 
+// Also prevent Crowdsignal from redirecting during onboarding in all both wp-admin and calypsoified ecommerce plan.
+require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-crowdsignal-redirect.php';
+
 if ( ! wc_calypso_bridge_is_ecommerce_plan() ) {
 	include_once dirname( __FILE__ ) . '/store-on-wpcom/class-wc-calypso-bridge.php';
 	return;
@@ -67,8 +70,8 @@ if ( ! function_exists( 'wc_calypso_bridge_init' ) ) {
 	 */
 	function wc_calypso_bridge_init() {
 		$plugin_path = dirname( __FILE__ ) . '/languages';
-		$locale = apply_filters( 'plugin_locale', determine_locale(), 'wc-calypso-bridge' );
-		$mofile = $plugin_path . '/wc-calypso-bridge-' . $locale . '.mo';
+		$locale      = apply_filters( 'plugin_locale', determine_locale(), 'wc-calypso-bridge' );
+		$mofile      = $plugin_path . '/wc-calypso-bridge-' . $locale . '.mo';
 
 		load_textdomain( 'wc-calypso-bridge', $mofile );
 	}


### PR DESCRIPTION
Currently the [Crowdsignal Forms](https://wordpress.org/plugins/crowdsignal-forms/) plugin adds in a redirect that results in a newly created ecommerce plan site in being redirected to their setup flow instead of Woo. Discussion and details about this can be seen in 716-gh-greenhouse

The proposed solution here is to hook into the `add_option` for the `crowdsignal_forms_do_activation_redirect` value which is used to determine if this redirect should happen. When the option is added, this branch simply deletes the option right away to prevent the redirect from happening.

__Before__
<img width="1608" alt="Getting Started ‹ ecomm woo test — WordPress 2020-09-09 11-15-58" src="https://user-images.githubusercontent.com/22080/92638132-af62ff80-f28e-11ea-99e1-1cc56c86fed6.png">

__After__
<img width="1608" alt="Plugins ‹ ecomm woo test — WordPress 2020-09-09 11-16-54" src="https://user-images.githubusercontent.com/22080/92638152-b722a400-f28e-11ea-8f42-167143040a20.png">

__To Test__

- Using `master` of `wc-calypso-bridge` add the Crowdsignal Forms plugin to your site, and activate.
- Note you are redirected to their setup page ( before screenshot above ).
- Deactivate the crowdsignal plugin.
- Apply this branch, and activate the Crowdsignal Forms plugin.
- Note that you are no longer redirected, but instead see the plugins page ( after screenshot above )