### PR TITLE
Remove Canada Post notice suppression and header fix

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -173,7 +173,7 @@ class WC_Calypso_Bridge {
 			add_filter( 'admin_footer_text', array( $this, 'update_woocommerce_footer' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'add_ecommerce_plan_styles' ) );
 
-			// Nav unification fixes.
+		// Nav unification fixes.
 		if ( function_exists( 'wpcomsh_activate_nav_unification' )
 			&& wpcomsh_activate_nav_unification( false )
 			&& ! Loader::is_feature_enabled( 'navigation' ) ) {

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -174,7 +174,7 @@ class WC_Calypso_Bridge {
 			add_action( 'admin_enqueue_scripts', array( $this, 'add_ecommerce_plan_styles' ) );
 
 			// Nav unification fixes.
-    if ( function_exists( 'wpcomsh_activate_nav_unification' )
+		if ( function_exists( 'wpcomsh_activate_nav_unification' )
 			&& wpcomsh_activate_nav_unification( false )
 			&& ! Loader::is_feature_enabled( 'navigation' ) ) {
 				add_action( 'admin_enqueue_scripts', array( $this, 'add_nav_unification_styles' ) );

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -9,6 +9,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\Loader;
+
 /**
  * WC Calypso Bridge
  */
@@ -172,7 +174,9 @@ class WC_Calypso_Bridge {
 			add_action( 'admin_enqueue_scripts', array( $this, 'add_ecommerce_plan_styles' ) );
 
 			// Nav unification fixes.
-			if ( function_exists( 'wpcomsh_activate_nav_unification' ) && wpcomsh_activate_nav_unification( false ) ) {
+    if ( function_exists( 'wpcomsh_activate_nav_unification' )
+			&& wpcomsh_activate_nav_unification( false )
+			&& ! Loader::is_feature_enabled( 'navigation' ) ) {
 				add_action( 'admin_enqueue_scripts', array( $this, 'add_nav_unification_styles' ) );
 			}
 		}

--- a/includes/class-wc-calypso-bridge-hide-alerts.php
+++ b/includes/class-wc-calypso-bridge-hide-alerts.php
@@ -87,9 +87,6 @@ class WC_Calypso_Bridge_Hide_Alerts {
 			WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', $class_name, current( $function_to_suppress ), key( $function_to_suppress ) );
 		}
 
-		// Canada Post Specific - refactor after launch to be included in the above loop.
-		WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', 'WC_Shipping_Canada_Post_Init', 'connect_canada_post', 10 );
-		WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', 'WC_Shipping_Canada_Post_Init', 'environment_check', 10 );
 		// Square Specific - refactor after launch to be included in the above loop.
 		WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', 'Woocommerce_Square', 'check_environment', 10 );
 		WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'admin_notices', 'Woocommerce_Square', 'is_connected_to_square', 10 );

--- a/store-on-wpcom/inc/wc-calypso-bridge-nav-unification-fixes.php
+++ b/store-on-wpcom/inc/wc-calypso-bridge-nav-unification-fixes.php
@@ -5,6 +5,8 @@
  * @since 1.7.4
  */
 
+use Automattic\WooCommerce\Admin\Loader;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -24,7 +26,9 @@ add_action( 'current_screen', 'load_ui_elements' );
  */
 function load_ui_elements() {
   if ( is_wc_calypso_bridge_page() ) {
-    if ( function_exists( 'wpcomsh_activate_nav_unification' ) && wpcomsh_activate_nav_unification( false ) ) {
+    if ( function_exists( 'wpcomsh_activate_nav_unification' )
+      && wpcomsh_activate_nav_unification( false )
+      && ! Loader::is_feature_enabled( 'navigation' ) ) {
       add_action( 'admin_enqueue_scripts', 'add_nav_unification_styles' );
     }
   }

--- a/store-on-wpcom/inc/wc-calypso-bridge-nav-unification-fixes.php
+++ b/store-on-wpcom/inc/wc-calypso-bridge-nav-unification-fixes.php
@@ -16,7 +16,7 @@ include_once dirname( __FILE__ ) . '/../../includes/class-wc-calypso-bridge-page
 // @todo This should rely on the navigation screens instead.
 $connect_files = glob( dirname( __FILE__ ) . '/../../includes/connect/*.php' );
 foreach ( $connect_files as $connect_file ) {
-  include_once $connect_file;
+	include_once $connect_file;
 }
 
 add_action( 'current_screen', 'load_ui_elements' );
@@ -25,19 +25,19 @@ add_action( 'current_screen', 'load_ui_elements' );
  * Updates required UI elements for calypso bridge pages only.
  */
 function load_ui_elements() {
-  if ( is_wc_calypso_bridge_page() ) {
-    if ( function_exists( 'wpcomsh_activate_nav_unification' )
-      && wpcomsh_activate_nav_unification( false )
-      && ! Loader::is_feature_enabled( 'navigation' ) ) {
-      add_action( 'admin_enqueue_scripts', 'add_nav_unification_styles' );
-    }
-  }
+	if ( is_wc_calypso_bridge_page() ) {
+		if ( function_exists( 'wpcomsh_activate_nav_unification' )
+			&& wpcomsh_activate_nav_unification( false )
+			&& ! Loader::is_feature_enabled( 'navigation' ) ) {
+			add_action( 'admin_enqueue_scripts', 'add_nav_unification_styles' );
+		}
+	}
 }
 
 /**
  * Add styles for nav unification fixes.
  */
 function add_nav_unification_styles() {
-  $asset_path = WC_Calypso_Bridge::$plugin_asset_path ? WC_Calypso_Bridge::$plugin_asset_path : WC_Calypso_Bridge::MU_PLUGIN_ASSET_PATH;
-  wp_enqueue_style( 'wp-calypso-bridge-nav-unification', $asset_path . 'assets/css/admin/nav-unification.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
+	$asset_path = WC_Calypso_Bridge::$plugin_asset_path ? WC_Calypso_Bridge::$plugin_asset_path : WC_Calypso_Bridge::MU_PLUGIN_ASSET_PATH;
+	wp_enqueue_style( 'wp-calypso-bridge-nav-unification', $asset_path . 'assets/css/admin/nav-unification.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
 }


### PR DESCRIPTION
Fixes #684.

This PR does the following:

- Removes the notice suppression for Canada Post since the extension requires a connection via woocommerce.com that can only be accessed via notice.
- Fix for header UI bug for e-commerce users. This was introduced in https://github.com/Automattic/wc-calypso-bridge/pull/682 where some e-commerce users with WooCommerce Navigation feature turned on but at the same time has nav unification flag enabled. The fix adds another check to make sure that Navigation feature is turned off before apply the original CSS fix.


## Testing instructions

1. Set the store's address to somewhere in Canada.
2. Install & activate `WooCommerce Canada Post Shipping` extension.
3. Observe the  "Connect Your Canada Post" notice in plugins page.

## Screenshots

### Canada Post notice:

![image](https://user-images.githubusercontent.com/3747241/122362787-010d8880-cf8b-11eb-8393-e9508528cde1.png)

### Header UI:

Before
![image](https://user-images.githubusercontent.com/3747241/122362526-c4da2800-cf8a-11eb-9607-0e05103b11bc.png)

After
![image](https://user-images.githubusercontent.com/3747241/122362579-d1f71700-cf8a-11eb-922a-e4a62ea77368.png)

