### PR TITLE
Atomic: Update how we fetch the plan slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,7 @@ add_filter( 'jetpack_tools_to_include', function( $tools ) {
 } );
 ```
 
-To make the bridge work, the site must have the ecommerce plan option set under the `at_options` option:
-
-```
-update_option( 'at_options', array( 'plan_slug' => 'ecommerce' ) );
-```
+To make bridge work, the site must have the eCommerce plan.
 
 Clicking the "I'm Done Setting Up" button on the Setup Checklist page will mark the option `atomic-ecommerce-setup-checklist-complete` as true.  If you need to access this page again, you can update this in your database or temporarily add the following to your plugin file:
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v1.5.0",
+  "version": "v1.5.1",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 1.5.0
+Stable tag: 1.5.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ This section describes how to install the plugin and get it working.
 1. Activate the plugin through the 'Plugins' screen in WordPress
 
 == Changelog ==
+
+= 1.5.1 =
+* Atomic: Change how we check the plan data
 
 = 1.5.0 =
 * Onboarding: Hide CBD option

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 1.5.0
+ * Version: 1.5.1
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -30,7 +30,7 @@ if ( file_exists( WP_PLUGIN_DIR . '/wc-calypso-bridge/wc-calypso-bridge.php' ) )
 	}
 }
 
-define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.5.0' );
+define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.5.1' );
 define( 'WC_MIN_VERSION', '3.0.0' );
 
 if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_plan' ) ) {

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -42,7 +42,7 @@ if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_plan' ) ) {
 	 * @return bool True if the site is an ecommerce site.
 	 */
 	function wc_calypso_bridge_is_ecommerce_plan() {
-		if ( class_exists( 'Atomic_Plan_Manager' ) ) {
+		if ( class_exists( 'Atomic_Plan_Manager' ) && method_exists( 'Atomic_Plan_Manager', 'current_plan_slug' ) ) {
 			return Atomic_Plan_Manager::current_plan_slug() === Atomic_Plan_Manager::ECOMMERCE_PLAN_SLUG;
 		}
 

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -42,10 +42,8 @@ if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_plan' ) ) {
 	 * @return bool True if the site is an ecommerce site.
 	 */
 	function wc_calypso_bridge_is_ecommerce_plan() {
-		$at_options = get_option( 'at_options', array() );
-
-		if ( array_key_exists( 'plan_slug', $at_options ) && 'ecommerce' === $at_options['plan_slug'] ) {
-			return true;
+		if ( class_exists( 'Atomic_Plan_Manager' ) ) {
+			return Atomic_Plan_Manager::current_plan_slug() === Atomic_Plan_Manager::ECOMMERCE_PLAN_SLUG;
 		}
 
 		return false;


### PR DESCRIPTION
Add a future proof method for checking if an Atomic site is on the eCommerce plan.