### PR TITLE
Add feature toggles if they don't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ update_option( 'at_options', array( 'plan_slug' => 'ecommerce' ) );
 ```
 >>>>>>> 198c79f... Remove remaining references to calypsoify
 
+<<<<<<< HEAD
 `add_filter( 'jetpack_offline_mode', '__return_true' );`
 
 To make bridge work, the site must have the eCommerce plan.
@@ -56,6 +57,8 @@ update_option( 'woocommerce_setup_ab_wc_admin_onboarding', 'a' );
 update_option( 'wc_onboarding_opt_in', 'no' );
 ```
 
+=======
+>>>>>>> ce907b7... Delete bridge setup checklist
 If you would like to skip all of the above, [just download this gist](https://gist.github.com/timmyc/72061e99f2e6893a94845ba93e6db6ca) as a plugin and activate it :).
 
 <<<<<<< HEAD

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You will need either a connected Jetpack site or use the following filter to for
 =======
 You will need either a connected Jetpack site or use the following filter to force Jetpack into development mode:
 
-`add_filter( 'jetpack_development_mode', '__return_true' );`
+`add_filter( 'jetpack_offline_mode', '__return_true' );`
 
 To make the bridge work, the site must have the ecommerce plan option set under the `at_options` option:
 

--- a/README.md
+++ b/README.md
@@ -30,22 +30,9 @@ To use the ecommerce plan changes in the dashboard and test various functionalit
 Note that the plugin expects to find these plugins in their original folders, so renaming these folders may prevent the plugin from running.
 
 #### Jetpack Connection && Option Values
-<<<<<<< HEAD
 
 You will need either a connected Jetpack site or use the following filter to force Jetpack into development mode:
-=======
-You will need either a connected Jetpack site or use the following filter to force Jetpack into development mode:
 
-`add_filter( 'jetpack_offline_mode', '__return_true' );`
-
-To make the bridge work, the site must have the ecommerce plan option set under the `at_options` option:
-
-```
-update_option( 'at_options', array( 'plan_slug' => 'ecommerce' ) );
-```
->>>>>>> 198c79f... Remove remaining references to calypsoify
-
-<<<<<<< HEAD
 `add_filter( 'jetpack_offline_mode', '__return_true' );`
 
 To make bridge work, the site must have the eCommerce plan.
@@ -57,14 +44,8 @@ update_option( 'woocommerce_setup_ab_wc_admin_onboarding', 'a' );
 update_option( 'wc_onboarding_opt_in', 'no' );
 ```
 
-=======
->>>>>>> ce907b7... Delete bridge setup checklist
 If you would like to skip all of the above, [just download this gist](https://gist.github.com/timmyc/72061e99f2e6893a94845ba93e6db6ca) as a plugin and activate it :).
 
-<<<<<<< HEAD
-=======
-
->>>>>>> 198c79f... Remove remaining references to calypsoify
 ### Plugin Integrations
 
 The ecommerce plan comes bundled with a number of plugins that this plugin integrates with if activated. To fully test this plugin's functionality, the following plugins can be installed.

--- a/README.md
+++ b/README.md
@@ -30,8 +30,20 @@ To use the ecommerce plan changes in the dashboard and test various functionalit
 Note that the plugin expects to find these plugins in their original folders, so renaming these folders may prevent the plugin from running.
 
 #### Jetpack Connection && Option Values
+<<<<<<< HEAD
 
 You will need either a connected Jetpack site or use the following filter to force Jetpack into development mode:
+=======
+You will need either a connected Jetpack site or use the following filter to force Jetpack into development mode:
+
+`add_filter( 'jetpack_development_mode', '__return_true' );`
+
+To make the bridge work, the site must have the ecommerce plan option set under the `at_options` option:
+
+```
+update_option( 'at_options', array( 'plan_slug' => 'ecommerce' ) );
+```
+>>>>>>> 198c79f... Remove remaining references to calypsoify
 
 `add_filter( 'jetpack_offline_mode', '__return_true' );`
 
@@ -46,6 +58,10 @@ update_option( 'wc_onboarding_opt_in', 'no' );
 
 If you would like to skip all of the above, [just download this gist](https://gist.github.com/timmyc/72061e99f2e6893a94845ba93e6db6ca) as a plugin and activate it :).
 
+<<<<<<< HEAD
+=======
+
+>>>>>>> 198c79f... Remove remaining references to calypsoify
 ### Plugin Integrations
 
 The ecommerce plan comes bundled with a number of plugins that this plugin integrates with if activated. To fully test this plugin's functionality, the following plugins can be installed.

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -37,6 +37,8 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 		}
 
 		add_filter( 'woocommerce_admin_features', array( $this, 'filter_wc_admin_enabled_features' ) );
+		add_filter( 'woocommerce_get_sections_advanced', array( __CLASS__, 'add_features_section' ) );
+		add_filter( 'woocommerce_get_settings_advanced', array( __CLASS__, 'add_features_settings' ), 20, 2 );
 	}
 
 	/**
@@ -55,6 +57,67 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 		}
 
 		return $features;
+	}
+
+	/**
+	 * Adds the Features section to the advanced tab of WooCommerce Settings
+	 *
+	 * @todo This should be removed once the WC version included with the ecommerce plan contains the bundled version of WCA 1.8.3.
+	 *
+	 * @param array $sections Sections.
+	 * @return array
+	 */
+	public static function add_features_section( $sections ) {
+		if ( ! isset( $sections['features'] ) ) {
+			$sections['features'] = __( 'Features', 'woocommerce-admin' );
+		}
+
+		return $sections;
+	}
+
+
+	/**
+	 * Adds the Features settings if it doesn't exist.
+	 *
+	 * @todo This should be removed once the WC version included with the ecommerce plan contains the bundled version of WCA 1.8.3.
+	 *
+	 * @param array  $settings Settings.
+	 * @param string $current_section Current section slug.
+	 * @return array
+	 */
+	public static function add_features_settings( $settings, $current_section ) {
+		if ( 'features' !== $current_section ) {
+			return $settings;
+		}
+
+		// Bail if the features section has alread been added.
+		foreach ( $settings as $setting ) {
+			if ( 'features_options' === $setting['id'] ) {
+				return $settings;
+			}
+		}
+
+		return apply_filters(
+			'woocommerce_settings_features',
+			array(
+				array(
+					'title' => __( 'Features', 'woocommerce-admin' ),
+					'type'  => 'title',
+					'desc'  => __( 'Start using new features that are being progressively rolled out to improve the store management experience.', 'woocommerce-admin' ),
+					'id'    => 'features_options',
+				),
+				array(
+					'title' => __( 'Navigation', 'woocommerce-admin' ),
+					'desc'  => __( 'Adds the new WooCommerce navigation experience to the dashboard', 'woocommerce-admin' ),
+					'id'    => 'woocommerce_navigation_enabled',
+					'type'  => 'checkbox',
+				),
+				array(
+					'type' => 'sectionend',
+					'id'   => 'features_options',
+				),
+			)
+		);
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -37,7 +37,7 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 		}
 
 		add_filter( 'woocommerce_admin_features', array( $this, 'filter_wc_admin_enabled_features' ) );
-		add_filter( 'woocommerce_get_sections_advanced', array( __CLASS__, 'add_features_section' ) );
+		add_filter( 'woocommerce_get_sections_advanced', array( __CLASS__, 'add_features_section' ), 20 );
 		add_filter( 'woocommerce_get_settings_advanced', array( __CLASS__, 'add_features_settings' ), 20, 2 );
 	}
 


### PR DESCRIPTION
Fixes #625

Adds in feature toggles if they don't exist in WCA.

### Screenshot
<img width="748" alt="Screen Shot 2021-01-06 at 2 38 27 PM" src="https://user-images.githubusercontent.com/10561050/103812761-01454780-502d-11eb-9713-cc1780050977.png">


### Testing

1. Make sure this branch works without error in the latest `main` of WCA.
2. Check out a branch of WCA that does not contain the feature toggles or comment them out in: https://github.com/woocommerce/woocommerce-admin/blob/c79542c6c6de3755abf5bceca9cefe22674ad9e9/src/Loader.php#L64-L65
3. Check that the features tab still exists under ecomm plans and that navigation can be toggled on/off.