### PR TITLE
Use woocommerce_admin_onboarding_industries filter for the create page callback

### DIFF
--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -39,7 +39,7 @@ class WC_Calypso_Bridge_Plugins {
 		add_action( 'update_option_active_plugins', array( $this, 'prevent_woocommerce_deactivation' ), 10, 2 );
 		add_action( 'current_screen', array( $this, 'prevent_woocommerce_deactiation_route' ), 10, 2 );
 		add_action( 'admin_notices', array( $this, 'prevent_woocommerce_deactiation_notice' ), 10, 2 );
-		add_action( 'wc_admin_daily', array( $this, 'maybe_create_wc_pages' ), 10, 2 );
+		add_filter( 'woocommerce_admin_onboarding_industries', array( $this, 'maybe_create_wc_pages' ), 10, 2 );
 	}
 
 	/**
@@ -102,8 +102,12 @@ class WC_Calypso_Bridge_Plugins {
 
 	/**
 	 * Check WooCommerce pages (shop, cart, my-account, checkout) and create them if they don't exist.
+	 *
+	 * @param array $industries Array of industries.
+	 *
+	 * @return array
 	 */
-	public function maybe_create_wc_pages() {
+	public function maybe_create_wc_pages($industries) {
 		global $wpdb;
 
 		$post_count = $wpdb->get_var( "select count(*) from $wpdb->posts where post_name in ('shop', 'cart', 'my-account', 'checkout')" );
@@ -115,7 +119,9 @@ class WC_Calypso_Bridge_Plugins {
 			}
 			WC_Install::create_pages();
 		}
-	}
 
+		return $industries;
+	}
 }
+
 $wc_calypso_bridge_plugins = WC_Calypso_Bridge_Plugins::get_instance();

--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -101,24 +101,49 @@ class WC_Calypso_Bridge_Plugins {
 	}
 
 	/**
-	 * Check WooCommerce pages (shop, cart, my-account, checkout) and create them if they don't exist.
+	 * Check WooCommerce pages (shop, cart, my-account, checkout) and create them if the following conditions are met.
+	 *
+	 * 1. This is the first time running this method.
+	 * 2. User has not finished Store details task.
+	 * 3. Shop, cart, my-account, and checkout pages do not exist.
 	 *
 	 * @param array $industries Array of industries.
 	 *
 	 * @return array
 	 */
-	public function maybe_create_wc_pages($industries) {
+	public function maybe_create_wc_pages( $industries ) {
 		global $wpdb;
+
+		$option_name = 'wc_pages_created_by_wc_calypso_bridge';
+
+		// Abort if we have attempted to create the pages already.
+		if ( 'yes' === get_option( $option_name, 'no' ) ) {
+			return $industries;
+		}
+
+		// Abort if the user has completed store details task already.
+		$completed_tasks = get_option( 'woocommerce_task_list_tracked_completed_tasks', [] );
+		if ( in_array( 'store_details', $completed_tasks ) ) {
+			return $industries;
+		}
 
 		$post_count = $wpdb->get_var( "select count(*) from $wpdb->posts where post_name in ('shop', 'cart', 'my-account', 'checkout')" );
 
-		if ( 4 !== (int) $post_count ) {
-			// reset the woocommerce_*_page_id options.
-			foreach ( [ 'shop', 'cart', 'myaccount', 'checkout' ] as $page ) {
-				delete_option( "woocommerce_{$page}_page_id" );
-			}
-			WC_Install::create_pages();
+		// Abort if we find any existing pages.
+		if ( 0 !== (int) $post_count ) {
+			return $industries;
 		}
+
+		// Reset the woocommerce_*_page_id options.
+		// This is needed as woocommerce_*_page_id options have incorrect values on a fresh installation
+		// for an ecom plan. WC_Install:create_pages() might not create all the
+		// required pages without resetting these options first.
+		foreach ( [ 'shop', 'cart', 'myaccount', 'checkout' ] as $page ) {
+			delete_option( "woocommerce_{$page}_page_id" );
+		}
+
+		WC_Install::create_pages();
+		update_option( $option_name, 'yes' );
 
 		return $industries;
 	}


### PR DESCRIPTION
This PR uses `woocommerce_admin_onboarding_industries` filter to check WC default pages and create them if they're missing.


## Testing Successful Page Creation

1. Delete the existing pages and options to reset the WC state.

```
delete from wp_posts where post_name in ('shop', 'cart', 'checkout', 'my-account');

delete from wp_options where option_name in ('woocommerce_task_list_tracked_completed_tasks', 'wc_pages_created_by_wc_calypso_bridge', 'woocommerce_onboarding_profile');
```

2. Navigate to WooCommerce -> Home
3. Click on the Store details task and finish the OBW. This isn't necessary for this particular test case, but we need it for the next test case. 
4. Navigate to WordPress -> Pages and confirm the shop, my account, checkout, and cart pages.
3. Confirm the `wc_pages_created_by_wc_calypso_bridge` option value is`yes`.
```
select option_value from wp_options where option_name = 'wc_pages_created_by_wc_calypso_bridge'
```

## Testing Guards

#### Case 1: wc_pages_created_by_wc_calypso_bridge
1. Delete `wc_pages_created_by_wc_calypso_bridge` option value.
```
delete from wp_options where option_name='wc_pages_created_by_wc_calypso_bridge';
```
2. Navigate to WooCommerce -> Home
3. Navigate WordPress -> Pages and observe the pages haven't updated. 

`maybe_create_wc_pages()` method should return at this [line](https://github.com/Automattic/wc-calypso-bridge/blob/e7cac2989793705165afc704ec7abad2d4fbcedb/includes/class-wc-calypso-bridge-plugins.php#L128) for this case.

#### Case 2: woocommerce_task_list_tracked_completed_tasks

1. Delete options 

```
delete from wp_options where option_name in ('woocommerce_task_list_tracked_completed_tasks', 'wc_pages_created_by_wc_calypso_bridge', 'woocommerce_onboarding_profile');
```
2. Navigate to WooCommerce -> Home
3. Navigate WordPress -> Pages and observe the pages haven't updated. 

`maybe_create_wc_pages()` method should return at this [line](https://github.com/Automattic/wc-calypso-bridge/blob/e7cac2989793705165afc704ec7abad2d4fbcedb/includes/class-wc-calypso-bridge-plugins.php#L135) for this case.

#### Case 3: Deleting one of the existing pages

1. Delete one of the existing pages and options.
```
delete from wp_options where option_name in ('woocommerce_task_list_tracked_completed_tasks', 'wc_pages_created_by_wc_calypso_bridge', 'woocommerce_onboarding_profile');

delete from wp_posts where post_name = 'shop';
```
2. Navigate to WooCommerce -> Home
3. Navigate WordPress -> Pages and confirm that the shop page hasn't been recreated. 

`maybe_create_wc_pages()` method should return at this [line](https://github.com/Automattic/wc-calypso-bridge/blob/e7cac2989793705165afc704ec7abad2d4fbcedb/includes/class-wc-calypso-bridge-plugins.php#L135) for this case.
