### PR TITLE
Add missing OBW Tweaks

### DIFF
--- a/assets/css/ecommerce.css
+++ b/assets/css/ecommerce.css
@@ -1,11 +1,3 @@
-/* Hide business extensions in Profiler > Business Details */
-.woocommerce-profile-wizard__body
-	.woocommerce-profile-wizard__container
-	div
-	.woocommerce-profile-wizard__benefit {
-	display: none;
-}
-
 /* Hides Theme Tabs ( All | Free | Paid ) since we only show installed themes */
 .woocommerce-profile-wizard__body
 	.woocommerce-profile-wizard__themes-tab-panel

--- a/assets/css/ecommerce.css
+++ b/assets/css/ecommerce.css
@@ -1,14 +1,24 @@
 /* Hide business extensions in Profiler > Business Details */
-.woocommerce-profile-wizard__body .woocommerce-profile-wizard__container div .woocommerce-profile-wizard__benefit {
+.woocommerce-profile-wizard__body
+	.woocommerce-profile-wizard__container
+	div
+	.woocommerce-profile-wizard__benefit {
 	display: none;
 }
 
 /* Hides Theme Tabs ( All | Free | Paid ) since we only show installed themes */
-.woocommerce-profile-wizard__body .woocommerce-profile-wizard__themes-tab-panel .components-tab-panel__tabs {
+.woocommerce-profile-wizard__body
+	.woocommerce-profile-wizard__themes-tab-panel
+	.components-tab-panel__tabs {
 	display: none;
 }
 
 /* Hides pricing toggle on Profiler > Product Types */
-.woocommerce-profile-wizard__body .woocommerce-profile-wizard__product-types .woocommerce-card__body .woocommerce-profile-wizard__product-types-pricing-toggle.woocommerce-profile-wizard__checkbox {
-	display: none;
+.woocommerce-profile-wizard__body
+	.woocommerce-profile-wizard__product-types
+	.woocommerce-profile-wizard__product-types-pricing-toggle.woocommerce-profile-wizard__checkbox {
+	display: none !important;
+}
+.woocommerce-profile-wizard__card-help-footnote {
+	margin-top: 16px;
 }

--- a/assets/css/ecommerce.css
+++ b/assets/css/ecommerce.css
@@ -22,3 +22,8 @@
 .woocommerce-profile-wizard__card-help-footnote {
 	margin-top: 16px;
 }
+
+.woocommerce-profile-wizard__container.business-features
+	.components-tab-panel__tabs {
+	display: none;
+}

--- a/assets/css/ecommerce.css
+++ b/assets/css/ecommerce.css
@@ -12,9 +12,10 @@
 	display: none !important;
 }
 .woocommerce-profile-wizard__card-help-footnote {
-	margin-top: 16px;
+	display: none;
 }
 
+/* Business and Free Features toggle on Business Details step */
 .woocommerce-profile-wizard__container.business-features
 	.components-tab-panel__tabs {
 	display: none;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wc-calypso-bridge/issues/635
Fixes https://github.com/Automattic/wc-calypso-bridge/issues/652

Some styles needed adjustment after de-Calypsoification

## Product Types Before

<img width="581" alt="Screen Shot 2021-04-08 at 4 13 47 PM" src="https://user-images.githubusercontent.com/1922453/113968202-bedb1300-9886-11eb-9d35-c5922611dae6.png">

## Product Types After

<img width="627" alt="Screen Shot 2021-04-09 at 11 55 49 AM" src="https://user-images.githubusercontent.com/1922453/114109982-91e03c00-992a-11eb-949c-61684edf6138.png">

## Business Details Before

<img width="636" alt="Screen Shot 2021-04-08 at 4 21 35 PM" src="https://user-images.githubusercontent.com/1922453/113968972-3b222600-9888-11eb-88d4-f031e83d9d81.png">

## Business Details After

<img width="621" alt="Screen Shot 2021-04-08 at 4 31 30 PM" src="https://user-images.githubusercontent.com/1922453/113968966-38273580-9888-11eb-8a5d-0c41082f78db.png">

## Testing Instructions

1. Enable the OBW
2. See Product Types step and Business Details
3. Ensure the right things are hidden and there are no regressions