### PR TITLE
Onboarding - Store Profiler: Hide the option "CBD and other hemp-derived products"

### DIFF
--- a/includes/class-wc-calypso-bridge-filters.php
+++ b/includes/class-wc-calypso-bridge-filters.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Filters for the ecommerce plan.
+ *
+ * @package WC_Calypso_Bridge/Classes
+ * @since   1.1.6
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC Calypso Bridge Filters
+ */
+class WC_Calypso_Bridge_Filters {
+
+	/**
+	 * Class instance.
+	 *
+	 * @var WC_Calypso_Filters instance
+	 */
+	protected static $instance = false;
+
+	/**
+	 * Get class instance
+	 */
+	public static function get_instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	private function __construct() {
+		add_action( 'woocommerce_admin_onboarding_industries', array( $this, 'remove_not_allowed_industries' ), 10, 1 );
+	}
+
+	/**
+	 * Remove `CBD and other hemp-derived products` option from industries list
+	 *
+	 * @param  array $industries Array of industries.
+	 * @return array
+	 */
+	public function remove_not_allowed_industries( $industries ) {
+		if ( isset( $industries['cbd-other-hemp-derived-products'] ) ) {
+			unset( $industries['cbd-other-hemp-derived-products'] );
+		} else {
+			$industries = array_filter( $industries, array( $this, 'filter_industries' ) );
+		}
+		return $industries;
+	}
+
+	/**
+	 * Filter method for industries to remove `CBD and other hemp-derived products` option.
+	 *
+	 * @param  array $industry Array of industries.
+	 * @return boolean
+	 */
+	public function filter_industries( $industry ) {
+		return 'cbd-other-hemp-derived-products' !== $industry['slug'];
+	}
+}
+
+$wc_calypso_bridge_filters = WC_Calypso_Bridge_Filters::get_instance();

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -134,10 +134,23 @@ class WC_Calypso_Bridge_Setup {
 	 * @return array
 	 */
 	public function remove_not_allowed_industries( $industries ) {
-		unset( $industries['cbd-other-hemp-derived-products'] );
+		if ( isset( $industries['cbd-other-hemp-derived-products'] ) ) {
+			unset( $industries['cbd-other-hemp-derived-products'] );
+		} else {
+			$industries = array_filter( $industries, array( $this, 'filter_industries' ) );
+		}
 		return $industries;
 	}
 
+	/**
+	 * Site Profiler OBW: Filter method for industries to remove `CBD and other hemp-derived products` option.
+	 *
+	 * @param  array $industry Array of industries.
+	 * @return boolean
+	 */
+	public function filter_industries( $industry ) {
+		return 'cbd-other-hemp-derived-products' !== $industry['slug'];
+	}
 }
 
 $wc_calypso_bridge_setup = WC_Calypso_Bridge_Setup::get_instance();

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -118,28 +118,6 @@ class WC_Calypso_Bridge_Setup {
 	}
 
 	/**
-	 * Site Profiler OBW: Remove CBD industry
-	 *
-	 * @param  array $industries Array of industries.
-	 * @return array
-	 */
-	public function remove_not_allowed_industries( $industries ) {
-		$filtered_industries = array_filter( $industries, array( $this, 'filter_industries' ) );
-		return $filtered_industries;
-	}
-
-	/**
-	 * Site Profiler OBW: Filter method for industries to remove `CBD and other hemp-derived products` option.
-	 *
-	 * @param  array $industries Array of industries.
-	 * @return array
-	 */
-	public function filter_industries( $industries ) {
-		unset( $industries['cbd-other-hemp-derived-products'] );
-		return $industries;
-	}
-
-	/**
 	 * Conditional method to determine if a theme is installed locally.
 	 *
 	 * @param array $theme Theme attributes.
@@ -148,6 +126,18 @@ class WC_Calypso_Bridge_Setup {
 	public function is_theme_installed( $theme ) {
 		return isset( $theme['is_installed'] ) && $theme['is_installed'];
 	}
+
+	/**
+	 * Site Profiler OBW: Remove CBD industry from industries list
+	 *
+	 * @param  array $industries Array of industries.
+	 * @return array
+	 */
+	public function remove_not_allowed_industries( $industries ) {
+		unset( $industries['cbd-other-hemp-derived-products'] );
+		return $industries;
+	}
+
 }
 
 $wc_calypso_bridge_setup = WC_Calypso_Bridge_Setup::get_instance();

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -42,7 +42,6 @@ class WC_Calypso_Bridge_Setup {
 		add_filter( 'default_option_woocommerce_onboarding_profile', array( $this, 'set_business_extensions_empty' ), 10, 1 );
 		add_filter( 'option_woocommerce_onboarding_profile', array( $this, 'set_business_extensions_empty' ), 10, 1 );
 		add_filter( 'woocommerce_admin_onboarding_themes', array( $this, 'remove_non_installed_themes' ), 10, 1 );
-		add_filter( 'woocommerce_admin_onboarding_industries', array( $this, 'remove_not_allowed_industries' ), 10, 1 );
 		add_filter( 'wp_redirect', array( $this, 'prevent_mailchimp_redirect' ), 10, 2 );
 		add_filter( 'woocommerce_admin_onboarding_product_types', array( $this, 'remove_paid_extension_upsells' ), 10, 2 );
 	}
@@ -125,31 +124,6 @@ class WC_Calypso_Bridge_Setup {
 	 */
 	public function is_theme_installed( $theme ) {
 		return isset( $theme['is_installed'] ) && $theme['is_installed'];
-	}
-
-	/**
-	 * Site Profiler OBW: Remove CBD industry from industries list
-	 *
-	 * @param  array $industries Array of industries.
-	 * @return array
-	 */
-	public function remove_not_allowed_industries( $industries ) {
-		if ( isset( $industries['cbd-other-hemp-derived-products'] ) ) {
-			unset( $industries['cbd-other-hemp-derived-products'] );
-		} else {
-			$industries = array_filter( $industries, array( $this, 'filter_industries' ) );
-		}
-		return $industries;
-	}
-
-	/**
-	 * Site Profiler OBW: Filter method for industries to remove `CBD and other hemp-derived products` option.
-	 *
-	 * @param  array $industry Array of industries.
-	 * @return boolean
-	 */
-	public function filter_industries( $industry ) {
-		return 'cbd-other-hemp-derived-products' !== $industry['slug'];
 	}
 }
 

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -42,6 +42,7 @@ class WC_Calypso_Bridge_Setup {
 		add_filter( 'default_option_woocommerce_onboarding_profile', array( $this, 'set_business_extensions_empty' ), 10, 1 );
 		add_filter( 'option_woocommerce_onboarding_profile', array( $this, 'set_business_extensions_empty' ), 10, 1 );
 		add_filter( 'woocommerce_admin_onboarding_themes', array( $this, 'remove_non_installed_themes' ), 10, 1 );
+		add_filter( 'woocommerce_admin_onboarding_industries', array( $this, 'remove_not_allowed_industries' ), 10, 1 );
 		add_filter( 'wp_redirect', array( $this, 'prevent_mailchimp_redirect' ), 10, 2 );
 		add_filter( 'woocommerce_admin_onboarding_product_types', array( $this, 'remove_paid_extension_upsells' ), 10, 2 );
 	}
@@ -114,6 +115,28 @@ class WC_Calypso_Bridge_Setup {
 	public function remove_non_installed_themes( $themes ) {
 		$local_themes = array_filter( $themes, array( $this, 'is_theme_installed' ) );
 		return $local_themes;
+	}
+
+	/**
+	 * Site Profiler OBW: Remove CBD industry
+	 *
+	 * @param  array $industries Array of industries.
+	 * @return array
+	 */
+	public function remove_not_allowed_industries( $industries ) {
+		$filtered_industries = array_filter( $industries, array( $this, 'filter_industries' ) );
+		return $filtered_industries;
+	}
+
+	/**
+	 * Site Profiler OBW: Filter method for industries to remove `CBD and other hemp-derived products` option.
+	 *
+	 * @param  array $industries Array of industries.
+	 * @return array
+	 */
+	public function filter_industries( $industries ) {
+		unset( $industries['cbd-other-hemp-derived-products'] );
+		return $industries;
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -34,18 +34,18 @@ class WC_Calypso_Bridge_Unit_Tests_Bootstrap {
 			$_SERVER['SERVER_NAME'] = 'localhost';
 		}
 
-		$this->tests_dir    = dirname( __FILE__ );
-		$this->plugin_dir   = dirname( $this->tests_dir );
-		$this->wc_dir = dirname( $this->plugin_dir ) . '/woocommerce';
+		$this->tests_dir      = dirname( __FILE__ );
+		$this->plugin_dir     = dirname( $this->tests_dir );
+		$this->wc_dir         = dirname( $this->plugin_dir ) . '/woocommerce';
 		$this->wc_api_dev_dir = dirname( $this->plugin_dir ) . '/wc-api-dev';
-		$this->wc_tests_dir = dirname( $this->plugin_dir ) . '/woocommerce/tests';
+		$this->wc_tests_dir   = dirname( $this->plugin_dir ) . '/woocommerce/tests';
 		if ( ! is_dir( $this->wc_tests_dir . '/framework' ) ) {
 			$this->wc_tests_dir .= '/legacy';
 		}
 		$this->wp_tests_dir = getenv( 'WP_TESTS_DIR' ) ? getenv( 'WP_TESTS_DIR' ) : '/tmp/wordpress-tests-lib';
 
 		// load test function so tests_add_filter() is available
-		require_once( $this->wp_tests_dir . '/includes/functions.php' );
+		require_once $this->wp_tests_dir . '/includes/functions.php';
 
 		// load WC
 		tests_add_filter( 'muplugins_loaded', array( $this, 'load_wc' ) );
@@ -57,24 +57,27 @@ class WC_Calypso_Bridge_Unit_Tests_Bootstrap {
 		tests_add_filter( 'setup_theme', array( $this, 'install_wc' ) );
 
 		// load the WP testing environment
-		require_once( $this->wp_tests_dir . '/includes/bootstrap.php' );
+		require_once $this->wp_tests_dir . '/includes/bootstrap.php';
 
 		// load WC testing framework
 		$this->includes();
+
+		// load extra filters
+		require_once $this->plugin_dir . '/includes/class-wc-calypso-bridge-filters.php';
 	}
 
 	/**
 	 * Load WooCommerce.
 	 */
 	public function load_wc() {
-		require_once( $this->wc_dir . '/woocommerce.php' );
+		require_once $this->wc_dir . '/woocommerce.php';
 	}
 
 	/**
 	 * Load WC Calypso Bridge.
 	 */
 	public function load_wc_calypso_bridge() {
-		require_once( $this->plugin_dir . '/class-wc-calypso-bridge.php' );
+		require_once $this->plugin_dir . '/class-wc-calypso-bridge.php';
 		WC_Calypso_Bridge::instance()->initialize();
 	}
 
@@ -86,7 +89,7 @@ class WC_Calypso_Bridge_Unit_Tests_Bootstrap {
 		// Clean existing install first.
 		define( 'WP_UNINSTALL_PLUGIN', true );
 		define( 'WC_REMOVE_ALL_DATA', true );
-		include( $this->wc_dir . '/uninstall.php' );
+		include $this->wc_dir . '/uninstall.php';
 
 		WC_Install::install();
 
@@ -109,29 +112,29 @@ class WC_Calypso_Bridge_Unit_Tests_Bootstrap {
 	 */
 	public function includes() {
 		// framework
-		require_once( $this->wc_tests_dir . '/framework/class-wc-unit-test-factory.php' );
-		require_once( $this->wc_tests_dir . '/framework/class-wc-mock-session-handler.php' );
-		require_once( $this->wc_tests_dir . '/framework/class-wc-mock-wc-data.php' );
-		require_once( $this->wc_tests_dir . '/framework/class-wc-mock-wc-object-query.php' );
-		require_once( $this->wc_tests_dir . '/framework/class-wc-payment-token-stub.php' );
-		require_once( $this->wc_tests_dir . '/framework/vendor/class-wp-test-spy-rest-server.php' );
+		require_once $this->wc_tests_dir . '/framework/class-wc-unit-test-factory.php';
+		require_once $this->wc_tests_dir . '/framework/class-wc-mock-session-handler.php';
+		require_once $this->wc_tests_dir . '/framework/class-wc-mock-wc-data.php';
+		require_once $this->wc_tests_dir . '/framework/class-wc-mock-wc-object-query.php';
+		require_once $this->wc_tests_dir . '/framework/class-wc-payment-token-stub.php';
+		require_once $this->wc_tests_dir . '/framework/vendor/class-wp-test-spy-rest-server.php';
 
 		// test cases
-		require_once( $this->wc_tests_dir . '/includes/wp-http-testcase.php' );
-		require_once( $this->wc_tests_dir . '/framework/class-wc-unit-test-case.php' );
-		require_once( $this->wc_tests_dir . '/framework/class-wc-api-unit-test-case.php' );
-		require_once( $this->wc_tests_dir . '/framework/class-wc-rest-unit-test-case.php' );
+		require_once $this->wc_tests_dir . '/includes/wp-http-testcase.php';
+		require_once $this->wc_tests_dir . '/framework/class-wc-unit-test-case.php';
+		require_once $this->wc_tests_dir . '/framework/class-wc-api-unit-test-case.php';
+		require_once $this->wc_tests_dir . '/framework/class-wc-rest-unit-test-case.php';
 
 		// Helpers
-		require_once( $this->wc_tests_dir . '/framework/helpers/class-wc-helper-product.php' );
-		require_once( $this->wc_tests_dir . '/framework/helpers/class-wc-helper-coupon.php' );
-		require_once( $this->wc_tests_dir . '/framework/helpers/class-wc-helper-fee.php' );
-		require_once( $this->wc_tests_dir . '/framework/helpers/class-wc-helper-shipping.php' );
-		require_once( $this->wc_tests_dir . '/framework/helpers/class-wc-helper-customer.php' );
-		require_once( $this->wc_tests_dir . '/framework/helpers/class-wc-helper-order.php' );
-		require_once( $this->wc_tests_dir . '/framework/helpers/class-wc-helper-shipping-zones.php' );
-		require_once( $this->wc_tests_dir . '/framework/helpers/class-wc-helper-payment-token.php' );
-		require_once( $this->wc_tests_dir . '/framework/helpers/class-wc-helper-settings.php' );
+		require_once $this->wc_tests_dir . '/framework/helpers/class-wc-helper-product.php';
+		require_once $this->wc_tests_dir . '/framework/helpers/class-wc-helper-coupon.php';
+		require_once $this->wc_tests_dir . '/framework/helpers/class-wc-helper-fee.php';
+		require_once $this->wc_tests_dir . '/framework/helpers/class-wc-helper-shipping.php';
+		require_once $this->wc_tests_dir . '/framework/helpers/class-wc-helper-customer.php';
+		require_once $this->wc_tests_dir . '/framework/helpers/class-wc-helper-order.php';
+		require_once $this->wc_tests_dir . '/framework/helpers/class-wc-helper-shipping-zones.php';
+		require_once $this->wc_tests_dir . '/framework/helpers/class-wc-helper-payment-token.php';
+		require_once $this->wc_tests_dir . '/framework/helpers/class-wc-helper-settings.php';
 	}
 
 	/**

--- a/tests/unit-tests/test-class-wc-calypso-bridge-filters.php
+++ b/tests/unit-tests/test-class-wc-calypso-bridge-filters.php
@@ -8,9 +8,9 @@ class WC_Calypso_Bridge_Filters_Test extends WC_Calypso_Bridge_Test {
 	 * Test removing `CBD and other hemp-derived products` option from industries list
 	 *
 	 */
-	public function test_remove_not_allowed_industries() {
-		$wc_calypso_bridge_filters     = WC_Calypso_Bridge_Filters::get_instance();
-		$industries                    = array(
+	public function test_remove_not_allowed_industries_from_industries_list() {
+		$wc_calypso_bridge_filters = WC_Calypso_Bridge_Filters::get_instance();
+		$industries                = array(
 			'fashion-apparel-accessories'     => array(
 				'label'             => 'Fashion, apparel, and accessories',
 				'use_description'   => false,
@@ -27,14 +27,22 @@ class WC_Calypso_Bridge_Filters_Test extends WC_Calypso_Bridge_Test {
 				'description_label' => 'Description',
 			),
 		);
-		$industries_variation          = array(
+		$filtered_industries       = $wc_calypso_bridge_filters->remove_not_allowed_industries( $industries );
+		$this->assertEquals( count( $filtered_industries ), 2 );
+	}
+
+	/**
+	 * Test removing `CBD and other hemp-derived products` option from slugs list
+	 *
+	 */
+	public function test_remove_not_allowed_industries_from_slug_list() {
+		$wc_calypso_bridge_filters = WC_Calypso_Bridge_Filters::get_instance();
+		$industries_slugs          = array(
 			array( 'slug' => 'fashion-apparel-accessories' ),
 			array( 'slug' => 'cbd-other-hemp-derived-products' ),
 			array( 'slug' => 'other' ),
 		);
-		$filtered_industries           = $wc_calypso_bridge_filters->remove_not_allowed_industries( $industries );
-		$filtered_industries_variation = $wc_calypso_bridge_filters->remove_not_allowed_industries( $industries_variation );
+		$filtered_industries       = $wc_calypso_bridge_filters->remove_not_allowed_industries( $industries_slugs );
 		$this->assertEquals( count( $filtered_industries ), 2 );
-		$this->assertEquals( count( $filtered_industries_variation ), 2 );
 	}
 }

--- a/tests/unit-tests/test-class-wc-calypso-bridge-filters.php
+++ b/tests/unit-tests/test-class-wc-calypso-bridge-filters.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Tests for WC_Calypso_Bridge_Filters
+ */
+
+class WC_Calypso_Bridge_Filters_Test extends WC_Calypso_Bridge_Test {
+	/**
+	 * Test removing `CBD and other hemp-derived products` option from industries list
+	 *
+	 */
+	public function test_remove_not_allowed_industries() {
+		$wc_calypso_bridge_filters     = WC_Calypso_Bridge_Filters::get_instance();
+		$industries                    = array(
+			'fashion-apparel-accessories'     => array(
+				'label'             => 'Fashion, apparel, and accessories',
+				'use_description'   => false,
+				'description_label' => '',
+			),
+			'cbd-other-hemp-derived-products' => array(
+				'label'             => 'CBD and other hemp-derived products',
+				'use_description'   => false,
+				'description_label' => '',
+			),
+			'other'                           => array(
+				'label'             => 'Other',
+				'use_description'   => true,
+				'description_label' => 'Description',
+			),
+		);
+		$industries_variation          = array(
+			array( 'slug' => 'fashion-apparel-accessories' ),
+			array( 'slug' => 'cbd-other-hemp-derived-products' ),
+			array( 'slug' => 'other' ),
+		);
+		$filtered_industries           = $wc_calypso_bridge_filters->remove_not_allowed_industries( $industries );
+		$filtered_industries_variation = $wc_calypso_bridge_filters->remove_not_allowed_industries( $industries_variation );
+		$this->assertEquals( count( $filtered_industries ), 2 );
+		$this->assertEquals( count( $filtered_industries_variation ), 2 );
+	}
+}

--- a/tests/unit-tests/test-class-wc-calypso-bridge-setup.php
+++ b/tests/unit-tests/test-class-wc-calypso-bridge-setup.php
@@ -28,4 +28,32 @@ class WC_Calypso_Bridge_Setup_Test extends WC_Calypso_Bridge_Test {
 		$this->assertEquals( $filtered_products['physical']['label'], 'Physical products' );
 	}
 
+	/**
+	 * Test removing CBD industry from industries list.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_remove_not_allowed_industries() {
+		$wc_calypso_bridge_setup = WC_Calypso_Bridge_Setup::get_instance();
+		$industries              = array(
+			'fashion-apparel-accessories'     => array(
+				'label'             => 'Fashion, apparel, and accessories',
+				'use_description'   => false,
+				'description_label' => '',
+			),
+			'cbd-other-hemp-derived-products' => array(
+				'label'             => 'CBD and other hemp-derived products',
+				'use_description'   => false,
+				'description_label' => '',
+			),
+			'other'                           => array(
+				'label'             => 'Other',
+				'use_description'   => true,
+				'description_label' => 'Description',
+			),
+		);
+		$filtered_industries     = $wc_calypso_bridge_setup->remove_not_allowed_industries( $industries );
+		$this->assertEquals( count( $filtered_industries ), 2 );
+	}
+
 }

--- a/tests/unit-tests/test-class-wc-calypso-bridge-setup.php
+++ b/tests/unit-tests/test-class-wc-calypso-bridge-setup.php
@@ -31,7 +31,6 @@ class WC_Calypso_Bridge_Setup_Test extends WC_Calypso_Bridge_Test {
 	/**
 	 * Test removing CBD industry from industries list.
 	 *
-	 * @since 3.5.0
 	 */
 	public function test_remove_not_allowed_industries() {
 		$wc_calypso_bridge_setup = WC_Calypso_Bridge_Setup::get_instance();

--- a/tests/unit-tests/test-class-wc-calypso-bridge-setup.php
+++ b/tests/unit-tests/test-class-wc-calypso-bridge-setup.php
@@ -33,8 +33,8 @@ class WC_Calypso_Bridge_Setup_Test extends WC_Calypso_Bridge_Test {
 	 *
 	 */
 	public function test_remove_not_allowed_industries() {
-		$wc_calypso_bridge_setup = WC_Calypso_Bridge_Setup::get_instance();
-		$industries              = array(
+		$wc_calypso_bridge_setup       = WC_Calypso_Bridge_Setup::get_instance();
+		$industries                    = array(
 			'fashion-apparel-accessories'     => array(
 				'label'             => 'Fashion, apparel, and accessories',
 				'use_description'   => false,
@@ -51,8 +51,15 @@ class WC_Calypso_Bridge_Setup_Test extends WC_Calypso_Bridge_Test {
 				'description_label' => 'Description',
 			),
 		);
-		$filtered_industries     = $wc_calypso_bridge_setup->remove_not_allowed_industries( $industries );
+		$industries_variation          = array(
+			array( 'slug' => 'fashion-apparel-accessories' ),
+			array( 'slug' => 'cbd-other-hemp-derived-products' ),
+			array( 'slug' => 'other' ),
+		);
+		$filtered_industries           = $wc_calypso_bridge_setup->remove_not_allowed_industries( $industries );
+		$filtered_industries_variation = $wc_calypso_bridge_setup->remove_not_allowed_industries( $industries_variation );
 		$this->assertEquals( count( $filtered_industries ), 2 );
+		$this->assertEquals( count( $filtered_industries_variation ), 2 );
 	}
 
 }

--- a/tests/unit-tests/test-class-wc-calypso-bridge-setup.php
+++ b/tests/unit-tests/test-class-wc-calypso-bridge-setup.php
@@ -27,39 +27,4 @@ class WC_Calypso_Bridge_Setup_Test extends WC_Calypso_Bridge_Test {
 		$this->assertEquals( count( $filtered_products ), 1 );
 		$this->assertEquals( $filtered_products['physical']['label'], 'Physical products' );
 	}
-
-	/**
-	 * Test removing CBD industry from industries list.
-	 *
-	 */
-	public function test_remove_not_allowed_industries() {
-		$wc_calypso_bridge_setup       = WC_Calypso_Bridge_Setup::get_instance();
-		$industries                    = array(
-			'fashion-apparel-accessories'     => array(
-				'label'             => 'Fashion, apparel, and accessories',
-				'use_description'   => false,
-				'description_label' => '',
-			),
-			'cbd-other-hemp-derived-products' => array(
-				'label'             => 'CBD and other hemp-derived products',
-				'use_description'   => false,
-				'description_label' => '',
-			),
-			'other'                           => array(
-				'label'             => 'Other',
-				'use_description'   => true,
-				'description_label' => 'Description',
-			),
-		);
-		$industries_variation          = array(
-			array( 'slug' => 'fashion-apparel-accessories' ),
-			array( 'slug' => 'cbd-other-hemp-derived-products' ),
-			array( 'slug' => 'other' ),
-		);
-		$filtered_industries           = $wc_calypso_bridge_setup->remove_not_allowed_industries( $industries );
-		$filtered_industries_variation = $wc_calypso_bridge_setup->remove_not_allowed_industries( $industries_variation );
-		$this->assertEquals( count( $filtered_industries ), 2 );
-		$this->assertEquals( count( $filtered_industries_variation ), 2 );
-	}
-
 }

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -52,6 +52,10 @@ if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_plan' ) ) {
 	}
 }
 
+// Filters we want to add for ecommerce plan.
+require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-filters.php';
+add_action( 'init', array( 'WC_Calypso_Bridge_Filters', 'get_instance' ) );
+
 // We want to adjust tracks settings for business, ecomm, in calypsoified and wp-admin views.
 require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-tracks.php';
 add_action( 'init', array( 'WC_Calypso_Bridge_Tracks', 'get_instance' ) );
@@ -67,8 +71,8 @@ if ( ! function_exists( 'wc_calypso_bridge_init' ) ) {
 	 */
 	function wc_calypso_bridge_init() {
 		$plugin_path = dirname( __FILE__ ) . '/languages';
-		$locale = apply_filters( 'plugin_locale', determine_locale(), 'wc-calypso-bridge' );
-		$mofile = $plugin_path . '/wc-calypso-bridge-' . $locale . '.mo';
+		$locale      = apply_filters( 'plugin_locale', determine_locale(), 'wc-calypso-bridge' );
+		$mofile      = $plugin_path . '/wc-calypso-bridge-' . $locale . '.mo';
 
 		load_textdomain( 'wc-calypso-bridge', $mofile );
 	}


### PR DESCRIPTION
Fixes #573

As WordPress.com doesn't support CBD, this PR removes the option `CBD and other hemp-derived products` from the Industry step in the eCommerce plan.

### Screenshots
![screenshot-three wordpress test-2020 09 10-10_49_02](https://user-images.githubusercontent.com/1314156/92739491-54471080-f353-11ea-9122-247f7d47881a.png)


### Detailed test instructions:
To test this PR it's necessary to use a site with [wc-calypso-bridge](https://github.com/Automattic/wc-calypso-bridge) installed.
- Go to the industry step in the store profiler (URL: `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=industry`)
- Verify the option `CBD and other hemp-derived products` is not visible anymore.

- Be sure the tests are running ok.

_The changes related to the effects this modification will have on the payments methods will be handled in the WooCommerce Admin [PR 5124](https://github.com/woocommerce/woocommerce-admin/pull/5124)_

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Removed CBD from onboarding for eCommerce plan
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
