### PR TITLE
remove create page logic

### DIFF
--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -39,8 +39,7 @@ class WC_Calypso_Bridge_Plugins {
 		add_action( 'update_option_active_plugins', array( $this, 'prevent_woocommerce_deactivation' ), 10, 2 );
 		add_action( 'current_screen', array( $this, 'prevent_woocommerce_deactiation_route' ), 10, 2 );
 		add_action( 'admin_notices', array( $this, 'prevent_woocommerce_deactiation_notice' ), 10, 2 );
-		add_action( 'woocommerce_admin_newly_installed', array( $this, 'maybe_create_wc_pages' ), 10, 2 );
-
+		add_action( 'woocommerce_installed', array( $this, 'maybe_create_wc_pages' ), 10, 2 );
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -39,7 +39,6 @@ class WC_Calypso_Bridge_Plugins {
 		add_action( 'update_option_active_plugins', array( $this, 'prevent_woocommerce_deactivation' ), 10, 2 );
 		add_action( 'current_screen', array( $this, 'prevent_woocommerce_deactiation_route' ), 10, 2 );
 		add_action( 'admin_notices', array( $this, 'prevent_woocommerce_deactiation_notice' ), 10, 2 );
-		add_action( 'woocommerce_installed', array( $this, 'maybe_create_wc_pages' ), 10, 2 );
 	}
 
 	/**
@@ -99,19 +98,5 @@ class WC_Calypso_Bridge_Plugins {
 		}
 		return $actions;
 	}
-
-	/**
-	 * Check WooCommerce pages (shop, cart, my-account, checkout) and create them if they don't exist.
-	 */
-	public function maybe_create_wc_pages() {
-		global $wpdb;
-
-		$post_count = $wpdb->get_var( "select count(*) from $wpdb->posts where post_name in ('shop', 'cart', 'my-account', 'checkout')" );
-
-		if ( 4 !== (int) $post_count ) {
-			WC_Install::create_pages();
-		}
-	}
-
 }
 $wc_calypso_bridge_plugins = WC_Calypso_Bridge_Plugins::get_instance();


### PR DESCRIPTION
This PR removes `maybe_create_wc_pages` method that was merged in https://github.com/Automattic/wc-calypso-bridge/pull/662

While investigating the original [issue](https://github.com/Automattic/wc-calypso-bridge/issues/637) further, I found that the [create_pages()](https://github.com/woocommerce/woocommerce/blob/trunk/includes/class-wc-install.php#L555) might be causing the bug.

Since my change does not fix the bug, this should be removed.

I will submit an issue to WooCommerce repository once my change gets removed and deployed.