### PR TITLE
Change redirect of onboarding logic.

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -339,7 +339,7 @@ class WC_Calypso_Bridge {
 		) {
 			if ( 1 !== (int) get_user_meta( get_current_user_id(), 'calypsoify', true ) ) {
 				update_user_meta( get_current_user_id(), 'calypsoify', 1 );
-				wp_safe_redirect( admin_url( 'admin.php?page=wc-setup' ) );
+				wp_safe_redirect( admin_url( 'admin.php?page=wc-admin&path=/setup-wizard' ) );
 				exit;
 			}
 		}

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -339,9 +339,9 @@ class WC_Calypso_Bridge {
 		) {
 			if ( 1 !== (int) get_user_meta( get_current_user_id(), 'calypsoify', true ) ) {
 				update_user_meta( get_current_user_id(), 'calypsoify', 1 );
-				wp_safe_redirect( admin_url( 'admin.php?page=wc-admin&path=/setup-wizard' ) );
-				exit;
 			}
+			wp_safe_redirect( admin_url( 'admin.php?page=wc-admin&path=/setup-wizard' ) );
+			exit;
 		}
 	}
 


### PR DESCRIPTION
Fixes #608

This seems to be another instance of the legacy OBW being deprecated in 4.6 causing a little bit of a bug. The logic being changed here is what listens for the incoming request when a user first finishes their purchase of an eCommerce Plan. The logic then forces the calypsoify view, and redirects to the OBW.

The change proposed here is to change the final redirect location to the OBW Profile wizard, not the legacy onboarding URL which was still being redirected by Woo core up until 4.6.

__Before__
![image](https://user-images.githubusercontent.com/22080/96481030-d696e000-11ef-11eb-937e-19e35ab967c9.png)

__After__
![image](https://user-images.githubusercontent.com/22080/96481268-2b3a5b00-11f0-11eb-8e82-9b7f752c6ad4.png)

__To Test__
You can test this out locally by setting up your site with WooCommerce 4.6, wc-calypso-bridge, and "activate" the ecommerce plan using the helper plugin ( https://wp.me/p90Yrv-1O5 )

- Using `master` of `wc-calypso-bridge` first verify the bug so you can confirm the fix here is functional. You can do this by visiting `/wp-admin/?page=wc-setup&calypsoify=1` you should see a screen like the before above.
- Next checkout this branch of `wc-calypso-bridge`, re-visit `/wp-admin/?page=wc-setup&calypsoify=1` and confirm you are redirected to the Profiler OBW. Proceed to the Product Types step and verify that no up-sells are sold ( after screenshot above ). This means you are in the calypsoified OBW.