### PR TITLE
Prep for 1.7.0 Release.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v1.6.0",
+  "version": "v1.7.0",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -27,6 +27,7 @@ This section describes how to install the plugin and get it working.
 * Set survey source with wpcom plan #638
 * Disable email based inbox notifications #641
 * Add Get Support link to WordPress.com support page #650
+* Remove filtered link in store manager order confirmation email #651
 
 = 1.6.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 1.6.0
+Stable tag: 1.7.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,12 @@ This section describes how to install the plugin and get it working.
 1. Activate the plugin through the 'Plugins' screen in WordPress
 
 == Changelog ==
+
+= 1.7.0 =
+* Set back button in new navigation to be WordPress.com Dashboard #634
+* Set survey source with wpcom plan #638
+* Disable email based inbox notifications #641
+* Add Get Support link to WordPress.com support page #650
 
 = 1.6.0 =
 

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 1.6.0
+ * Version: 1.7.0
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -31,7 +31,7 @@ if ( file_exists( WP_PLUGIN_DIR . '/wc-calypso-bridge/wc-calypso-bridge.php' ) )
 }
 
 define( 'WC_CALYSPO_BRIDGE_PLUGIN_FILE', __FILE__ );
-define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.6.0' );
+define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.7.0' );
 define( 'WC_MIN_VERSION', '3.0.0' );
 
 if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_plan' ) ) {


### PR DESCRIPTION
Getting things ready to roll for a new bridge release.

## Test Instructions

While each PR has already been tested, if you want to take a zip of `master`, you can test out the functionality from the PRs in this release:

* Set back button in new navigation to be WordPress.com Dashboard #634
* Set survey source with wpcom plan #638
* Disable email based inbox notifications #641
* Add Get Support link to WordPress.com support page #650
* Remove filtered link in store manager order confirmation email #651