### PR TITLE
Onboarding: Hide pricing toggle via css.

### DIFF
--- a/assets/css/calypsoify.css
+++ b/assets/css/calypsoify.css
@@ -2655,7 +2655,7 @@ h3#woocommerce_stripe_connection_status {
 	border-color: #007cba;
 }
 
-/* New WooCommerce Onboarding resets to play nicely with Calypsoify */
+/* New WooCommerce Onboarding resets to play nicely with Calypsoify and also hides some functionality we don't want on the ecomm plan*/
 .woocommerce-profile-wizard__body label, .woocommerce-task-dashboard__container label {
 	font-weight: normal;
 }
@@ -2787,5 +2787,10 @@ body.woocommerce-page .components-form-toggle.is-checked .components-form-toggle
 }
 /* Hides Theme Tabs ( All | Free | Paid ) since we only show installed themes */
 .woocommerce-profile-wizard__body .woocommerce-profile-wizard__themes-tab-panel .components-tab-panel__tabs {
+	display: none;
+}
+
+/* Hides pricing toggle on Profiler > Product Types */
+.woocommerce-profile-wizard__body .woocommerce-profile-wizard__product-types .woocommerce-card__body .woocommerce-profile-wizard__product-types-pricing-toggle.woocommerce-profile-wizard__checkbox {
 	display: none;
 }


### PR DESCRIPTION
Fixes #606 

This branch adds in some very specific css to hide the pricing toggle on the Product Types step of the profiler.

__Before__
<img width="940" alt="toggle-before" src="https://user-images.githubusercontent.com/22080/96160981-8b1cc300-0ecb-11eb-90a8-18fa12a985cc.png">

__After__
<img width="915" alt="toggle-gone" src="https://user-images.githubusercontent.com/22080/96161002-9112a400-0ecb-11eb-8086-ffba20e4cdfa.png">

__To Test__
- Setup your local environment to be using calypsoify
- Apply this branch and launch the profile wizard `/wp-admin/admin.php?page=wc-admin&reset_profiler=1`
- Verify you do not see the pricing toggle anymore.

Note: For me firefox would not let go of the old cached version of `calypsoify.css`.  You might need to manually clear your browser cache, use an incognito window, or change the version number [being used here](https://github.com/Automattic/wc-calypso-bridge/blob/master/class-wc-calypso-bridge.php#L246) to PHP's `time()` to constantly force a cache bust.