### PR TITLE
Create WooCommerce pages if they are missing on a new installation

### DIFF
--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -39,6 +39,8 @@ class WC_Calypso_Bridge_Plugins {
 		add_action( 'update_option_active_plugins', array( $this, 'prevent_woocommerce_deactivation' ), 10, 2 );
 		add_action( 'current_screen', array( $this, 'prevent_woocommerce_deactiation_route' ), 10, 2 );
 		add_action( 'admin_notices', array( $this, 'prevent_woocommerce_deactiation_notice' ), 10, 2 );
+		add_action( 'woocommerce_admin_newly_installed', array( $this, 'maybe_create_wc_pages' ), 10, 2 );
+
 	}
 
 	/**
@@ -99,6 +101,18 @@ class WC_Calypso_Bridge_Plugins {
 		return $actions;
 	}
 
+	/**
+	 * Check WooCommerce pages (shop, cart, my-account, checkout) and create them if they don't exist.
+	 */
+	public function maybe_create_wc_pages() {
+		global $wpdb;
+
+		$post_count = $wpdb->get_var( "select count(*) from $wpdb->posts where post_name in ('shop', 'cart', 'my-account', 'checkout')" );
+
+		if ( 4 !== (int) $post_count ) {
+			WC_Install::create_pages();
+		}
+	}
 
 }
 $wc_calypso_bridge_plugins = WC_Calypso_Bridge_Plugins::get_instance();


### PR DESCRIPTION
Fixes WooCommerce page issue in [636](https://github.com/Automattic/wc-calypso-bridge/issues/637) 

### Detailed test instructions

**Before getting started**:

1. Make sure to delete WooCommerce & WooCommerce Admin plugins. 
2. Make sure to delete `woocommerce_db_version` and `woocommerce_version` options from the `wp_options` table. You can use the following query.
```
delete from wp_options where option_name='woocommerce_version' or option_name='woocommerce_admin_version'
```
3. Make sure to delete WooCommerce pages (Cart, Checkout, My account, Shop) from the previous installation. If you have those pages in WordPress -> Pages, please delete them first.

Start with a fresh installation if you want to skip these steps.

**To test**:

1. Checkout this branch
2. Make sure you're on an eCommerce plan. If you're testing locally, use this [plugin](https://gist.github.com/psealock/531205e2c3d37be1d8ac4d3ef4f346bc).
3. Activate `wc-calypso-bridge` plugin (this plugin)
4. Navigate to WordPress -> Plugins -> Add New and install & activate WooCommerce
5. Confirm that you have Cart, Checkout, My account, and Shop pages in WordPress -> Pages

