### PR TITLE
Added help documentation filter

### DIFF
--- a/includes/class-wc-calypso-bridge-filters.php
+++ b/includes/class-wc-calypso-bridge-filters.php
@@ -81,16 +81,16 @@ class WC_Calypso_Bridge_Filters {
 		?>
 		<!-- WooCommerce JS Help documentation filter -->
 		<script type="text/javascript">
-			filterCalypsoDocumentation = function( documentationList ) {
-				if ( documentationList ) {
-					documentationList.map( ( item ) => {
+			filterCalypsoDocumentation = function( helpDocumentationList ) {
+				if ( helpDocumentationList ) {
+					helpDocumentationList.map( ( item ) => {
 						if ( item.title === 'Get Support' ) {
 							item.link = 'https://wordpress.com/help';
 						}
 						return item;
 					} )
 				}
-				return documentationList;
+				return helpDocumentationList;
 			}
 
 			if ( window.wp && window.wp.hooks && window.wp.hooks.addFilter ) {

--- a/includes/class-wc-calypso-bridge-filters.php
+++ b/includes/class-wc-calypso-bridge-filters.php
@@ -36,6 +36,7 @@ class WC_Calypso_Bridge_Filters {
 	 */
 	private function __construct() {
 		add_action( 'woocommerce_admin_onboarding_industries', array( $this, 'remove_not_allowed_industries' ), 10, 1 );
+		add_filter( 'admin_footer', array( $this, 'add_documentation_js_filter' ) );
 
 		// Turn off email notifications.
 		add_filter( 'pre_option_woocommerce_merchant_email_notifications', array( $this, 'disable_email_notes' ) );
@@ -71,6 +72,32 @@ class WC_Calypso_Bridge_Filters {
 	 */
 	public function disable_email_notes() {
 		return 'no';
+	}
+
+	/**
+	 * Add filter to js-based help documentation. This will modify the "Get Support" target link in the help documentation.
+	 */
+	public function add_documentation_js_filter() {
+		?>
+		<!-- WooCommerce JS Help documentation filter -->
+		<script type="text/javascript">
+			filterCalypsoDocumentation = function( documentationList ) {
+				if ( documentationList ) {
+					documentationList.map( ( item ) => {
+						if ( item.title === 'Get Support' ) {
+							item.link = 'https://wordpress.com/help';
+						}
+						return item;
+					} )
+				}
+				return documentationList;
+			}
+
+			if ( window.wp && window.wp.hooks && window.wp.hooks.addFilter ) {
+				window.wp.hooks.addFilter( "woocommerce_admin_setup_task_help_items", "woocommerce", filterCalypsoDocumentation );
+			}
+		</script>
+		<?php
 	}
 }
 


### PR DESCRIPTION
Fixes #602
 
This PR adds a filter to modify the "Get Support" link for the `eCommerce` plan under the help documentation.

### Screenshots
![Screen Capture on 2021-02-18 at 10-58-15](https://user-images.githubusercontent.com/1314156/108368102-d7a93f80-71d8-11eb-8a0d-729613f5d802.gif)


### Detailed test instructions:

1- With `wc-calypso-bridge` installed, checkout this branch (`git checkout fix/602`).
2- Go to `Home` screen.
3- Press `Help`.
4- Verify the `Get Support` link is pointing to `https://wordpress.com/help`.