### PR TITLE
Add Tooling for React Pages

### DIFF
--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -42,6 +42,7 @@ class WC_Calypso_Bridge_Setup {
 		add_filter( 'wp_redirect', array( $this, 'prevent_redirects_on_activation' ), 10, 2 );
 		add_filter( 'woocommerce_admin_onboarding_product_types', array( $this, 'remove_paid_extension_upsells' ), 10, 2 );
 		add_filter( 'pre_option_woocommerce_homescreen_enabled', array( $this, 'always_enable_homescreen' ) );
+		add_action( 'admin_menu', array( $this, 'register_payments_welcome_page' ) );
 	}
 
 	/**
@@ -155,6 +156,19 @@ class WC_Calypso_Bridge_Setup {
 	 */
 	public function is_theme_installed( $theme ) {
 		return isset( $theme['is_installed'] ) && $theme['is_installed'];
+	}
+
+	/**
+	 * Registers the WooCommerce Payments welcome page.
+	 */
+	public function register_payments_welcome_page() {
+		wc_admin_register_page(
+			array(
+				'id'       => 'wc-calypso-bridge-payments-welcome-page',
+				'title'    => __( 'Payments', 'wc-calypso-bridge' ),
+				'path'     => '/payments-welcome',
+			)
+		);
 	}
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2018,6 +2018,33 @@
 				"loader-utils": "^2.0.0"
 			}
 		},
+		"@tannin/compile": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
+			"integrity": "sha512-n8m9eNDfoNZoxdvWiTfW/hSPhehzLJ3zW7f8E7oT6mCROoMNWCB4TYtv041+2FMAxweiE0j7i1jubQU4MEC/Gg==",
+			"requires": {
+				"@tannin/evaluate": "^1.2.0",
+				"@tannin/postfix": "^1.1.0"
+			}
+		},
+		"@tannin/evaluate": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.2.0.tgz",
+			"integrity": "sha512-3ioXvNowbO/wSrxsDG5DKIMxC81P0QrQTYai8zFNY+umuoHWRPbQ/TuuDEOju9E+jQDXmj6yI5GyejNuh8I+eg=="
+		},
+		"@tannin/plural-forms": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.1.0.tgz",
+			"integrity": "sha512-xl9R2mDZO/qiHam1AgMnAES6IKIg7OBhcXqy6eDsRCdXuxAFPcjrej9HMjyCLE0DJ/8cHf0i5OQTstuBRhpbHw==",
+			"requires": {
+				"@tannin/compile": "^1.1.0"
+			}
+		},
+		"@tannin/postfix": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
+			"integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw=="
+		},
 		"@types/anymatch": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -2567,6 +2594,14 @@
 				"eslint-plugin-testing-library": "^3.10.1",
 				"prettier": "npm:wp-prettier@2.2.1-beta-1",
 				"requireindex": "1.2.0"
+			},
+			"dependencies": {
+				"prettier": {
+					"version": "npm:wp-prettier@2.2.1-beta-1",
+					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+					"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/babel-plugin-import-jsx-pragma": {
@@ -2666,6 +2701,67 @@
 					"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-1.0.1.tgz",
 					"integrity": "sha512-LgnivcSTWqUgy5JE24+AKygtQsVvcdvNUGEyeM4K4urWgnyvmkeyZDfbN1nuK2b7E1oRMSSCCwxqQJDoxlFgUg==",
 					"dev": true
+				},
+				"prettier": {
+					"version": "npm:wp-prettier@2.2.1-beta-1",
+					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+					"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
+					"dev": true
+				}
+			}
+		},
+		"@wordpress/hooks": {
+			"version": "2.12.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.12.3.tgz",
+			"integrity": "sha512-LmKiwKldZt6UYqOxV/a6+eUFXdvALFnB/pQx3RmrMvO64sgFhfR6dhrlv+uVbuuezSuv8dce1jx8lUWAT0krMA==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+					"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				}
+			}
+		},
+		"@wordpress/i18n": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.1.1.tgz",
+			"integrity": "sha512-Ra/hxR8WCLqDp2P49Ibr9ANhZZZ8WHnsO+4WG3XDarJ3lmzux0TcRThDKRCcYHsW3pzieARmrEa/BOlYD7ZEjQ==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/hooks": "^3.1.1",
+				"gettext-parser": "^1.3.1",
+				"lodash": "^4.17.21",
+				"memize": "^1.1.0",
+				"sprintf-js": "^1.1.1",
+				"tannin": "^1.2.0"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+					"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@wordpress/hooks": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.1.1.tgz",
+					"integrity": "sha512-9f6H9WBwu6x/MM4ZCVLGGBuMiBcyaLapmAku5IwcWaeB2PtPduwjmk2NfGx35TuhBQD554DUg8WtTjIS019UAg==",
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"sprintf-js": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+					"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
 				}
 			}
 		},
@@ -2869,6 +2965,15 @@
 						"strip-bom": "^2.0.0"
 					}
 				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
 				"lru-cache": {
 					"version": "4.1.5",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -2878,6 +2983,30 @@
 						"pseudomap": "^1.0.2",
 						"yallist": "^2.1.2"
 					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
 				},
 				"parse-json": {
 					"version": "2.2.0",
@@ -2906,6 +3035,59 @@
 						"graceful-fs": "^4.1.2",
 						"pify": "^2.0.0",
 						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"pkg-dir": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.0.0"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "4.1.0",
+							"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+							"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+							"dev": true,
+							"requires": {
+								"locate-path": "^5.0.0",
+								"path-exists": "^4.0.0"
+							}
+						},
+						"path-exists": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+							"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+							"dev": true
+						}
+					}
+				},
+				"prettier": {
+					"version": "npm:wp-prettier@2.2.1-beta-1",
+					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+					"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
+					"dev": true
+				},
+				"puppeteer": {
+					"version": "npm:puppeteer-core@5.5.0",
+					"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
+					"integrity": "sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==",
+					"dev": true,
+					"requires": {
+						"debug": "^4.1.0",
+						"devtools-protocol": "0.0.818844",
+						"extract-zip": "^2.0.0",
+						"https-proxy-agent": "^4.0.0",
+						"node-fetch": "^2.6.1",
+						"pkg-dir": "^4.2.0",
+						"progress": "^2.0.1",
+						"proxy-from-env": "^1.0.0",
+						"rimraf": "^3.0.2",
+						"tar-fs": "^2.0.0",
+						"unbzip2-stream": "^1.3.3",
+						"ws": "^7.2.3"
 					}
 				},
 				"read-pkg": {
@@ -3745,6 +3927,16 @@
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
 			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
 			"dev": true
+		},
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"file-uri-to-path": "1.0.0"
+			}
 		},
 		"bl": {
 			"version": "4.1.0",
@@ -5354,6 +5546,24 @@
 			"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
 			"dev": true
 		},
+		"encoding": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+			"requires": {
+				"iconv-lite": "^0.6.2"
+			},
+			"dependencies": {
+				"iconv-lite": {
+					"version": "0.6.3",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+					"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3.0.0"
+					}
+				}
+			}
+		},
 		"end-of-stream": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -6570,6 +6780,13 @@
 				}
 			}
 		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"dev": true,
+			"optional": true
+		},
 		"fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -7209,6 +7426,15 @@
 			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
+			}
+		},
+		"gettext-parser": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+			"integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+			"requires": {
+				"encoding": "^0.1.12",
+				"safe-buffer": "^5.1.1"
 			}
 		},
 		"glob": {
@@ -10010,8 +10236,7 @@
 		"lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"lodash.debounce": {
 			"version": "4.0.8",
@@ -10378,6 +10603,11 @@
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
 			"integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
 			"dev": true
+		},
+		"memize": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+			"integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg=="
 		},
 		"memory-fs": {
 			"version": "0.4.1",
@@ -10879,6 +11109,13 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
+		},
+		"nan": {
+			"version": "2.14.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+			"integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+			"dev": true,
+			"optional": true
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -12056,10 +12293,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "npm:wp-prettier@2.2.1-beta-1",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-			"dev": true
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+			"integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ=="
 		},
 		"prettier-linter-helpers": {
 			"version": "1.0.0",
@@ -12254,86 +12490,6 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
-		},
-		"puppeteer": {
-			"version": "npm:puppeteer-core@5.5.0",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
-			"integrity": "sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==",
-			"dev": true,
-			"requires": {
-				"debug": "^4.1.0",
-				"devtools-protocol": "0.0.818844",
-				"extract-zip": "^2.0.0",
-				"https-proxy-agent": "^4.0.0",
-				"node-fetch": "^2.6.1",
-				"pkg-dir": "^4.2.0",
-				"progress": "^2.0.1",
-				"proxy-from-env": "^1.0.0",
-				"rimraf": "^3.0.2",
-				"tar-fs": "^2.0.0",
-				"unbzip2-stream": "^1.3.3",
-				"ws": "^7.2.3"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				},
-				"pkg-dir": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-					"dev": true,
-					"requires": {
-						"find-up": "^4.0.0"
-					}
-				}
-			}
 		},
 		"q": {
 			"version": "1.5.1",
@@ -12596,8 +12752,7 @@
 		"regenerator-runtime": {
 			"version": "0.13.7",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-			"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-			"dev": true
+			"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
 		},
 		"regenerator-transform": {
 			"version": "0.14.5",
@@ -13046,8 +13201,7 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"safe-json-parse": {
 			"version": "1.0.1",
@@ -13067,8 +13221,7 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"sane": {
 			"version": "4.1.0",
@@ -14553,6 +14706,14 @@
 				}
 			}
 		},
+		"tannin": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
+			"integrity": "sha512-U7GgX/RcSeUETbV7gYgoz8PD7Ni4y95pgIP/Z6ayI3CfhSujwKEBlGFTCRN+Aqnuyf4AN2yHL+L8x+TCGjb9uA==",
+			"requires": {
+				"@tannin/plural-forms": "^1.1.0"
+			}
+		},
 		"tapable": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
@@ -15602,7 +15763,11 @@
 					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
 					"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"bindings": "^1.5.0",
+						"nan": "^2.12.1"
+					}
 				},
 				"glob-parent": {
 					"version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
 	"devDependencies": {
 		"@woocommerce/dependency-extraction-webpack-plugin": "1.4.0",
 		"@woocommerce/eslint-plugin": "1.1.0",
-		"@wordpress/scripts": "^13.0.3"
+		"@wordpress/scripts": "^13.0.3",
+		"prettier": "^2.3.2"
 	},
 	"dependencies": {
 		"@wordpress/hooks": "^2.11.1"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"prettier": "^2.3.2"
 	},
 	"dependencies": {
-		"@wordpress/hooks": "^2.11.1"
+		"@wordpress/hooks": "^2.12.3",
+		"@wordpress/i18n": "^4.1.1"
 	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,26 @@
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { addFilter } from '@wordpress/hooks';
+
+/**
  * Internal dependencies
  */
 import wcNavFilterRootUrl from './wc-navigation-root-url';
+import PaymentsWelcomePage from './payments-welcome';
 
 wcNavFilterRootUrl();
+
+addFilter('woocommerce_admin_pages_list', 'wc-calypso-bridge', (pages) => {
+	pages.push({
+		container: PaymentsWelcomePage,
+		path: '/payments-welcome',
+		breadcrumbs: [__('WooCommerce Payments', 'wc-calypso-bridge')],
+		navArgs: {
+			id: 'wc-calypso-bridge-payments-welcome-page',
+		},
+	});
+
+	return pages;
+});

--- a/src/payments-welcome/index.js
+++ b/src/payments-welcome/index.js
@@ -1,0 +1,5 @@
+const PaymentsWelcomePage = () => (
+	<p>This is the WooCommerce Payments welcome page!</p>
+);
+
+export default PaymentsWelcomePage;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wc-calypso-bridge/issues/693

The Bridge had more support for React already than I expected. 

I used [this guide](https://developer.woocommerce.com/extension-developer-guide/working-with-woocommerce-admin-pages/) to add a dummy page using WC Admin APIs. This added a "Payments" menu item to the normal WP menu. However it does not appear in the new Woo Navigation. We could investigate that further in issue https://github.com/Automattic/wc-calypso-bridge/issues/688.

![image](https://user-images.githubusercontent.com/9312929/124281428-48e00280-db7c-11eb-89c0-2e8449ea170e.png)

![image](https://user-images.githubusercontent.com/9312929/124281527-601ef000-db7c-11eb-8add-09436f8b983a.png)

Dependencies were added to package.json:
- `prettier`
- `@wordpress/hooks`
- `@wordpress/i18n`

### Testing Instructions

- Install the [helper plugin from the gist](https://gist.github.com/psealock/531205e2c3d37be1d8ac4d3ef4f346bc) listed in the README.
- See that the "Payments" menu item appears.
- Modify the `PaymentsWelcomePage` React component and check that it builds ok.