### PR TITLE
Notes: Prevent email notifications from being sent.

### DIFF
--- a/includes/class-wc-calypso-bridge-filters.php
+++ b/includes/class-wc-calypso-bridge-filters.php
@@ -69,7 +69,7 @@ class WC_Calypso_Bridge_Filters {
 	/**
 	 * Disable email based notifications.
 	 */
-	function disable_email_notes(){
+	public function disable_email_notes() {
 		return 'no';
 	}
 }

--- a/includes/class-wc-calypso-bridge-filters.php
+++ b/includes/class-wc-calypso-bridge-filters.php
@@ -38,7 +38,7 @@ class WC_Calypso_Bridge_Filters {
 		add_action( 'woocommerce_admin_onboarding_industries', array( $this, 'remove_not_allowed_industries' ), 10, 1 );
 
 		// Turn off email notifications.
-		//add_filter( 'pre_option_woocommerce_merchant_email_notifications', array( $this, 'disable_email_notes' ) );
+		add_filter( 'pre_option_woocommerce_merchant_email_notifications', array( $this, 'disable_email_notes' ) );
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-filters.php
+++ b/includes/class-wc-calypso-bridge-filters.php
@@ -36,6 +36,9 @@ class WC_Calypso_Bridge_Filters {
 	 */
 	private function __construct() {
 		add_action( 'woocommerce_admin_onboarding_industries', array( $this, 'remove_not_allowed_industries' ), 10, 1 );
+
+		// Turn off email notifications.
+		//add_filter( 'pre_option_woocommerce_merchant_email_notifications', array( $this, 'disable_email_notes' ) );
 	}
 
 	/**
@@ -61,6 +64,13 @@ class WC_Calypso_Bridge_Filters {
 	 */
 	public function filter_industries( $industry ) {
 		return 'cbd-other-hemp-derived-products' !== $industry['slug'];
+	}
+
+	/**
+	 * Disable email based notifications.
+	 */
+	function disable_email_notes(){
+		return 'no';
 	}
 }
 

--- a/includes/class-wc-calypso-bridge-notes.php
+++ b/includes/class-wc-calypso-bridge-notes.php
@@ -44,6 +44,16 @@ class WC_Calypso_Bridge_Notes {
 		include_once dirname( __FILE__ ) . '/notes/class-wc-calypso-bridge-navigation-learn-more-note.php';
 
 		$navigation_learn_more_note = new WC_Calypso_Bridge_Navigation_Learn_More_Note();
+
+		// Turn off email notifications.
+		add_filter( 'pre_option_woocommerce_merchant_email_notifications', array( $this, 'disable_email_notes' ) );
+	}
+
+	/**
+	 * Disable email based notifications.
+	 */
+	function disable_email_notes(){
+		return 'no';
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-notes.php
+++ b/includes/class-wc-calypso-bridge-notes.php
@@ -44,16 +44,6 @@ class WC_Calypso_Bridge_Notes {
 		include_once dirname( __FILE__ ) . '/notes/class-wc-calypso-bridge-navigation-learn-more-note.php';
 
 		$navigation_learn_more_note = new WC_Calypso_Bridge_Navigation_Learn_More_Note();
-
-		// Turn off email notifications.
-		add_filter( 'pre_option_woocommerce_merchant_email_notifications', array( $this, 'disable_email_notes' ) );
-	}
-
-	/**
-	 * Disable email based notifications.
-	 */
-	function disable_email_notes(){
-		return 'no';
 	}
 
 	/**


### PR DESCRIPTION
This pull request implements similar logic as @octaedro's branch https://github.com/woocommerce/woocommerce-admin/pull/6324 .

This PR adds a filter to the option value used to determine if email based notes should be sent, and always returns `no` to prevent them from being emailed. This logic is included in such a way that it will prevent the email notes from being sent on *all* Atomic sites running Woo ( Biz and ecomm plan ).

### Detailed test instructions:
Test Setup: You could perform this on any test site you might have, but would be best if you were running Woo core 5.0, and deactivate any copy of wc-admin that you might have present.

I also reccomend having the following setup:
- [`crontrol` plugin](https://wordpress.org/plugins/wp-crontrol/)
- A plugin or some local system to log/catch email. Local By Flywheel has Mailhog setup by default so that is what I used.

#### Step 0: Get the Email Notification to Send
I think its best to get your site to a place where the email notification will send. I personally found it easier to just modify the logic in the email note file to bypass all the checks in place ( store age, number of products ) and have it so the note will send upon running of the `wc_admin_daily` cron job.

To go this route, locate the following file in your local copy of WooCommerce 5.0:

`woocommerce/packages/woocommerce-admin/src/Notes/AddFirstProduct.php`

Inside this file there are two checks you need to comment out, in order for the email note to be truthy and send:

- [The `return` for store age needs to be commented out](https://github.com/woocommerce/woocommerce-admin/blob/release/1.9.0/src/Notes/AddFirstProduct.php#L34)
- And [the `return` for number of products needs to be commented out too](https://github.com/woocommerce/woocommerce-admin/blob/release/1.9.0/src/Notes/AddFirstProduct.php#L47)

WIth that all dialed in, open up the Crontrol UI, and execute the `wc_admin_daily` job, and using your email logger, verify that the Store Setup email was sent:

<img width="856" alt="store-setup-email" src="https://user-images.githubusercontent.com/22080/108127215-c852b680-705f-11eb-8a67-e113f4bd81e3.png">

#### 1: Download `wc-calypso-bridge`, activate, and checkout this branch

That way you can test out the fix here :)

#### 2: Reset the Note database `status` for `wc-admin-add-first-product-note`

In order to set the stage for the email note to be sent again, you will need to manipulate the database row in `wc_admin_notes` and change the `status` field for the `wc-admin-add-first-product-note` note to be set to `unactioned` - because it should currently be set to `sent` after running the test in step 0.

Use wp cli, or your database manager of choice to ( note you may need to change the database table name depending on your prefix )

`UPDATE wp_wc_admin_notes SET status='unactioned' WHERE name = 'wc-admin-add-first-product-note'`

#### 3. Re-Run `wc_admin_daily` job

Now you can actually test this PR :) - using wp crontrol again, execute the `wc_admin_daily` job.

- Verify no new Store setup email is sent.
- Verify the `status` of the `wc-admin-add-first-product-note` in the database is still sent to `unactioned`.