### PR TITLE
Setup: Prevent Creative Mail and Crowdsignal Forms redirects when activating plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ The ecommerce plan comes bundled with a number of plugins that this plugin integ
 - Marketing:
   - [MailChimp for WooCommerce](https://wordpress.org/plugins/mailchimp-for-woocommerce/)
   - [Facebook  for WooCommerce](https://woocommerce.com/products/facebook/)
+  - [Creative Mail](https://wordpress.org/plugins/creative-mail-by-constant-contact/)
+  - [Crowdsignal Forms](https://wordpress.org/plugins/crowdsignal-forms/)
 - Store Management:
 
   - [TaxJar -- Sales Tax Automation for WooCommerce](https://wordpress.org/plugins/taxjar-simplified-taxes-for-woocommerce/)

--- a/README.md
+++ b/README.md
@@ -60,43 +60,43 @@ If you would like to skip all of the above, [just download this gist](https://gi
 The ecommerce plan comes bundled with a number of plugins that this plugin integrates with if activated. To fully test this plugin's functionality, the following plugins can be installed.
 
 - Payments
-  - [WooCommerce Stripe Payment Gateway](https://href.li/?https://wordpress.org/plugins/woocommerce-gateway-stripe/)
-  - [WooCommerce PayPal Checkout Payment Gateway](https://href.li/?https://wordpress.org/plugins/woocommerce-gateway-paypal-express-checkout/)
-  - [WooCommerce Square](https://href.li/?https://wordpress.org/plugins/woocommerce-square/)
-  - [Klarna Payments for WooCommerce](https://href.li/?https://wordpress.org/plugins/klarna-payments-for-woocommerce/)
-  - [Klarna Checkout for WooCommerce](https://href.li/?https://wordpress.org/plugins/klarna-checkout-for-woocommerce/)
-  - [WooCommerce eWAY Gateway](https://href.li/?https://wordpress.org/plugins/woocommerce-gateway-eway/)
-  - [WooCommerce PayFast Gateway](https://href.li/?https://wordpress.org/plugins/woocommerce-payfast-gateway/)
+  - [WooCommerce Stripe Payment Gateway](https://wordpress.org/plugins/woocommerce-gateway-stripe/)
+  - [WooCommerce PayPal Checkout Payment Gateway](https://wordpress.org/plugins/woocommerce-gateway-paypal-express-checkout/)
+  - [WooCommerce Square](https://wordpress.org/plugins/woocommerce-square/)
+  - [Klarna Payments for WooCommerce](https://wordpress.org/plugins/klarna-payments-for-woocommerce/)
+  - [Klarna Checkout for WooCommerce](https://wordpress.org/plugins/klarna-checkout-for-woocommerce/)
+  - [WooCommerce eWAY Gateway](https://wordpress.org/plugins/woocommerce-gateway-eway/)
+  - [WooCommerce PayFast Gateway](https://wordpress.org/plugins/woocommerce-payfast-gateway/)
 - Taxes:
-  - [TaxJar -- Sales Tax Automation for WooCommerce](https://href.li/?https://wordpress.org/plugins/taxjar-simplified-taxes-for-woocommerce/)
+  - [TaxJar -- Sales Tax Automation for WooCommerce](https://wordpress.org/plugins/taxjar-simplified-taxes-for-woocommerce/)
 - Shipping:
-  - [WooCommerce Services](https://href.li/?https://wordpress.org/plugins/woocommerce-services/)
+  - [WooCommerce Services](https://wordpress.org/plugins/woocommerce-services/)
 - Marketing:
-  - [MailChimp for WooCommerce](https://href.li/?https://wordpress.org/plugins/mailchimp-for-woocommerce/)
-  - [Facebook  for WooCommerce](https://href.li/?https://woocommerce.com/products/facebook/)
+  - [MailChimp for WooCommerce](https://wordpress.org/plugins/mailchimp-for-woocommerce/)
+  - [Facebook  for WooCommerce](https://woocommerce.com/products/facebook/)
 - Store Management:
 
-  - [TaxJar -- Sales Tax Automation for WooCommerce](https://href.li/?https://wordpress.org/plugins/taxjar-simplified-taxes-for-woocommerce/)
+  - [TaxJar -- Sales Tax Automation for WooCommerce](https://wordpress.org/plugins/taxjar-simplified-taxes-for-woocommerce/)
 
 - Theme:
-  - [Storefront](https://href.li/?https://woocommerce.com/storefront/)
+  - [Storefront](https://woocommerce.com/storefront/)
 
 #### Paid extensions
 
 - Shipping (everywhere):
-  - [UPS Shipping Method](https://href.li/?https://woocommerce.com/products/ups-shipping-method/)
+  - [UPS Shipping Method](https://woocommerce.com/products/ups-shipping-method/)
 - Shipping (based on geo):
-  - [USPS Shipping Method](https://href.li/?https://woocommerce.com/products/usps-shipping-method/)
-  - [Canada Post shipping](https://href.li/?https://woocommerce.com/products/canada-post-shipping-method/)
-  - [Royal Mail](https://href.li/?https://woocommerce.com/products/royal-mail/)
-  - [Australia Post Shipping Method](https://href.li/?https://woocommerce.com/products/australia-post-shipping-method/)
+  - [USPS Shipping Method](https://woocommerce.com/products/usps-shipping-method/)
+  - [Canada Post shipping](https://woocommerce.com/products/canada-post-shipping-method/)
+  - [Royal Mail](https://woocommerce.com/products/royal-mail/)
+  - [Australia Post Shipping Method](https://woocommerce.com/products/australia-post-shipping-method/)
 - Product Page Features:
-  - [Product Add-Ons](https://href.li/?https://woocommerce.com/products/product-add-ons/)
+  - [Product Add-Ons](https://woocommerce.com/products/product-add-ons/)
 - Storefront premium options
-  - [Galleria](https://href.li/?https://woocommerce.com/products/galleria/)
-  - [Homestore](https://href.li/?https://woocommerce.com/products/homestore/)
-  - [Bookshop](https://href.li/?https://woocommerce.com/products/bookshop/)
-  - [Storefront Powerpack design options](https://href.li/?https://woocommerce.com/products/storefront-powerpack/)
+  - [Galleria](https://woocommerce.com/products/galleria/)
+  - [Homestore](https://woocommerce.com/products/homestore/)
+  - [Bookshop](https://woocommerce.com/products/bookshop/)
+  - [Storefront Powerpack design options](https://woocommerce.com/products/storefront-powerpack/)
   - [Blog Customizer](https://woocommerce.com/products/storefront-blog-customiser/)
   - [Parallax Hero](https://woocommerce.com/products/storefront-parallax-hero/)
   - [Product Hero](https://woocommerce.com/products/storefront-product-hero/)

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -45,7 +45,7 @@ class WC_Calypso_Bridge_Setup {
 	}
 
 	/**
-	 * Opt all sites into using WooCommerec Home Screen.
+	 * Opt all sites into using WooCommerce Home Screen.
 	 */
 	public function always_enable_homescreen() {
 		return 'yes';

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -39,7 +39,7 @@ class WC_Calypso_Bridge_Setup {
 		add_filter( 'option_woocommerce_onboarding_profile', array( $this, 'set_business_extensions_empty' ) );
 		add_filter( 'default_option_woocommerce_navigation_enabled', array( $this, 'enable_navigation_by_default' ) );
 		add_filter( 'woocommerce_admin_onboarding_themes', array( $this, 'remove_non_installed_themes' ) );
-		add_filter( 'wp_redirect', array( $this, 'prevent_mailchimp_redirect' ), 10, 2 );
+		add_filter( 'wp_redirect', array( $this, 'prevent_redirects_on_activation' ), 10, 2 );
 		add_filter( 'woocommerce_admin_onboarding_product_types', array( $this, 'remove_paid_extension_upsells' ), 10, 2 );
 		add_filter( 'pre_option_woocommerce_homescreen_enabled', array( $this, 'always_enable_homescreen' ) );
 	}
@@ -52,16 +52,33 @@ class WC_Calypso_Bridge_Setup {
 	}
 
 	/**
-	 * Prevent MailChimp redirect on initial setup.
+	 * Prevent redirects on activation when WooCommerce is being setup. Some plugins
+	 * do this when they are activated.
 	 *
 	 * @param string $location Redirect location.
 	 * @param string $status Status code.
 	 * @return string
 	 */
-	public function prevent_mailchimp_redirect( $location, $status ) {
-		if ( 'admin.php?page=mailchimp-woocommerce' === $location ) {
-			// Delete the redirect option so we don't end up here anymore.
-			delete_option( 'mailchimp_woocommerce_plugin_do_activation_redirect' );
+	public function prevent_redirects_on_activation( $location, $status ) {
+		$location_prefix = '';
+		if ( parse_url( $location, PHP_URL_SCHEME ) !== null ) {
+			// $location has a URL scheme, so it is probably a full URL;
+			// we will need to match against a full URL
+			$location_prefix = admin_url();
+		}
+
+		$redirect_options_by_location = array(
+			$location_prefix . 'admin.php?page=mailchimp-woocommerce'   => 'mailchimp_woocommerce_plugin_do_activation_redirect',
+			$location_prefix . 'admin.php?page=crowdsignal-forms-setup' => 'crowdsignal_forms_do_activation_redirect',
+			$location_prefix . 'admin.php?page=creativemail'            => 'ce4wp_activation_redirect',
+		);
+
+		if ( isset( $redirect_options_by_location[ $location ] ) ) {
+			$option_to_delete = $redirect_options_by_location[ $location ];
+			if ( is_string( $option_to_delete ) ) {
+				// Delete the redirect option so we don't end up here anymore.
+				delete_option( $option_to_delete );
+			}
 			$location = admin_url( 'admin.php?page=wc-admin' );
 		}
 

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -61,7 +61,7 @@ class WC_Calypso_Bridge_Setup {
 	 */
 	public function prevent_redirects_on_activation( $location, $status ) {
 		$location_prefix = '';
-		if ( parse_url( $location, PHP_URL_SCHEME ) !== null ) {
+		if ( wp_parse_url( $location, PHP_URL_SCHEME ) !== null ) {
 			// $location has a URL scheme, so it is probably a full URL;
 			// we will need to match against a full URL
 			$location_prefix = admin_url();


### PR DESCRIPTION
This PR addresses https://github.com/Automattic/wp-calypso/issues/49925

It uses the same approach as originally used to prevent MailChimp redirects (https://github.com/Automattic/wc-calypso-bridge/pull/478).

## Test instructions

To reproduce the redirect locally, all one must do is install and activate the Creative Mail and Crowdsignal Forms plugins. It might be good to do this once before you test this branch. Then deactivate/delete the plugins.

1. Check out this branch
2. Install and activate the Creative Mail plugin
3. Verify that you end up on the Setup dashboard instead of the Creative Mail settings page
4. Install and activate Crowdsignal Forms plugin
5. Verify that you end up on the Setup dashboard instead of the Crowdsignal Forms plugin

Once this is merged and a wpcomsh release is done, we can test this in production to formally verify that it fixes https://github.com/Automattic/wp-calypso/issues/49925