### PR TITLE
 Enable navigation feature by default

### DIFF
--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -35,9 +35,10 @@ class WC_Calypso_Bridge_Setup {
 	 * Constructor.
 	 */
 	private function __construct() {
-		add_filter( 'default_option_woocommerce_onboarding_profile', array( $this, 'set_business_extensions_empty' ), 10, 1 );
-		add_filter( 'option_woocommerce_onboarding_profile', array( $this, 'set_business_extensions_empty' ), 10, 1 );
-		add_filter( 'woocommerce_admin_onboarding_themes', array( $this, 'remove_non_installed_themes' ), 10, 1 );
+		add_filter( 'default_option_woocommerce_onboarding_profile', array( $this, 'set_business_extensions_empty' ) );
+		add_filter( 'default_option_woocommerce_navigation_enabled', array( $this, 'enable_navigation_by_default' ) );
+		add_filter( 'option_woocommerce_onboarding_profile', array( $this, 'enable_navigation_by_default' ) );
+		add_filter( 'woocommerce_admin_onboarding_themes', array( $this, 'remove_non_installed_themes' ) );
 		add_filter( 'wp_redirect', array( $this, 'prevent_mailchimp_redirect' ), 10, 2 );
 		add_filter( 'woocommerce_admin_onboarding_product_types', array( $this, 'remove_paid_extension_upsells' ), 10, 2 );
 		add_filter( 'pre_option_woocommerce_homescreen_enabled', array( $this, 'always_enable_homescreen' ) );
@@ -107,6 +108,15 @@ class WC_Calypso_Bridge_Setup {
 		}
 
 		return $option;
+	}
+
+	/**
+	 * Enable the navigation feature by default.
+	 *
+	 * @return string
+	 */
+	public function enable_navigation_by_default() {
+		return 'yes';
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -50,6 +50,10 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 			$features[] = 'remote-inbox-notifications';
 		}
 
+		if ( ! array_key_exists( 'navigation', $features ) && 'yes' === get_option( 'woocommerce_navigation_enabled', 'yes' ) ) {
+			$features[] = 'navigation';
+		}
+
 		return $features;
 	}
 


### PR DESCRIPTION
Turns on the navigation by default when the ecomm plan is on, but allows it to be toggled on/off.

### Screenshot
<img width="629" alt="Screen Shot 2020-10-28 at 10 45 17 AM" src="https://user-images.githubusercontent.com/10561050/97452013-aeebfa00-190a-11eb-9435-ab4e0ea3c819.png">


### Testing

1. Make sure you're running a version of WCA that has trhe nav feature.
1. Delete the `woocommerce_navigation_enabled` option from your database.
1. Deactivate the bridge or opt out of the ecomm plan option.
1. Make sure the new nav is not shown.
1. Opt in to the new ecomm plan and make sure the new navigation is shown on WC pages by default.
1. Navigate to Settings->Advanced->Features ( `wp-admin/admin.php?page=wc-settings&tab=advanced&section=features` ) and make sure you can toggle the nav feature on/off.
1. Note that an extra refresh may be required to see your settings (this is an old bug that has regressed and will need to be addressed in a follow-up).