### PR TITLE
Remove filters adding the Payments menu item

### DIFF
--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -42,7 +42,6 @@ class WC_Calypso_Bridge_Setup {
 		add_filter( 'wp_redirect', array( $this, 'prevent_redirects_on_activation' ), 10, 2 );
 		add_filter( 'woocommerce_admin_onboarding_product_types', array( $this, 'remove_paid_extension_upsells' ), 10, 2 );
 		add_filter( 'pre_option_woocommerce_homescreen_enabled', array( $this, 'always_enable_homescreen' ) );
-		add_action( 'admin_menu', array( $this, 'register_payments_welcome_page' ) );
 	}
 
 	/**

--- a/src/index.js
+++ b/src/index.js
@@ -11,16 +11,3 @@ import wcNavFilterRootUrl from './wc-navigation-root-url';
 import PaymentsWelcomePage from './payments-welcome';
 
 wcNavFilterRootUrl();
-
-addFilter('woocommerce_admin_pages_list', 'wc-calypso-bridge', (pages) => {
-	pages.push({
-		container: PaymentsWelcomePage,
-		path: '/payments-welcome',
-		breadcrumbs: [__('WooCommerce Payments', 'wc-calypso-bridge')],
-		navArgs: {
-			id: 'wc-calypso-bridge-payments-welcome-page',
-		},
-	});
-
-	return pages;
-});


### PR DESCRIPTION
PR #695 was merged to `master` prematurely as it contains a dummy menu item. To prevent any possible early deployment of this work, this PR temporarily removes the filters that add the menu item.

There is now a `payments` development branch containing the work in progress for this feature.

### Testing Instructions

Ensure a "Payments" menu item does not render.