### PR TITLE
Fix nav unification header overflow breaking mobile views

### DIFF
--- a/store-on-wpcom/assets/css/admin/nav-unification.css
+++ b/store-on-wpcom/assets/css/admin/nav-unification.css
@@ -1,4 +1,6 @@
 /* Fix header overflow https://github.com/woocommerce/woocommerce-admin/issues/7035 */
-.jetpack-connected .woocommerce-layout__header {
-	width: calc( 100% - 272px );
+@media (min-width: 961px) {
+	.jetpack-connected .woocommerce-layout__header {
+		width: calc( 100% - 272px );
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/7035 again.

This PR is a follow-up to https://github.com/Automattic/wc-calypso-bridge/pull/680, which broke the header for screen width < `961px`.

### Testing instructions

1. In order to enable nav unification, make sure to have `wpcomsh` and Jetpack installed and connected.
2. If you're experiencing fatal error due to `wpcomsh` conflict, try using my [fork of the bridge helper](https://gist.github.com/ilyasfoo/3a898d3aca8c6a27acc851a28636332d).
2. Make sure new navigation feature is turned off.
3. Navigate to any WooCommerce page, observe a normal header.

### Screenshots

**Before:**

![image](https://user-images.githubusercontent.com/3747241/120609012-5f634300-c484-11eb-885d-0afae19670f9.png)

**After:**

![image](https://user-images.githubusercontent.com/3747241/120609289-9f2a2a80-c484-11eb-8ff6-072033de4a69.png)
