### PR TITLE
Replaced calypso header with wc-admin header

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2576,10 +2576,6 @@ h3#woocommerce_stripe_connection_status {
   line-height: unset !important;
   padding: 0 0 0 var(--large-gap) !important;
 }
-
-.woocommerce-layout__activity-panel-tabs {
-  height: 30px;
-}
 .woocommerce-layout {
   padding-top: 0px !important;
 }
@@ -2591,18 +2587,31 @@ h3#woocommerce_stripe_connection_status {
 .woocommerce-embed-page .woocommerce-layout__primary {
 	padding: 0;
 }
+
 .woocommerce-embed-page .wrap {
 	padding: 0;
 	padding-top: 15px !important;
 }
+
 .woocommerce-layout__primary {
 	margin: 0;
 }
+
 .woocommerce_page_wc-admin .wrap {
 	max-width: 100%;
 }
+
 .woocommerce-layout .woocommerce-layout__main {
 	padding-right: 0;
+}
+
+.woocommerce-layout__activity-panel {
+	top: 45px;
+}
+
+.woocommerce-layout__activity-panel .page-title-action {
+	margin: 0 5px 0 0 !important;
+	width: 100% !important;
 }
 
 .wc-setup-step__new_onboarding .wc-setup-step__new_onboarding-wrapper .wc-logo {

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2041,7 +2041,7 @@ form[name="cleanup_options"] fieldset label input[type="checkbox"] {
 .wp-admin .wrap > h2:nth-child(2) {
 	display: none;
 }
-.wp-admin .wrap h1, .wp-admin .wrap h2 {
+.wp-admin .wrap h2 {
 	padding-left: 0;
 }
 
@@ -2543,13 +2543,8 @@ h3#woocommerce_stripe_connection_status {
 
 /* WooCommerce Admin */
 .woocommerce-layout__header {
-  width: 100%;
-  min-height: 56px;
-  margin: 0 0 8px;
-  padding: 8px 16px 8px 0;
   display: -webkit-box;
   display: -ms-flexbox;
-  display: flex;
   -webkit-box-pack: start;
   -ms-flex-pack: start;
   justify-content: flex-start;
@@ -2566,7 +2561,7 @@ h3#woocommerce_stripe_connection_status {
   border-bottom: 1px solid #c8d7e1;
   position: fixed;
   z-index: 10000;
-  top: 46px;
+  top: 43px;
   left: 0px;
 }
 
@@ -2576,6 +2571,17 @@ h3#woocommerce_stripe_connection_status {
   line-height: unset !important;
   padding: 0 0 0 var(--large-gap) !important;
 }
+
+
+.woocommerce-layout__header-heading {
+	background: none !important;
+	height: 59px !important;
+}
+
+.woocommerce-layout__activity-panel-tabs button{
+	height: 57px !important;
+}
+
 .woocommerce-layout {
   padding-top: 0px !important;
 }

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2590,6 +2590,10 @@ h3#woocommerce_stripe_connection_status {
   margin: 20px !important;
 }
 
+.wrap {
+	display: none;
+}
+
 .woocommerce-embed-page .woocommerce-layout__primary {
 	padding: 0;
 }

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -783,7 +783,7 @@ html.wp-toolbar {
 	max-width: 1040px;
 }
 #adminmenu {
-	margin-top: 0;
+	margin-top: 9px;
 }
 @media screen and ( min-width: 661px ) {
 	html.wp-toolbar {
@@ -2589,6 +2589,7 @@ h3#woocommerce_stripe_connection_status {
 }
 .woocommerce-embed-page .wrap {
 	padding: 0;
+	padding-top: 15px !important;
 }
 .woocommerce-layout__primary {
 	margin: 0;

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -810,32 +810,17 @@ html.wp-toolbar {
 
 /* Action header */
 .action-header {
-	width: 100%;
-	min-height: 47px;
-	margin: 0 0 8px;
-	padding: 8px 16px 8px 0;
-	display: -webkit-box;
-	display: -ms-flexbox;
-	display: flex;
-	-webkit-box-pack: start;
-	-ms-flex-pack: start;
-	justify-content: flex-start;
-	-webkit-box-orient: horizontal;
-	-webkit-box-direction: normal;
-	-ms-flex-direction: row;
-	flex-direction: row;
-	-webkit-box-align: center;
-	-ms-flex-align: center;
-	align-items: center;
-	-webkit-box-sizing: border-box;
-	box-sizing: border-box;
-	color: #2e4453;
-	background: #fff;
-	border-bottom: 1px solid #c8d7e1;
-	position: fixed;
-	z-index: 10000;
-	top: 46px;
-	left: 0px;
+  width: 100%;
+  min-height: 56px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  color: #2e4453;
+  background: #fff;
+  border-bottom: 1px solid #c8d7e1;
+  position: fixed;
+  z-index: 10000;
+  top: 46px;
+  left: 0px;
 }
 @media screen and ( min-width: 481px ) {
 	.action-header {
@@ -2554,7 +2539,49 @@ h3#woocommerce_stripe_connection_status {
 
 /* WooCommerce Admin */
 .woocommerce-layout__header {
-	display: none;
+  width: 100%;
+  min-height: 56px;
+  margin: 0 0 8px;
+  padding: 8px 16px 8px 0;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  color: #2e4453;
+  border-bottom: 1px solid #c8d7e1;
+  position: fixed;
+  z-index: 10000;
+  top: 46px;
+  left: 0px;
+}
+
+.woocommerce-layout__header-breadcrumbs {
+  flex: unset !important;
+  height: unset !important;
+  line-height: unset !important;
+  padding: 0 0 0 var(--large-gap) !important;
+}
+
+.woocommerce-layout__activity-panel-tabs {
+  height: 30px;
+}
+.woocommerce-layout {
+  padding-top: 0px !important;
+}
+
+.woocommerce-store-alerts {
+  margin: 20px !important;
 }
 
 .woocommerce-embed-page .woocommerce-layout__primary {

--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -1495,6 +1495,10 @@ table.widefat {
 	display: none;
 }
 
+.submit > .taxonomy-edit-cancel-button {
+	margin-left: 15px;
+}
+
 /* WooCommerce Admin Onboarding */
 .woocommerce-admin-full-screen #wpcontent {
 	padding: 0;

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -52,6 +52,34 @@
 	} );
 // @todo End
 
+  /**
+   * Get the URL params.
+   */
+  function getUrlParams( locationSearch ) {
+    if ( locationSearch ) {
+      return locationSearch
+        .substr( 1 )
+        .split( '&' )
+        .reduce( ( params, query ) => {
+          const chunks = query.split( '=' );
+          const key = chunks[ 0 ];
+          let value = decodeURIComponent( chunks[ 1 ] );
+          value = isNaN( Number( value ) ) ? value : Number( value );
+          return ( params[ key ] = value ), params;
+        }, {} );
+    }
+    return {};
+  }
+  
+  /**
+   * Move page actions to action header.
+   */
+  const searchParams = getUrlParams( window.location.search );
+  if ( searchParams.post_type?.includes( 'product' ) ) {
+    $( '.page-title-action, .add-new-h2' ).prependTo( '#col-container' );
+  }
+
+
 	/**
 	 * Move notices on pages with sub navigation.
 	 *
@@ -93,6 +121,8 @@
 		$( '#col-container > #col-right' ).toggle();
 		$( '.taxonomy-form-toggle' ).toggle();
 		$( '.wrap .search-form' ).toggle();
+		$( '.col-wrap > .taxonomy-form-cancel-button').toggle();
+		$( 'form > .taxonomy-form-cancel-button').toggle();
 		$( '.form-wrap h2:first' ).hide();
 		const formTitle = $( '.form-wrap h2:first' ).text();
 		if ( ! $( '#breadcrumb-taxonomy' ).length ) {
@@ -129,7 +159,7 @@
 	/**
 	 * Add cancel button to taxonomy edit forms.
 	 */
-	$( '.edit-tag-actions .button:first' ).after(
+	$( '#submit' ).after(
 		'<a href="' + ( 'undefined' !== typeof taxonomy ? taxonomy.listUrl : '#' ) + '" class="button button-secondary button-large taxonomy-edit-cancel-button">' + translations.cancel + '</a>'
 	);
 

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -52,33 +52,30 @@
 	} );
 // @todo End
 
-  /**
-   * Get the URL params.
-   */
-  function getUrlParams( locationSearch ) {
-    if ( locationSearch ) {
-      return locationSearch
-        .substr( 1 )
-        .split( '&' )
-        .reduce( ( params, query ) => {
-          const chunks = query.split( '=' );
-          const key = chunks[ 0 ];
-          let value = decodeURIComponent( chunks[ 1 ] );
-          value = isNaN( Number( value ) ) ? value : Number( value );
-          return ( params[ key ] = value ), params;
-        }, {} );
-    }
-    return {};
-  }
-  
-  /**
-   * Move page actions to action header.
-   */
-  const searchParams = getUrlParams( window.location.search );
-  if ( searchParams.post_type?.includes( 'product' ) ) {
-    $( '.page-title-action, .add-new-h2' ).prependTo( '#col-container' );
-  }
-
+	/**
+	 * Move page actions to action header.
+	 */
+	$( document ).ready( function() {
+		const $actions = $( '.page-title-action, .add-new-h2' );
+		if ( ! $actions.is( 'button' ) ) {
+			const buttons = [];
+			$actions.each( function( index, anAction ) {
+				const { className, href, text } = anAction;
+				const button = $( '<button/>' ,{
+					class: 'button button-primary',
+					text,
+				} );
+				buttons.push( $( '<a/>' ,{
+			  	class: className,
+					href
+				} ).append( button ) );
+			} );
+			$( '.woocommerce-layout__activity-panel' ).prepend( buttons );
+			$actions.remove();
+		} else {
+			$actions.prependTo( '.woocommerce-layout__activity-panel' );
+		}
+	} );
 
 	/**
 	 * Move notices on pages with sub navigation.

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -52,6 +52,14 @@
 	} );
 // @todo End
 
+
+	/**
+	 * Show content wrapper.
+	 */
+	$( document ).ready( function() {
+		$( '.wrap' ).fadeIn();
+	} );
+
 	/**
 	 * Move page actions to action header.
 	 */

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -56,18 +56,17 @@
 	 * Move page actions to action header.
 	 */
 	$( document ).ready( function() {
-		const $actions = $( '.page-title-action, .add-new-h2' );
+		var $actions = $( '.page-title-action, .add-new-h2' );
 		if ( ! $actions.is( 'button' ) ) {
-			const buttons = [];
+			var buttons = [];
 			$actions.each( function( index, anAction ) {
-				const { className, href, text } = anAction;
-				const button = $( '<button/>' ,{
+				var button = $( '<button/>' ,{
 					class: 'button button-primary',
-					text,
+					text: anAction.text,
 				} );
 				buttons.push( $( '<a/>' ,{
-			  	class: className,
-					href
+			  	class: anAction.className,
+					href: anAction.href
 				} ).append( button ) );
 			} );
 			$( '.woocommerce-layout__activity-panel' ).prepend( buttons );
@@ -96,8 +95,8 @@
 	 */
 	$( document ).ready( function() {
 		$( '#wpbody-content .subsubsub, #wpbody-content .nav-tab-wrapper' ).each( function() {
-			const currentText = $( this ).find( 'a.current, .nav-tab-active' ).text();
-			const $toggle = $( '<div class="nav-tab-toggle"><span class="nav-tab-toggle__current-page">' + currentText + '</span>' + icons.chevronDown + '</div>' );
+			var currentText = $( this ).find( 'a.current, .nav-tab-active' ).text();
+			var $toggle = $( '<div class="nav-tab-toggle"><span class="nav-tab-toggle__current-page">' + currentText + '</span>' + icons.chevronDown + '</div>' );
 			$( this ).wrap( '<div class="nav-tab-container"></div>' );
 			$( this ).before( $toggle );
 		} );
@@ -121,7 +120,7 @@
 		$( '.col-wrap > .taxonomy-form-cancel-button').toggle();
 		$( 'form > .taxonomy-form-cancel-button').toggle();
 		$( '.form-wrap h2:first' ).hide();
-		const formTitle = $( '.form-wrap h2:first' ).text();
+		var formTitle = $( '.form-wrap h2:first' ).text();
 		if ( ! $( '#breadcrumb-taxonomy' ).length ) {
 			$( '.action-header__breadcrumbs' ).append(
 				'<span id="breadcrumb-taxonomy" style="display: none;">' + formTitle + '</span>'
@@ -235,9 +234,9 @@
 	function appendInputsToForm( e ) {
 		if ( e.type === 'click' || e.which === 13 ) {
 			e.preventDefault();
-			const formId = $( this ).closest( '.search-box' ).data( 'target-form-id' );
-			const $form = $( 'form[data-form-id="' + formId + '"' );
-			const $searchInput = $( this ).closest( '.search-box' ).find( 'input[type="search"]' );
+			var formId = $( this ).closest( '.search-box' ).data( 'target-form-id' );
+			var $form = $( 'form[data-form-id="' + formId + '"' );
+			var $searchInput = $( this ).closest( '.search-box' ).find( 'input[type="search"]' );
 			$( '<input>' ).attr( {
 					type: 'hidden',
 					id: $searchInput.attr( 'id' ),
@@ -305,7 +304,7 @@
 	 * Table scrolling shadow.
 	 */
 	function checkTableScroll() {
-		const scrolledToEnd = $( this )[0].scrollWidth - $( this )[0].scrollLeft <= $( this )[0].offsetWidth;
+		var scrolledToEnd = $( this )[0].scrollWidth - $( this )[0].scrollLeft <= $( this )[0].offsetWidth;
 		if ( ! scrolledToEnd ) {
 			$( this ).parent().addClass( 'is-scrollable' )
 		} else {
@@ -376,8 +375,8 @@
 	 * Support link click event.
 	 */
 	$( '.wc-support-link' ).unbind( 'click' ).click( function( e ) {
-		const source = $( this ).data( 'source' )
-		const href = $( this ).attr( 'href' );
+		var source = $( this ).data( 'source' )
+		var href = $( this ).attr( 'href' );
 		trackSupportClick( source, href );
 	} );
 

--- a/assets/js/calypsoify.js
+++ b/assets/js/calypsoify.js
@@ -53,11 +53,6 @@
 // @todo End
 
 	/**
-	 * Move page actions to action header.
-	 */
-	$( '.page-title-action, .add-new-h2' ).appendTo( '#action-header .action-header__actions' );
-
-	/**
 	 * Move notices on pages with sub navigation.
 	 *
 	 * WP Core moves notices with jQuery so this is needed to move them again since
@@ -123,11 +118,6 @@
 	$( window ).on( 'popstate', function( e ) {
 		toggleTaxonomyForm();
 	} );
-
-	/**
-	 * Move cancel button.
-	 */
-	$( '.taxonomy-form-cancel-button' ).appendTo( 'p.submit' );
 
 	/**
 	 * Product attributes form is not AJAX'ed so toggle back if any errors.

--- a/includes/class-wc-calypso-bridge-action-header.php
+++ b/includes/class-wc-calypso-bridge-action-header.php
@@ -127,37 +127,6 @@ class WC_Calypso_Bridge_Action_Header {
 	}
 
 	/**
-	 * Get array of breadcrumbs
-	 *
-	 * @return array
-	 */
-	public function get_crumbs() {
-		global $submenu, $menu, $pagenow, $wp;
-		$crumbs      = array( array( 'name' => get_admin_page_title() ) );
-		$page_parent = get_admin_page_parent();
-
-		$parent = false;
-		foreach ( $menu as $top_level_menu_item ) {
-			$parent_name = ! empty( $top_level_menu_item[3] ) ? $top_level_menu_item[3] : $top_level_menu_item[0];
-			if ( $top_level_menu_item[2] === $page_parent && $crumbs[0]['name'] !== $parent_name ) {
-				$parent = $top_level_menu_item;
-				break;
-			}
-		}
-
-		if ( $parent ) {
-			array_unshift(
-				$crumbs,
-				array(
-					'name' => $parent_name,
-					'url'  => $this->get_parent_url( $parent[2] ),
-				)
-			);
-		}
-		return $crumbs;
-	}
-
-	/**
 	 * Get parent page URL from slug
 	 *
 	 * @param string $parent_menu_slug Parent page slug.
@@ -177,28 +146,6 @@ class WC_Calypso_Bridge_Action_Header {
 			}
 		}
 		return null;
-	}
-
-	/**
-	 * Breadcrumbs
-	 */
-	public function breadcrumbs() {
-		$crumbs = $this->get_crumbs();
-		?>
-		<div class="action-header__breadcrumbs">
-			<?php foreach ( $crumbs as $crumb ) { ?>
-				<span>
-					<?php if ( isset( $crumb['url'] ) ) { ?>
-						<a href="<?php echo esc_url( admin_url( $crumb['url'] ) ); ?>">
-					<?php } ?>
-						<?php echo esc_html( wp_strip_all_tags( $crumb['name'] ) ); ?>
-					<?php if ( isset( $crumb['url'] ) ) { ?>
-						</a>
-					<?php } ?>
-				</span>
-			<?php } ?>
-		</div>
-		<?php
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-action-header.php
+++ b/includes/class-wc-calypso-bridge-action-header.php
@@ -45,17 +45,7 @@ class WC_Calypso_Bridge_Action_Header {
 	 */
 	public function render_action_header() {
 		?>
-		<div class="action-header" id="action-header">
-			<?php $this->back_button(); ?>
-			<div class="action-header__content">
-				<?php $this->site_icon(); ?>
-				<div class="action-header__details">
-					<?php $this->site_title(); ?>
-					<?php $this->breadcrumbs(); ?>
-				</div>
-			</div>
-			<div class="action-header__actions"></div>
-		</div>
+		<div class="action-header" id="action-header"></div>
 		<?php
 	}
 


### PR DESCRIPTION
Fixes #592

This PR changes the header for eCommerce customers using Calypso.

Details:
- Replaces the Calypso top nav bar on all pages with WooCommerce Admin header
- Moves action buttons to the navbar.

### Screenshots
![screenshot-three wordpress test-2020 09 29-12_35_12](https://user-images.githubusercontent.com/1314156/94580573-76e09100-0250-11eb-97e6-f05fbce605d1.png)



### Detailed test instructions:
- Go to `WooCommerce` | `Products` (URL: `/wp-admin/edit.php?post_type=product`).
- Verify the action buttons are visible in the navbar.
- Same in `WooCommerce` | `Marketing` | `Coupons` (URL: `/wp-admin/edit.php?post_type=shop_coupon`) and `WooCommerce`  | `Orders` (URL: `/wp-admin/edit.php?post_type=shop_order`)
- Go to `WooCommerce` | `Products` | `Product categories` (URL: `/wp-admin/edit-tags.php?taxonomy=product_cat&post_type=product`).
- Verify the button `Add` is visible in the navbar.
- Press it.
- Verify the form is visible.
- Verify the button `Cancel` is alongside the `Add new category` button and the `Add` button is not visible anymore.
- Press `Cancel`.
- Verify the form is not visible anymore and the `Add` button is back in the navbar.
- Same in `WooCommerce` | `Products` | `Product tags` (URL: `/wp-admin/edit-tags.php?taxonomy=product_tag&post_type=product`) and in `WooCommerce` | `Products` | `Attributes` (URL: `/wp-admin/edit.php?post_type=product&page=product_attributes`).



<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Replaced Calypso header with WooCommerce Admin header and moved action buttons to header.
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
