### PR TITLE
Filter the nav back URL for ecomm plan users

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -112,6 +112,7 @@ class WC_Calypso_Bridge {
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-addons-screen.php';
 		include_once dirname( __FILE__ ) . '/includes/gutenberg.php';
 		require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-woocommerce-admin.php';
+		require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-woocommerce-admin-navigation.php';
 		require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-notes.php';
 
 		// Shared with store-on-wpcom.

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-navigation.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-navigation.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Modify the navigation to fit the bridge needs.
+ *
+ * @package WC_Calypso_Bridge/Classes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Calypso_Bridge_WooCommerce_Admin_Navigation
+ */
+class WC_Calypso_Bridge_WooCommerce_Admin_Navigation {
+
+	/**
+	 * Class Instance.
+	 *
+	 * @var WC_Calypso_Bridge_WooCommerce_Admin_Navigation instance
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Get class instance
+	 */
+	public static function get_instance() {
+		if ( ! static::$instance ) {
+			static::$instance = new static();
+		}
+		return static::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_filter( 'woocommerce_navigation_root_back_url', array( $this, 'add_calypso_url' ) );
+	}
+
+	/**
+	 * Add calypso URL.
+	 */
+	public static function add_calypso_url() {
+		$strip_http = '/.*?:\/\//i';
+		$site_slug  = preg_replace( $strip_http, '', get_home_url() );
+		$site_slug  = str_replace( '/', '::', $site_slug );
+
+		$store_url = 'https://wordpress.com/home/' . $site_slug;
+		return $store_url;
+	}
+}
+
+WC_Calypso_Bridge_WooCommerce_Admin_Navigation::get_instance();


### PR DESCRIPTION
Fixes #633 

Filters the back URL used in the new navigation experience to redirect back to the Calypso dashboard.

@pmcpinto Do we also want to change the text from "WordPress Dashboard" on this back button or leave it as is?

### Screenshots
<img width="298" alt="Screen Shot 2021-01-15 at 3 10 13 PM" src="https://user-images.githubusercontent.com/10561050/104773985-e2893400-5743-11eb-844a-5e3b26fb9151.png">


### Testing

1. Create an ecomm plan site.
2. Load a WC page.
3. Navigate to the root of the navigation and click the back button "WordPress Dashboard"
4. Make sure this takes you to the site's Calypso dashboard. `http://wordpress.com/home/yoursite.com`