### PR TITLE
Delete woocommerce_*_page_id options before attempting to create WC pages and use wc_admin_daily action

### DIFF
--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -109,10 +109,10 @@ class WC_Calypso_Bridge_Plugins {
 		$post_count = $wpdb->get_var( "select count(*) from $wpdb->posts where post_name in ('shop', 'cart', 'my-account', 'checkout')" );
 
 		if ( 4 !== (int) $post_count ) {
-	    	//reset the woocommerce_*_page_id options
-            foreach (['shop', 'cart', 'myaccount', 'checkout'] as $page) {
-                delete_option("woocommerce_{$page}_page_id");
-            }
+			// reset the woocommerce_*_page_id options.
+			foreach ( [ 'shop', 'cart', 'myaccount', 'checkout' ] as $page ) {
+				delete_option( "woocommerce_{$page}_page_id" );
+			}
 			WC_Install::create_pages();
 		}
 	}

--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -39,8 +39,7 @@ class WC_Calypso_Bridge_Plugins {
 		add_action( 'update_option_active_plugins', array( $this, 'prevent_woocommerce_deactivation' ), 10, 2 );
 		add_action( 'current_screen', array( $this, 'prevent_woocommerce_deactiation_route' ), 10, 2 );
 		add_action( 'admin_notices', array( $this, 'prevent_woocommerce_deactiation_notice' ), 10, 2 );
-		add_action( 'woocommerce_admin_newly_installed', array( $this, 'maybe_create_wc_pages' ), 10, 2 );
-
+		add_action( 'wc_admin_daily', array( $this, 'maybe_create_wc_pages' ), 10, 2 );
 	}
 
 	/**
@@ -110,7 +109,7 @@ class WC_Calypso_Bridge_Plugins {
 		$post_count = $wpdb->get_var( "select count(*) from $wpdb->posts where post_name in ('shop', 'cart', 'my-account', 'checkout')" );
 
 		if ( 4 !== (int) $post_count ) {
-		    // reset the woocommerce_*_page_id options
+	    	//reset the woocommerce_*_page_id options
             foreach (['shop', 'cart', 'myaccount', 'checkout'] as $page) {
                 delete_option("woocommerce_{$page}_page_id");
             }

--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -110,6 +110,10 @@ class WC_Calypso_Bridge_Plugins {
 		$post_count = $wpdb->get_var( "select count(*) from $wpdb->posts where post_name in ('shop', 'cart', 'my-account', 'checkout')" );
 
 		if ( 4 !== (int) $post_count ) {
+		    // reset the woocommerce_*_page_id options
+            foreach (['shop', 'cart', 'myaccount', 'checkout'] as $page) {
+                delete_option("woocommerce_{$page}_page_id");
+            }
 			WC_Install::create_pages();
 		}
 	}


### PR DESCRIPTION
This is a follow-up PR for https://github.com/Automattic/wc-calypso-bridge/pull/662

The previous PR did not work on ECOMMERCE plan. It looks `maybe_create_wc_pages` never gets called.

My best guess is that `wc-calypso-bridge` plugin [does not add](https://github.com/Automattic/wc-calypso-bridge/blob/master/wc-calypso-bridge.php#L20) any actions because WooCommerce is not available by the time it is activated.

1. wpcomsh gets installed & activated. `wc-calypso-bridge` does not add any actions at this time because WooCommerce is not available.
2. Other ecommerce plan plugins including WooCommerce gets installed & activated via a script, so `wc-calypso-bridge` does not get a chance to add actions including `woocommerce_admin_newly_installed`. 

This PR uses `wc_admin_daily` instead because it's executed by the scheduler. It should give `wc-calypso-bridge` enough time to add actions after WooCommerce gets installed. I think `wc_admin_daily` is the best action we can use for now.
