### PR TITLE
Added a new class to register actions even without WooCommerce detected

### DIFF
--- a/includes/class-wc-calypso-bridge-mu-events.php
+++ b/includes/class-wc-calypso-bridge-mu-events.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Events that must be registered even without WooCommerce detected.
+ *
+ * @package WC_Calypso_Bridge/Classes
+ * @since   1.0.0
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC Calypso Bridge Mu Events
+ */
+class WC_Calypso_Bridge_Mu_Events {
+
+	/**
+	 * Class instance.
+	 *
+	 * @var WC_Calypso_Bridge_Themes_Setup instance
+	 */
+	protected static $instance = false;
+
+	/**
+	 * Get class instance
+	 */
+	public static function get_instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	private function __construct() {
+		add_action( 'woocommerce_admin_newly_installed', array( $this, 'maybe_create_wc_pages' ), 10, 2 );
+	}
+
+	/**
+	 * Check WooCommerce pages (shop, cart, my-account, checkout) and create them if they don't exist.
+	 */
+	public function maybe_create_wc_pages() {
+		global $wpdb;
+
+		$post_count = $wpdb->get_var( "select count(*) from $wpdb->posts where post_name in ('shop', 'cart', 'my-account', 'checkout')" );
+
+		if ( 4 !== (int) $post_count ) {
+			// reset the woocommerce_*_page_id options.
+			foreach ( [ 'shop', 'cart', 'myaccount', 'checkout' ] as $page ) {
+				delete_option( "woocommerce_{$page}_page_id" );
+			}
+			WC_Install::create_pages();
+		}
+	}
+}
+
+$wc_calypso_bridge_must_use_events = WC_Calypso_Bridge_Mu_Events::get_instance();

--- a/includes/class-wc-calypso-bridge-mu-events.php
+++ b/includes/class-wc-calypso-bridge-mu-events.php
@@ -44,6 +44,10 @@ class WC_Calypso_Bridge_Mu_Events {
 	public function maybe_create_wc_pages() {
 		global $wpdb;
 
+		if ( ! class_exists( 'WC_Install' ) ) {
+			return;
+		}
+
 		$post_count = $wpdb->get_var( "select count(*) from $wpdb->posts where post_name in ('shop', 'cart', 'my-account', 'checkout')" );
 
 		if ( 4 !== (int) $post_count ) {

--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -39,7 +39,6 @@ class WC_Calypso_Bridge_Plugins {
 		add_action( 'update_option_active_plugins', array( $this, 'prevent_woocommerce_deactivation' ), 10, 2 );
 		add_action( 'current_screen', array( $this, 'prevent_woocommerce_deactiation_route' ), 10, 2 );
 		add_action( 'admin_notices', array( $this, 'prevent_woocommerce_deactiation_notice' ), 10, 2 );
-		add_action( 'wc_admin_daily', array( $this, 'maybe_create_wc_pages' ), 10, 2 );
 	}
 
 	/**
@@ -99,23 +98,5 @@ class WC_Calypso_Bridge_Plugins {
 		}
 		return $actions;
 	}
-
-	/**
-	 * Check WooCommerce pages (shop, cart, my-account, checkout) and create them if they don't exist.
-	 */
-	public function maybe_create_wc_pages() {
-		global $wpdb;
-
-		$post_count = $wpdb->get_var( "select count(*) from $wpdb->posts where post_name in ('shop', 'cart', 'my-account', 'checkout')" );
-
-		if ( 4 !== (int) $post_count ) {
-			// reset the woocommerce_*_page_id options.
-			foreach ( [ 'shop', 'cart', 'myaccount', 'checkout' ] as $page ) {
-				delete_option( "woocommerce_{$page}_page_id" );
-			}
-			WC_Install::create_pages();
-		}
-	}
-
 }
 $wc_calypso_bridge_plugins = WC_Calypso_Bridge_Plugins::get_instance();

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -17,6 +17,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	return;
 }
 
+require_once dirname(__FILE__) . '/includes/class-wc-calypso-bridge-mu-events.php';
+add_action( 'init', array( 'WC_Calypso_Bridge_Mu_Events', 'get_instance' ) );
+
+
 if ( ! file_exists( WP_PLUGIN_DIR . '/woocommerce/woocommerce.php' ) ) {
 	// No WooCommerce installed, we don't need this.
 	return;


### PR DESCRIPTION
This PR is another attempt to fix ECOM page bug described in https://github.com/Automattic/wc-calypso-bridge/issues/637

I added a new class to register actions even without WooCommerce detected.

When a user signs up for an ecommerce plan (this is my best guess),
 
1. Install & Activate MU plugins. `wc-calypso-bridge` does not register anything because WooCommerce is not installed yet. See [here](https://github.com/Automattic/wc-calypso-bridge/blob/master/wc-calypso-bridge.php#L20).
2. Install & Activate WooCommerce and other plugins. Since the plugins are installed & activated via a script in a single session, `wc-calypso-bridge` does not get a chance to add any actions. I think that's the reason why both `woocommerce_admin_newly_installed` and `wc_admin_daily` callbacks never worked in my previous PRs.

This PR initializes `WC_Calypso_Bridge_Mu_Events` class before [this line](https://github.com/Automattic/wc-calypso-bridge/blob/master/wc-calypso-bridge.php#L20) to make sure the actions get registered.
