### PR TITLE
Add TypeScript Support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,4 +9,27 @@ module.exports = {
 			{ definedTags: [ 'jest-environment' ] },
 		],
 	},
+	overrides: [
+		{
+			files: ['*.ts', '*.tsx'],
+			parser: '@typescript-eslint/parser',
+			extends: [
+				'plugin:@woocommerce/eslint-plugin/recommended',
+				'plugin:@typescript-eslint/recommended',
+			],
+			rules: {
+				camelcase: 'off',
+				'import/no-unresolved': 'warn',
+				'import/no-extraneous-dependencies': 'warn',
+				'@typescript-eslint/no-explicit-any': 'error',
+				'no-use-before-define': 'off',
+				'@typescript-eslint/no-use-before-define': ['error'],
+				'jsdoc/require-param': 'off',
+				// Making use of typescript no-shadow instead, fixes issues with enum.
+				'no-shadow': 'off',
+				'@typescript-eslint/no-shadow': ['error'],
+				'@typescript-eslint/no-empty-function': 'off',
+			},
+		},
+	],
 };

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,7 @@
+{
+    "presets": [
+        "@babel/react",
+        "@babel/typescript",
+        "@wordpress/babel-preset-default"
+    ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,63 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@babel/cli": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.14.5.tgz",
+			"integrity": "sha512-poegjhRvXHWO0EAsnYajwYZuqcz7gyfxwfaecUESxDujrqOivf3zrjFbub8IJkrqEaz3fvJWh001EzxBub54fg==",
+			"dev": true,
+			"requires": {
+				"@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.2",
+				"chokidar": "^3.4.0",
+				"commander": "^4.0.1",
+				"convert-source-map": "^1.1.0",
+				"fs-readdir-recursive": "^1.1.0",
+				"glob": "^7.0.0",
+				"make-dir": "^2.1.0",
+				"slash": "^2.0.0",
+				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+					"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+					"dev": true
+				},
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+					"dev": true,
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					}
+				},
+				"pify": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+					"dev": true
+				},
+				"slash": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
 		"@babel/code-frame": {
 			"version": "7.12.13",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
 			"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-			"dev": true,
 			"requires": {
 				"@babel/highlight": "^7.12.13"
 			}
@@ -16,33 +68,275 @@
 		"@babel/compat-data": {
 			"version": "7.13.6",
 			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.6.tgz",
-			"integrity": "sha512-VhgqKOWYVm7lQXlvbJnWOzwfAQATd2nV52koT0HZ/LdDH0m4DUDwkKYsH+IwpXb+bKPyBJzawA4I6nBKqZcpQw==",
-			"dev": true
+			"integrity": "sha512-VhgqKOWYVm7lQXlvbJnWOzwfAQATd2nV52koT0HZ/LdDH0m4DUDwkKYsH+IwpXb+bKPyBJzawA4I6nBKqZcpQw=="
 		},
 		"@babel/core": {
-			"version": "7.13.1",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.1.tgz",
-			"integrity": "sha512-FzeKfFBG2rmFtGiiMdXZPFt/5R5DXubVi82uYhjGX4Msf+pgYQMCFIqFXZWs5vbIYbf14VeBIgdGI03CDOOM1w==",
+			"version": "7.14.6",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.6.tgz",
+			"integrity": "sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.12.13",
-				"@babel/generator": "^7.13.0",
-				"@babel/helper-compilation-targets": "^7.13.0",
-				"@babel/helper-module-transforms": "^7.13.0",
-				"@babel/helpers": "^7.13.0",
-				"@babel/parser": "^7.13.0",
-				"@babel/template": "^7.12.13",
-				"@babel/traverse": "^7.13.0",
-				"@babel/types": "^7.13.0",
+				"@babel/code-frame": "^7.14.5",
+				"@babel/generator": "^7.14.5",
+				"@babel/helper-compilation-targets": "^7.14.5",
+				"@babel/helper-module-transforms": "^7.14.5",
+				"@babel/helpers": "^7.14.6",
+				"@babel/parser": "^7.14.6",
+				"@babel/template": "^7.14.5",
+				"@babel/traverse": "^7.14.5",
+				"@babel/types": "^7.14.5",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
 				"json5": "^2.1.2",
-				"lodash": "^4.17.19",
-				"semver": "7.0.0",
+				"semver": "^6.3.0",
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+					"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.14.5"
+					}
+				},
+				"@babel/compat-data": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz",
+					"integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==",
+					"dev": true
+				},
+				"@babel/generator": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
+					"integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-compilation-targets": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
+					"integrity": "sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==",
+					"dev": true,
+					"requires": {
+						"@babel/compat-data": "^7.14.5",
+						"@babel/helper-validator-option": "^7.14.5",
+						"browserslist": "^4.16.6",
+						"semver": "^6.3.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+					"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.14.5",
+						"@babel/template": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+					"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-hoist-variables": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
+					"integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
+					"integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
+					"integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz",
+					"integrity": "sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.14.5",
+						"@babel/helper-replace-supers": "^7.14.5",
+						"@babel/helper-simple-access": "^7.14.5",
+						"@babel/helper-split-export-declaration": "^7.14.5",
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"@babel/template": "^7.14.5",
+						"@babel/traverse": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
+					"integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
+					"integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.14.5",
+						"@babel/helper-optimise-call-expression": "^7.14.5",
+						"@babel/traverse": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz",
+					"integrity": "sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+					"integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+					"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+					"dev": true
+				},
+				"@babel/helper-validator-option": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+					"integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+					"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
+					"integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+					"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/parser": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
+					"integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/generator": "^7.14.5",
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/helper-hoist-variables": "^7.14.5",
+						"@babel/helper-split-export-declaration": "^7.14.5",
+						"@babel/parser": "^7.14.7",
+						"@babel/types": "^7.14.5",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+					"integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"browserslist": {
+					"version": "4.16.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+					"integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30001219",
+						"colorette": "^1.2.2",
+						"electron-to-chromium": "^1.3.723",
+						"escalade": "^3.1.1",
+						"node-releases": "^1.1.71"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30001242",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz",
+					"integrity": "sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug==",
+					"dev": true
+				},
+				"colorette": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+					"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+					"dev": true
+				},
+				"electron-to-chromium": {
+					"version": "1.3.766",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.766.tgz",
+					"integrity": "sha512-u2quJ862q9reRKh/je3GXis3w38+RoXH1J9N3XjtsS6NzmUAosNsyZgUVFZPN/ZlJ3v6T0rTyZR3q/J5c6Sy5w==",
+					"dev": true
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
 				"json5": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
@@ -53,9 +347,9 @@
 					}
 				},
 				"semver": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-					"integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				},
 				"source-map": {
@@ -70,7 +364,6 @@
 			"version": "7.13.0",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.0.tgz",
 			"integrity": "sha512-zBZfgvBB/ywjx0Rgc2+BwoH/3H+lDtlgD4hBOpEv5LxRnYsm/753iRuLepqnYlynpjC3AdQxtxsoeHJoEEwOAw==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.13.0",
 				"jsesc": "^2.5.1",
@@ -80,8 +373,7 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
@@ -89,7 +381,6 @@
 			"version": "7.12.13",
 			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.13.tgz",
 			"integrity": "sha512-7YXfX5wQ5aYM/BOlbSccHDbuXXFPxeoUmfWtz8le2yTkTZc+BxsiEnENFoi2SlmA8ewDkG2LgIMIVzzn2h8kfw==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.12.13"
 			}
@@ -108,7 +399,6 @@
 			"version": "7.13.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.0.tgz",
 			"integrity": "sha512-SOWD0JK9+MMIhTQiUVd4ng8f3NXhPVQvTv7D3UN4wbp/6cAHnB2EmMaU1zZA2Hh1gwme+THBrVSqTFxHczTh0Q==",
-			"dev": true,
 			"requires": {
 				"@babel/compat-data": "^7.13.0",
 				"@babel/helper-validator-option": "^7.12.17",
@@ -119,8 +409,7 @@
 				"semver": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-					"integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-					"dev": true
+					"integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="
 				}
 			}
 		},
@@ -141,7 +430,6 @@
 			"version": "7.12.17",
 			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.17.tgz",
 			"integrity": "sha512-p2VGmBu9oefLZ2nQpgnEnG0ZlRPvL8gAGvPUMQwUdaE8k49rOMuZpOwdQoy5qJf6K8jL3bcAMhVUlHAjIgJHUg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.12.13",
 				"regexpu-core": "^4.7.1"
@@ -184,7 +472,6 @@
 			"version": "7.12.13",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
 			"integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-get-function-arity": "^7.12.13",
 				"@babel/template": "^7.12.13",
@@ -195,7 +482,6 @@
 			"version": "7.12.13",
 			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
 			"integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.12.13"
 			}
@@ -223,7 +509,6 @@
 			"version": "7.12.13",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
 			"integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.12.13"
 			}
@@ -257,8 +542,7 @@
 		"@babel/helper-plugin-utils": {
 			"version": "7.13.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
-			"integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
-			"dev": true
+			"integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ=="
 		},
 		"@babel/helper-remap-async-to-generator": {
 			"version": "7.13.0",
@@ -305,7 +589,6 @@
 			"version": "7.12.13",
 			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
 			"integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.12.13"
 			}
@@ -313,14 +596,12 @@
 		"@babel/helper-validator-identifier": {
 			"version": "7.12.11",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-			"dev": true
+			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
 		},
 		"@babel/helper-validator-option": {
 			"version": "7.12.17",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
-			"integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
-			"dev": true
+			"integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw=="
 		},
 		"@babel/helper-wrap-function": {
 			"version": "7.13.0",
@@ -335,21 +616,153 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.13.0",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.0.tgz",
-			"integrity": "sha512-aan1MeFPxFacZeSz6Ld7YZo5aPuqnKlD7+HZY75xQsueczFccP9A7V05+oe0XpLwHK3oLorPe9eaAUljL7WEaQ==",
+			"version": "7.14.6",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.6.tgz",
+			"integrity": "sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.12.13",
-				"@babel/traverse": "^7.13.0",
-				"@babel/types": "^7.13.0"
+				"@babel/template": "^7.14.5",
+				"@babel/traverse": "^7.14.5",
+				"@babel/types": "^7.14.5"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+					"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.14.5"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
+					"integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+					"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.14.5",
+						"@babel/template": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+					"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-hoist-variables": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
+					"integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+					"integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+					"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+					"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
+					"integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+					"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/parser": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
+					"integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/generator": "^7.14.5",
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/helper-hoist-variables": "^7.14.5",
+						"@babel/helper-split-export-declaration": "^7.14.5",
+						"@babel/parser": "^7.14.7",
+						"@babel/types": "^7.14.5",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+					"integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/highlight": {
 			"version": "7.12.13",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
 			"integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.12.11",
 				"chalk": "^2.0.0",
@@ -359,8 +772,56 @@
 		"@babel/parser": {
 			"version": "7.13.4",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.4.tgz",
-			"integrity": "sha512-uvoOulWHhI+0+1f9L4BoozY7U5cIkZ9PgJqvb041d6vypgUmtVPG4vmGm4pSggjl8BELzvHyUeJSUyEMY6b+qA==",
-			"dev": true
+			"integrity": "sha512-uvoOulWHhI+0+1f9L4BoozY7U5cIkZ9PgJqvb041d6vypgUmtVPG4vmGm4pSggjl8BELzvHyUeJSUyEMY6b+qA=="
+		},
+		"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.14.5.tgz",
+			"integrity": "sha512-ZoJS2XCKPBfTmL122iP6NM9dOg+d4lc9fFk3zxc8iDjvt8Pk4+TlsHSKhIPf6X+L5ORCdBzqMZDjL/WHj7WknQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.14.5",
+				"@babel/plugin-proposal-optional-chaining": "^7.14.5"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+					"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+				},
+				"@babel/helper-skip-transparent-expression-wrappers": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.14.5.tgz",
+					"integrity": "sha512-dmqZB7mrb94PZSAOYtr+ZN5qt5owZIAgqtoTuqiFbHFtxgEcmQlRJVI+bO++fciBunXtB6MK7HrzrfcAzIz2NQ==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+					"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg=="
+				},
+				"@babel/plugin-proposal-optional-chaining": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.14.5.tgz",
+					"integrity": "sha512-ycz+VOzo2UbWNI1rQXxIuMOzrDdHGrI23fRiz/Si2R4kv2XZQ1BK8ccdHwehMKBlcH/joGW/tzrUmo67gbJHlQ==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/helper-skip-transparent-expression-wrappers": "^7.14.5",
+						"@babel/plugin-syntax-optional-chaining": "^7.8.3"
+					}
+				},
+				"@babel/types": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+					"integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
 			"version": "7.13.5",
@@ -381,6 +842,188 @@
 			"requires": {
 				"@babel/helper-create-class-features-plugin": "^7.13.0",
 				"@babel/helper-plugin-utils": "^7.13.0"
+			}
+		},
+		"@babel/plugin-proposal-class-static-block": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.14.5.tgz",
+			"integrity": "sha512-KBAH5ksEnYHCegqseI5N9skTdxgJdmDoAOc0uXa+4QMYKeZD0w5IARh4FMlTNtaHhbB8v+KzMdTgxMMzsIy6Yg==",
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.14.5",
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/plugin-syntax-class-static-block": "^7.14.5"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+					"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+					"requires": {
+						"@babel/highlight": "^7.14.5"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
+					"integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
+					"requires": {
+						"@babel/types": "^7.14.5",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-annotate-as-pure": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.14.5.tgz",
+					"integrity": "sha512-EivH9EgBIb+G8ij1B2jAwSH36WnGvkQSEC6CkX/6v6ZFlw5fVOHvsgGF4uiEHO2GzMvunZb6tDLQEQSdrdocrA==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-create-class-features-plugin": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.6.tgz",
+					"integrity": "sha512-Z6gsfGofTxH/+LQXqYEK45kxmcensbzmk/oi8DmaQytlQCgqNZt9XQF8iqlI/SeXWVjaMNxvYvzaYw+kh42mDg==",
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.14.5",
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/helper-member-expression-to-functions": "^7.14.5",
+						"@babel/helper-optimise-call-expression": "^7.14.5",
+						"@babel/helper-replace-supers": "^7.14.5",
+						"@babel/helper-split-export-declaration": "^7.14.5"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+					"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.14.5",
+						"@babel/template": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+					"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-hoist-variables": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
+					"integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
+					"integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
+					"integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+					"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
+					"integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.14.5",
+						"@babel/helper-optimise-call-expression": "^7.14.5",
+						"@babel/traverse": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+					"integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+					"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg=="
+				},
+				"@babel/highlight": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+					"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
+					"integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA=="
+				},
+				"@babel/template": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+					"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/parser": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
+					"integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/generator": "^7.14.5",
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/helper-hoist-variables": "^7.14.5",
+						"@babel/helper-split-export-declaration": "^7.14.5",
+						"@babel/parser": "^7.14.7",
+						"@babel/types": "^7.14.5",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+					"integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				}
 			}
 		},
 		"@babel/plugin-proposal-dynamic-import": {
@@ -485,11 +1128,193 @@
 				"@babel/helper-plugin-utils": "^7.13.0"
 			}
 		},
+		"@babel/plugin-proposal-private-property-in-object": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.14.5.tgz",
+			"integrity": "sha512-62EyfyA3WA0mZiF2e2IV9mc9Ghwxcg8YTu8BS4Wss4Y3PY725OmS9M0qLORbJwLqFtGh+jiE4wAmocK2CTUK2Q==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.14.5",
+				"@babel/helper-create-class-features-plugin": "^7.14.5",
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+					"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+					"requires": {
+						"@babel/highlight": "^7.14.5"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
+					"integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
+					"requires": {
+						"@babel/types": "^7.14.5",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-annotate-as-pure": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.14.5.tgz",
+					"integrity": "sha512-EivH9EgBIb+G8ij1B2jAwSH36WnGvkQSEC6CkX/6v6ZFlw5fVOHvsgGF4uiEHO2GzMvunZb6tDLQEQSdrdocrA==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-create-class-features-plugin": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.6.tgz",
+					"integrity": "sha512-Z6gsfGofTxH/+LQXqYEK45kxmcensbzmk/oi8DmaQytlQCgqNZt9XQF8iqlI/SeXWVjaMNxvYvzaYw+kh42mDg==",
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.14.5",
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/helper-member-expression-to-functions": "^7.14.5",
+						"@babel/helper-optimise-call-expression": "^7.14.5",
+						"@babel/helper-replace-supers": "^7.14.5",
+						"@babel/helper-split-export-declaration": "^7.14.5"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+					"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.14.5",
+						"@babel/template": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+					"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-hoist-variables": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
+					"integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
+					"integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
+					"integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+					"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
+					"integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.14.5",
+						"@babel/helper-optimise-call-expression": "^7.14.5",
+						"@babel/traverse": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+					"integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+					"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg=="
+				},
+				"@babel/highlight": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+					"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
+					"integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA=="
+				},
+				"@babel/template": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+					"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/parser": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
+					"integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/generator": "^7.14.5",
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/helper-hoist-variables": "^7.14.5",
+						"@babel/helper-split-export-declaration": "^7.14.5",
+						"@babel/parser": "^7.14.7",
+						"@babel/types": "^7.14.5",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+					"integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				}
+			}
+		},
 		"@babel/plugin-proposal-unicode-property-regex": {
 			"version": "7.12.13",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.12.13.tgz",
 			"integrity": "sha512-XyJmZidNfofEkqFV5VC/bLabGmO5QzenPO/YOfGuEbgU+2sSwMmio3YLb4WtBgcmmdwZHyVyv8on77IUjQ5Gvg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-create-regexp-features-plugin": "^7.12.13",
 				"@babel/helper-plugin-utils": "^7.12.13"
@@ -499,7 +1324,6 @@
 			"version": "7.8.4",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
 			"integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			}
@@ -517,16 +1341,29 @@
 			"version": "7.12.13",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
 			"integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.12.13"
+			}
+		},
+		"@babel/plugin-syntax-class-static-block": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+			"integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+					"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+				}
 			}
 		},
 		"@babel/plugin-syntax-dynamic-import": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
 			"integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			}
@@ -535,7 +1372,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
 			"integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
 			}
@@ -553,7 +1389,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
 			"integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			}
@@ -562,7 +1397,6 @@
 			"version": "7.12.13",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.13.tgz",
 			"integrity": "sha512-d4HM23Q1K7oq/SLNmG6mRt85l2csmQ0cHRaxRXjKW0YFdEXqlZ5kzFQKH5Uc3rDJECgu+yCRgPkG04Mm98R/1g==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.12.13"
 			}
@@ -571,7 +1405,6 @@
 			"version": "7.10.4",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
 			"integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
@@ -580,7 +1413,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
 			"integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			}
@@ -589,7 +1421,6 @@
 			"version": "7.10.4",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
 			"integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
@@ -598,7 +1429,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
 			"integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			}
@@ -607,7 +1437,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
 			"integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			}
@@ -616,9 +1445,23 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
 			"integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-private-property-in-object": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+			"integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+					"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+				}
 			}
 		},
 		"@babel/plugin-syntax-top-level-await": {
@@ -628,6 +1471,21 @@
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.12.13"
+			}
+		},
+		"@babel/plugin-syntax-typescript": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.14.5.tgz",
+			"integrity": "sha512-u6OXzDaIXjEstBRRoBCQ/uKQKlbuaeE5in0RvWdA4pN6AhqxTIwUsnHPU1CFZA/amYObMsuWhYfRl3Ch90HD0Q==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+					"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+				}
 			}
 		},
 		"@babel/plugin-transform-arrow-functions": {
@@ -713,7 +1571,6 @@
 			"version": "7.12.13",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.12.13.tgz",
 			"integrity": "sha512-foDrozE65ZFdUC2OfgeOCrEPTxdB3yjqxpXh8CH+ipd9CHd4s/iq81kcUpyH8ACGNEPdFqbtzfgzbT/ZGlbDeQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-create-regexp-features-plugin": "^7.12.13",
 				"@babel/helper-plugin-utils": "^7.12.13"
@@ -889,7 +1746,6 @@
 			"version": "7.12.17",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.17.tgz",
 			"integrity": "sha512-mwaVNcXV+l6qJOuRhpdTEj8sT/Z0owAVWf9QujTZ0d2ye9X/K+MTOTSizcgKOj18PGnTc/7g1I4+cIUjsKhBcw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.12.13",
 				"@babel/helper-module-imports": "^7.12.13",
@@ -936,24 +1792,139 @@
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.13.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.13.7.tgz",
-			"integrity": "sha512-pXfYTTSbU5ThVTUyQ6TUdUkonZYKKq8M6vDUkFCjFw8vT42hhayrbJPVWGC7B97LkzFYBtdW/SBGVZtRaopW6Q==",
-			"dev": true,
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.14.5.tgz",
+			"integrity": "sha512-fPMBhh1AV8ZyneiCIA+wYYUH1arzlXR1UMcApjvchDhfKxhy2r2lReJv8uHEyihi4IFIGlr1Pdx7S5fkESDQsg==",
 			"requires": {
-				"@babel/helper-module-imports": "^7.12.13",
-				"@babel/helper-plugin-utils": "^7.13.0",
-				"babel-plugin-polyfill-corejs2": "^0.1.4",
-				"babel-plugin-polyfill-corejs3": "^0.1.3",
-				"babel-plugin-polyfill-regenerator": "^0.1.2",
-				"semver": "7.0.0"
+				"@babel/helper-module-imports": "^7.14.5",
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"babel-plugin-polyfill-corejs2": "^0.2.2",
+				"babel-plugin-polyfill-corejs3": "^0.2.2",
+				"babel-plugin-polyfill-regenerator": "^0.2.2",
+				"semver": "^6.3.0"
 			},
 			"dependencies": {
+				"@babel/compat-data": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz",
+					"integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw=="
+				},
+				"@babel/helper-define-polyfill-provider": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.3.tgz",
+					"integrity": "sha512-RH3QDAfRMzj7+0Nqu5oqgO5q9mFtQEVvCRsi8qCEfzLR9p2BHfn5FzhSB2oj1fF7I2+DcTORkYaQ6aTR9Cofew==",
+					"requires": {
+						"@babel/helper-compilation-targets": "^7.13.0",
+						"@babel/helper-module-imports": "^7.12.13",
+						"@babel/helper-plugin-utils": "^7.13.0",
+						"@babel/traverse": "^7.13.0",
+						"debug": "^4.1.1",
+						"lodash.debounce": "^4.0.8",
+						"resolve": "^1.14.2",
+						"semver": "^6.1.2"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
+					"integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+					"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+					"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg=="
+				},
+				"@babel/types": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+					"integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"babel-plugin-polyfill-corejs2": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.2.tgz",
+					"integrity": "sha512-kISrENsJ0z5dNPq5eRvcctITNHYXWOA4DUZRFYCz3jYCcvTb/A546LIddmoGNMVYg2U38OyFeNosQwI9ENTqIQ==",
+					"requires": {
+						"@babel/compat-data": "^7.13.11",
+						"@babel/helper-define-polyfill-provider": "^0.2.2",
+						"semver": "^6.1.1"
+					}
+				},
+				"babel-plugin-polyfill-corejs3": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.3.tgz",
+					"integrity": "sha512-rCOFzEIJpJEAU14XCcV/erIf/wZQMmMT5l5vXOpL5uoznyOGfDIjPj6FVytMvtzaKSTSVKouOCTPJ5OMUZH30g==",
+					"requires": {
+						"@babel/helper-define-polyfill-provider": "^0.2.2",
+						"core-js-compat": "^3.14.0"
+					}
+				},
+				"babel-plugin-polyfill-regenerator": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.2.tgz",
+					"integrity": "sha512-Goy5ghsc21HgPDFtzRkSirpZVW35meGoTmTOb2bxqdl60ghub4xOidgNTHaZfQ2FaxQsKmwvXtOAkcIS4SMBWg==",
+					"requires": {
+						"@babel/helper-define-polyfill-provider": "^0.2.2"
+					}
+				},
+				"browserslist": {
+					"version": "4.16.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+					"integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+					"requires": {
+						"caniuse-lite": "^1.0.30001219",
+						"colorette": "^1.2.2",
+						"electron-to-chromium": "^1.3.723",
+						"escalade": "^3.1.1",
+						"node-releases": "^1.1.71"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30001242",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz",
+					"integrity": "sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug=="
+				},
+				"colorette": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+					"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
+				},
+				"core-js-compat": {
+					"version": "3.15.2",
+					"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.15.2.tgz",
+					"integrity": "sha512-Wp+BJVvwopjI+A1EFqm2dwUmWYXrvucmtIB2LgXn/Rb+gWPKYxtmb4GKHGKG/KGF1eK9jfjzT38DITbTOCX/SQ==",
+					"requires": {
+						"browserslist": "^4.16.6",
+						"semver": "7.0.0"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "7.0.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+							"integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="
+						}
+					}
+				},
+				"electron-to-chromium": {
+					"version": "1.3.766",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.766.tgz",
+					"integrity": "sha512-u2quJ862q9reRKh/je3GXis3w38+RoXH1J9N3XjtsS6NzmUAosNsyZgUVFZPN/ZlJ3v6T0rTyZR3q/J5c6Sy5w=="
+				},
 				"semver": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-					"integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-					"dev": true
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},
@@ -1001,6 +1972,188 @@
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.12.13"
+			}
+		},
+		"@babel/plugin-transform-typescript": {
+			"version": "7.14.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.14.6.tgz",
+			"integrity": "sha512-XlTdBq7Awr4FYIzqhmYY80WN0V0azF74DMPyFqVHBvf81ZUgc4X7ZOpx6O8eLDK6iM5cCQzeyJw0ynTaefixRA==",
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.14.6",
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/plugin-syntax-typescript": "^7.14.5"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+					"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+					"requires": {
+						"@babel/highlight": "^7.14.5"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
+					"integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
+					"requires": {
+						"@babel/types": "^7.14.5",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-annotate-as-pure": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.14.5.tgz",
+					"integrity": "sha512-EivH9EgBIb+G8ij1B2jAwSH36WnGvkQSEC6CkX/6v6ZFlw5fVOHvsgGF4uiEHO2GzMvunZb6tDLQEQSdrdocrA==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-create-class-features-plugin": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.6.tgz",
+					"integrity": "sha512-Z6gsfGofTxH/+LQXqYEK45kxmcensbzmk/oi8DmaQytlQCgqNZt9XQF8iqlI/SeXWVjaMNxvYvzaYw+kh42mDg==",
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.14.5",
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/helper-member-expression-to-functions": "^7.14.5",
+						"@babel/helper-optimise-call-expression": "^7.14.5",
+						"@babel/helper-replace-supers": "^7.14.5",
+						"@babel/helper-split-export-declaration": "^7.14.5"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+					"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.14.5",
+						"@babel/template": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+					"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-hoist-variables": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
+					"integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
+					"integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
+					"integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+					"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
+					"integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.14.5",
+						"@babel/helper-optimise-call-expression": "^7.14.5",
+						"@babel/traverse": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+					"integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+					"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg=="
+				},
+				"@babel/highlight": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+					"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
+					"integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA=="
+				},
+				"@babel/template": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+					"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/parser": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
+					"integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/generator": "^7.14.5",
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/helper-hoist-variables": "^7.14.5",
+						"@babel/helper-split-export-declaration": "^7.14.5",
+						"@babel/parser": "^7.14.7",
+						"@babel/types": "^7.14.5",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+					"integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				}
 			}
 		},
 		"@babel/plugin-transform-unicode-escapes": {
@@ -1110,7 +2263,6 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
 			"integrity": "sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
@@ -1132,13 +2284,52 @@
 				"@babel/plugin-transform-react-pure-annotations": "^7.12.1"
 			}
 		},
+		"@babel/preset-typescript": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.14.5.tgz",
+			"integrity": "sha512-u4zO6CdbRKbS9TypMqrlGH7sd2TAJppZwn3c/ZRLeO/wGsbddxgbPDUZVNrie3JWYLQ9vpineKlsrWFvO6Pwkw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/helper-validator-option": "^7.14.5",
+				"@babel/plugin-transform-typescript": "^7.14.5"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+					"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+				},
+				"@babel/helper-validator-option": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+					"integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow=="
+				}
+			}
+		},
 		"@babel/runtime": {
 			"version": "7.13.7",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.7.tgz",
 			"integrity": "sha512-h+ilqoX998mRVM5FtB5ijRuHUDVt5l3yfoOi2uh18Z/O3hvyaHQ39NpxVkCIG5yFs+mLq/ewFp8Bss6zmWv6ZA==",
-			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
+			}
+		},
+		"@babel/runtime-corejs2": {
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.10.5.tgz",
+			"integrity": "sha512-LJwyb1ac//Jr2zrGTTaNJhrP1wYCgVw9rzHbQPogKXCTLQ60EEWgeNtuqs6cLsq64O557SYzziCrOxNp0rRi8w==",
+			"dev": true,
+			"requires": {
+				"core-js": "^2.6.5",
+				"regenerator-runtime": "^0.13.4"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.6.12",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+					"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/runtime-corejs3": {
@@ -1155,7 +2346,6 @@
 			"version": "7.12.13",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
 			"integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.12.13",
 				"@babel/parser": "^7.12.13",
@@ -1166,7 +2356,6 @@
 			"version": "7.13.0",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.0.tgz",
 			"integrity": "sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.12.13",
 				"@babel/generator": "^7.13.0",
@@ -1182,8 +2371,7 @@
 				"globals": {
 					"version": "11.12.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-					"dev": true
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
 				}
 			}
 		},
@@ -1191,7 +2379,6 @@
 			"version": "7.13.0",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
 			"integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.12.11",
 				"lodash": "^4.17.19",
@@ -1213,6 +2400,155 @@
 				"exec-sh": "^0.3.2",
 				"minimist": "^1.2.0"
 			}
+		},
+		"@emotion/cache": {
+			"version": "10.0.29",
+			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
+			"integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
+			"dev": true,
+			"requires": {
+				"@emotion/sheet": "0.9.4",
+				"@emotion/stylis": "0.8.5",
+				"@emotion/utils": "0.11.3",
+				"@emotion/weak-memoize": "0.2.5"
+			}
+		},
+		"@emotion/core": {
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.1.tgz",
+			"integrity": "sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.5.5",
+				"@emotion/cache": "^10.0.27",
+				"@emotion/css": "^10.0.27",
+				"@emotion/serialize": "^0.11.15",
+				"@emotion/sheet": "0.9.4",
+				"@emotion/utils": "0.11.3"
+			}
+		},
+		"@emotion/css": {
+			"version": "10.0.27",
+			"resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
+			"integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
+			"dev": true,
+			"requires": {
+				"@emotion/serialize": "^0.11.15",
+				"@emotion/utils": "0.11.3",
+				"babel-plugin-emotion": "^10.0.27"
+			}
+		},
+		"@emotion/hash": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+			"integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
+			"dev": true
+		},
+		"@emotion/is-prop-valid": {
+			"version": "0.8.8",
+			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+			"integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+			"dev": true,
+			"requires": {
+				"@emotion/memoize": "0.7.4"
+			}
+		},
+		"@emotion/memoize": {
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+			"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+			"dev": true
+		},
+		"@emotion/native": {
+			"version": "10.0.27",
+			"resolved": "https://registry.npmjs.org/@emotion/native/-/native-10.0.27.tgz",
+			"integrity": "sha512-3qxR2XFizGfABKKbX9kAYc0PHhKuCEuyxshoq3TaMEbi9asWHdQVChg32ULpblm4XAf9oxaitAU7J9SfdwFxtw==",
+			"dev": true,
+			"requires": {
+				"@emotion/primitives-core": "10.0.27"
+			}
+		},
+		"@emotion/primitives-core": {
+			"version": "10.0.27",
+			"resolved": "https://registry.npmjs.org/@emotion/primitives-core/-/primitives-core-10.0.27.tgz",
+			"integrity": "sha512-fRBEDNPSFFOrBJ0OcheuElayrNTNdLF9DzMxtL0sFgsCFvvadlzwJHhJMSwEJuxwARm9GhVLr1p8G8JGkK98lQ==",
+			"dev": true,
+			"requires": {
+				"css-to-react-native": "^2.2.1"
+			}
+		},
+		"@emotion/serialize": {
+			"version": "0.11.16",
+			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
+			"integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+			"dev": true,
+			"requires": {
+				"@emotion/hash": "0.8.0",
+				"@emotion/memoize": "0.7.4",
+				"@emotion/unitless": "0.7.5",
+				"@emotion/utils": "0.11.3",
+				"csstype": "^2.5.7"
+			},
+			"dependencies": {
+				"csstype": {
+					"version": "2.6.17",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
+					"integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A==",
+					"dev": true
+				}
+			}
+		},
+		"@emotion/sheet": {
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+			"integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==",
+			"dev": true
+		},
+		"@emotion/styled": {
+			"version": "10.0.27",
+			"resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-10.0.27.tgz",
+			"integrity": "sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==",
+			"dev": true,
+			"requires": {
+				"@emotion/styled-base": "^10.0.27",
+				"babel-plugin-emotion": "^10.0.27"
+			}
+		},
+		"@emotion/styled-base": {
+			"version": "10.0.31",
+			"resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.0.31.tgz",
+			"integrity": "sha512-wTOE1NcXmqMWlyrtwdkqg87Mu6Rj1MaukEoEmEkHirO5IoHDJ8LgCQL4MjJODgxWxXibGR3opGp1p7YvkNEdXQ==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.5.5",
+				"@emotion/is-prop-valid": "0.8.8",
+				"@emotion/serialize": "^0.11.15",
+				"@emotion/utils": "0.11.3"
+			}
+		},
+		"@emotion/stylis": {
+			"version": "0.8.5",
+			"resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+			"integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
+			"dev": true
+		},
+		"@emotion/unitless": {
+			"version": "0.7.5",
+			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+			"integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
+			"dev": true
+		},
+		"@emotion/utils": {
+			"version": "0.11.3",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+			"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==",
+			"dev": true
+		},
+		"@emotion/weak-memoize": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+			"integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
+			"dev": true
 		},
 		"@eslint/eslintrc": {
 			"version": "0.3.0",
@@ -1808,6 +3144,227 @@
 				}
 			}
 		},
+		"@nicolo-ribaudo/chokidar-2": {
+			"version": "2.1.8-no-fsevents.2",
+			"resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.2.tgz",
+			"integrity": "sha512-Fb8WxUFOBQVl+CX4MWet5o7eCc6Pj04rXIwVKZ6h1NnqTo45eOQW6aWyhG25NIODvWFwTDMwBsYxrQ3imxpetg==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"anymatch": "^2.0.0",
+				"async-each": "^1.0.1",
+				"braces": "^2.3.2",
+				"glob-parent": "^5.1.2",
+				"inherits": "^2.0.3",
+				"is-binary-path": "^1.0.0",
+				"is-glob": "^4.0.0",
+				"normalize-path": "^3.0.0",
+				"path-is-absolute": "^1.0.0",
+				"readdirp": "^2.2.1",
+				"upath": "^1.1.1"
+			},
+			"dependencies": {
+				"anymatch": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"micromatch": "^3.1.4",
+						"normalize-path": "^2.1.1"
+					},
+					"dependencies": {
+						"normalize-path": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+							"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"remove-trailing-separator": "^1.0.1"
+							}
+						}
+					}
+				},
+				"binary-extensions": {
+					"version": "1.13.1",
+					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+					"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+					"dev": true,
+					"optional": true
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"glob-parent": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
+				"is-binary-path": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+					"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"binary-extensions": "^1.0.0"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				},
+				"readable-stream": {
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"readdirp": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+					"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"graceful-fs": "^4.1.11",
+						"micromatch": "^3.1.10",
+						"readable-stream": "^2.0.2"
+					}
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
+					}
+				}
+			}
+		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
@@ -1856,6 +3413,12 @@
 			"version": "1.0.0-next.11",
 			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.11.tgz",
 			"integrity": "sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA==",
+			"dev": true
+		},
+		"@popperjs/core": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
+			"integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==",
 			"dev": true
 		},
 		"@sinonjs/commons": {
@@ -2147,8 +3710,7 @@
 		"@types/json-schema": {
 			"version": "7.0.7",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
-			"integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
-			"dev": true
+			"integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
 		},
 		"@types/json5": {
 			"version": "0.0.29",
@@ -2204,8 +3766,7 @@
 		"@types/prop-types": {
 			"version": "15.7.3",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-			"integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
-			"dev": true
+			"integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
 		},
 		"@types/q": {
 			"version": "1.5.4",
@@ -2214,23 +3775,27 @@
 			"dev": true
 		},
 		"@types/react": {
-			"version": "16.14.4",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.4.tgz",
-			"integrity": "sha512-ETj7GbkPGjca/A4trkVeGvoIakmLV6ZtX3J8dcmOpzKzWVybbrOxanwaIPG71GZwImoMDY6Fq4wIe34lEqZ0FQ==",
-			"dev": true,
+			"version": "16.14.10",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.10.tgz",
+			"integrity": "sha512-QadBsMyF6ldjEAXEhsmEW/L0uBDJT8yw7Qoe5sRnEKVrzMkiYoJwqoL5TKJOlArsn/wvIJM/XdVzkdL6+AS64Q==",
 			"requires": {
 				"@types/prop-types": "*",
+				"@types/scheduler": "*",
 				"csstype": "^3.0.2"
 			}
 		},
 		"@types/react-dom": {
-			"version": "16.9.11",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.11.tgz",
-			"integrity": "sha512-3UuR4MoWf5spNgrG6cwsmT9DdRghcR4IDFOzNZ6+wcmacxkFykcb5ji0nNVm9ckBT4BCxvCrJJbM4+EYsEEVIg==",
-			"dev": true,
+			"version": "16.9.13",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.13.tgz",
+			"integrity": "sha512-34Hr3XnmUSJbUVDxIw/e7dhQn2BJZhJmlAaPyPwfTQyuVS9mV/CeyghFcXyvkJXxI7notQJz8mF8FeCVvloJrA==",
 			"requires": {
 				"@types/react": "^16"
 			}
+		},
+		"@types/scheduler": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
+			"integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
 		},
 		"@types/source-list-map": {
 			"version": "0.1.2",
@@ -2321,6 +3886,125 @@
 			"optional": true,
 			"requires": {
 				"@types/node": "*"
+			}
+		},
+		"@typescript-eslint/eslint-plugin": {
+			"version": "4.28.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.1.tgz",
+			"integrity": "sha512-9yfcNpDaNGQ6/LQOX/KhUFTR1sCKH+PBr234k6hI9XJ0VP5UqGxap0AnNwBnWFk1MNyWBylJH9ZkzBXC+5akZQ==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/experimental-utils": "4.28.1",
+				"@typescript-eslint/scope-manager": "4.28.1",
+				"debug": "^4.3.1",
+				"functional-red-black-tree": "^1.0.1",
+				"regexpp": "^3.1.0",
+				"semver": "^7.3.5",
+				"tsutils": "^3.21.0"
+			},
+			"dependencies": {
+				"@typescript-eslint/experimental-utils": {
+					"version": "4.28.1",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.1.tgz",
+					"integrity": "sha512-n8/ggadrZ+uyrfrSEchx3jgODdmcx7MzVM2sI3cTpI/YlfSm0+9HEUaWw3aQn2urL2KYlWYMDgn45iLfjDYB+Q==",
+					"dev": true,
+					"requires": {
+						"@types/json-schema": "^7.0.7",
+						"@typescript-eslint/scope-manager": "4.28.1",
+						"@typescript-eslint/types": "4.28.1",
+						"@typescript-eslint/typescript-estree": "4.28.1",
+						"eslint-scope": "^5.1.1",
+						"eslint-utils": "^3.0.0"
+					}
+				},
+				"@typescript-eslint/scope-manager": {
+					"version": "4.28.1",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.1.tgz",
+					"integrity": "sha512-o95bvGKfss6705x7jFGDyS7trAORTy57lwJ+VsYwil/lOUxKQ9tA7Suuq+ciMhJc/1qPwB3XE2DKh9wubW8YYA==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "4.28.1",
+						"@typescript-eslint/visitor-keys": "4.28.1"
+					}
+				},
+				"@typescript-eslint/types": {
+					"version": "4.28.1",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.1.tgz",
+					"integrity": "sha512-4z+knEihcyX7blAGi7O3Fm3O6YRCP+r56NJFMNGsmtdw+NCdpG5SgNz427LS9nQkRVTswZLhz484hakQwB8RRg==",
+					"dev": true
+				},
+				"@typescript-eslint/typescript-estree": {
+					"version": "4.28.1",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.1.tgz",
+					"integrity": "sha512-GhKxmC4sHXxHGJv8e8egAZeTZ6HI4mLU6S7FUzvFOtsk7ZIDN1ksA9r9DyOgNqowA9yAtZXV0Uiap61bIO81FQ==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "4.28.1",
+						"@typescript-eslint/visitor-keys": "4.28.1",
+						"debug": "^4.3.1",
+						"globby": "^11.0.3",
+						"is-glob": "^4.0.1",
+						"semver": "^7.3.5",
+						"tsutils": "^3.21.0"
+					}
+				},
+				"@typescript-eslint/visitor-keys": {
+					"version": "4.28.1",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.1.tgz",
+					"integrity": "sha512-K4HMrdFqr9PFquPu178SaSb92CaWe2yErXyPumc8cYWxFmhgJsNY9eSePmO05j0JhBvf2Cdhptd6E6Yv9HVHcg==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "4.28.1",
+						"eslint-visitor-keys": "^2.0.0"
+					}
+				},
+				"eslint-utils": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+					"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+					"dev": true,
+					"requires": {
+						"eslint-visitor-keys": "^2.0.0"
+					}
+				},
+				"eslint-visitor-keys": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+					"dev": true
+				},
+				"globby": {
+					"version": "11.0.4",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+					"integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+					"dev": true,
+					"requires": {
+						"array-union": "^2.1.0",
+						"dir-glob": "^3.0.1",
+						"fast-glob": "^3.1.1",
+						"ignore": "^5.1.4",
+						"merge2": "^1.3.0",
+						"slash": "^3.0.0"
+					}
+				},
+				"semver": {
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"tsutils": {
+					"version": "3.21.0",
+					"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+					"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+					"dev": true,
+					"requires": {
+						"tslib": "^1.8.1"
+					}
+				}
 			}
 		},
 		"@typescript-eslint/experimental-utils": {
@@ -2572,6 +4256,232 @@
 				"@xtuc/long": "4.2.2"
 			}
 		},
+		"@woocommerce/components": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@woocommerce/components/-/components-7.0.0.tgz",
+			"integrity": "sha512-LomGBIwPWZuLk4ndIvfvsoPK8OOxQT2Gtj1gj/JdhBIVH9DNSpcVoV/sgvo8uGkJw6hhx+lR85muB/K2gW/zTA==",
+			"dev": true,
+			"requires": {
+				"@woocommerce/csv-export": "^1.3.1",
+				"@woocommerce/currency": "^3.1.0",
+				"@woocommerce/data": "^1.3.1",
+				"@woocommerce/date": "^3.0.0",
+				"@woocommerce/experimental": "^1.3.0",
+				"@woocommerce/navigation": "^6.0.1",
+				"@wordpress/api-fetch": "^3.21.5",
+				"@wordpress/components": "10.2.0",
+				"@wordpress/compose": "3.23.1",
+				"@wordpress/date": "3.13.0",
+				"@wordpress/deprecated": "^3.1.1",
+				"@wordpress/dom": "2.16.0",
+				"@wordpress/element": "2.19.0",
+				"@wordpress/html-entities": "2.10.0",
+				"@wordpress/i18n": "3.17.0",
+				"@wordpress/icons": "^2.10.3",
+				"@wordpress/keycodes": "2.18.0",
+				"@wordpress/viewport": "2.24.0",
+				"classnames": "^2.3.1",
+				"core-js": "3.9.1",
+				"d3-axis": "1.0.12",
+				"d3-format": "1.4.5",
+				"d3-scale": "2.2.2",
+				"d3-scale-chromatic": "1.5.0",
+				"d3-selection": "1.4.2",
+				"d3-shape": "1.3.7",
+				"d3-time-format": "2.3.0",
+				"dompurify": "2.2.9",
+				"emoji-flags": "1.3.0",
+				"gridicons": "3.3.1",
+				"interpolate-components": "1.1.1",
+				"md5": "2.3.0",
+				"memoize-one": "5.1.1",
+				"moment": "2.29.1",
+				"prop-types": "15.7.2",
+				"qs": "6.9.6",
+				"react-dates": "^17.2.0",
+				"react-router-dom": "5.2.0",
+				"react-transition-group": "4.4.1"
+			},
+			"dependencies": {
+				"@wordpress/element": {
+					"version": "2.19.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.19.0.tgz",
+					"integrity": "sha512-t6GnllujeJU2N7RagWvPSSki+VnIxUQktg+cDAFDWC4XHCVoZKgs/0B48yeZSvd9T/t4ry0aILh+zeEJ+5DuHg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.12.5",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^1.11.0",
+						"lodash": "^4.17.19",
+						"react": "^16.13.1",
+						"react-dom": "^16.13.1"
+					}
+				},
+				"@wordpress/escape-html": {
+					"version": "1.12.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.12.2.tgz",
+					"integrity": "sha512-FabgSwznhdaUwe6hr1CsGpgxQbzqEoGevv73WIL1B9GvlZ6csRWodgHfWh4P6fYqpzxFL4WYB8wPJ1PdO32XFA==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					},
+					"dependencies": {
+						"@babel/runtime": {
+							"version": "7.14.6",
+							"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+							"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+							"dev": true,
+							"requires": {
+								"regenerator-runtime": "^0.13.4"
+							}
+						}
+					}
+				},
+				"@wordpress/i18n": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.17.0.tgz",
+					"integrity": "sha512-CTZ0oezI6BT5GlmiE4X0fzRY6i7bNsX6hxiROkGlpREY6q4s1pnwhM8ggLIaP18Bvkb/HDkUEENDrv3iwM/LIQ==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.12.5",
+						"gettext-parser": "^1.3.1",
+						"lodash": "^4.17.19",
+						"memize": "^1.1.0",
+						"sprintf-js": "^1.1.1",
+						"tannin": "^1.2.0"
+					}
+				},
+				"core-js": {
+					"version": "3.9.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
+					"integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg==",
+					"dev": true
+				},
+				"qs": {
+					"version": "6.9.6",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+					"integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==",
+					"dev": true
+				},
+				"sprintf-js": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+					"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+					"dev": true
+				}
+			}
+		},
+		"@woocommerce/csv-export": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@woocommerce/csv-export/-/csv-export-1.3.2.tgz",
+			"integrity": "sha512-WaKcgzMfLHHU8XZT5F6DDOJS1Md+IDyAk7sltxUivNpQJjK7xrE11VavQ7LwxIERtqhtjNThDRsHoJcOoT1i9A==",
+			"dev": true,
+			"requires": {
+				"browser-filesaver": "1.1.1",
+				"moment": "2.29.1"
+			}
+		},
+		"@woocommerce/currency": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@woocommerce/currency/-/currency-3.1.0.tgz",
+			"integrity": "sha512-umQebrVkkHV5L3/zWwrRjznhPWLHHntZiZqAABhpJm/T9bLGS4imzP9FEeOJWH5i3Ol9msAJh6PLw4Sztl+ZgQ==",
+			"dev": true,
+			"requires": {
+				"@woocommerce/number": "2.1.0",
+				"@wordpress/deprecated": "^2.9.0",
+				"@wordpress/html-entities": "2.10.0"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+					"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@wordpress/deprecated": {
+					"version": "2.12.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.12.3.tgz",
+					"integrity": "sha512-qr+yDfTQfI3M4h6oY6IeHWwoHr4jxbILjSlV+Ht6Jjto9Owap6OuzSqR13Ev4xqIoG4C7b5B3gZXVfwVDae1zg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/hooks": "^2.12.3"
+					}
+				}
+			}
+		},
+		"@woocommerce/data": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@woocommerce/data/-/data-1.3.1.tgz",
+			"integrity": "sha512-9h+HaEBgz6WCGGGNPjew509lDiDB0BbE8JazxWU7+AKRbkIxqJ7mGDFCzNDx2V923E47/82jb9CFSbWeofXDqQ==",
+			"dev": true,
+			"requires": {
+				"@woocommerce/date": "^3.0.0",
+				"@woocommerce/navigation": "^6.0.1",
+				"@wordpress/i18n": "3.17.0",
+				"md5": "^2.3.0",
+				"rememo": "^3.0.0"
+			},
+			"dependencies": {
+				"@wordpress/i18n": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.17.0.tgz",
+					"integrity": "sha512-CTZ0oezI6BT5GlmiE4X0fzRY6i7bNsX6hxiROkGlpREY6q4s1pnwhM8ggLIaP18Bvkb/HDkUEENDrv3iwM/LIQ==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.12.5",
+						"gettext-parser": "^1.3.1",
+						"lodash": "^4.17.19",
+						"memize": "^1.1.0",
+						"sprintf-js": "^1.1.1",
+						"tannin": "^1.2.0"
+					}
+				},
+				"sprintf-js": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+					"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+					"dev": true
+				}
+			}
+		},
+		"@woocommerce/date": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@woocommerce/date/-/date-3.0.0.tgz",
+			"integrity": "sha512-yFDKEHuNDXXOssmuTaOVjcVHZsfPcc0HuhnuuDucKNtnHDAPjbhJlPpqyLGNaZ3jVFxqROCF36YZhua9Ee6Pwg==",
+			"dev": true,
+			"requires": {
+				"@wordpress/date": "3.13.0",
+				"@wordpress/i18n": "3.17.0",
+				"moment": "2.29.1"
+			},
+			"dependencies": {
+				"@wordpress/i18n": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.17.0.tgz",
+					"integrity": "sha512-CTZ0oezI6BT5GlmiE4X0fzRY6i7bNsX6hxiROkGlpREY6q4s1pnwhM8ggLIaP18Bvkb/HDkUEENDrv3iwM/LIQ==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.12.5",
+						"gettext-parser": "^1.3.1",
+						"lodash": "^4.17.19",
+						"memize": "^1.1.0",
+						"sprintf-js": "^1.1.1",
+						"tannin": "^1.2.0"
+					}
+				},
+				"sprintf-js": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+					"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+					"dev": true
+				}
+			}
+		},
 		"@woocommerce/dependency-extraction-webpack-plugin": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/@woocommerce/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-1.4.0.tgz",
@@ -2604,28 +4514,1145 @@
 				}
 			}
 		},
-		"@wordpress/babel-plugin-import-jsx-pragma": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-3.0.1.tgz",
-			"integrity": "sha512-vwd43RNda63/URoAQ+CnLiEkgYG+yYe6S19sWGQ/ekPeORFh7l8J/1MgegPBSt/w5fPQ8UK2DUgavTU0AElPKg==",
-			"dev": true
-		},
-		"@wordpress/babel-preset-default": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-5.0.1.tgz",
-			"integrity": "sha512-wbTWlx3nJe1KvFt+5pWoCaU/LW1PjCDKtG97nse888++1xXGycCI40rOzyPjhCfwN9VehE9unWEC8+C1FRwyZQ==",
+		"@woocommerce/experimental": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@woocommerce/experimental/-/experimental-1.3.0.tgz",
+			"integrity": "sha512-KzsKQBnWUHS6ZC3vEwXesuWgbwutQ8jKAP18/FOpzvlTKWRdlpV2cx1v/F9KWLhGS4Yy7b+CchbXdnvJQJApGA==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.12.9",
+				"@babel/runtime": "7.14.0",
+				"@woocommerce/components": "^7.0.0",
+				"@wordpress/components": "10.2.0",
+				"@wordpress/element": "2.19.0",
+				"@wordpress/i18n": "3.17.0",
+				"@wordpress/icons": "2.10.3",
+				"@wordpress/keycodes": "2.18.0",
+				"classnames": "^2.3.1",
+				"dompurify": "2.2.9",
+				"gridicons": "3.3.1",
+				"moment": "2.29.1",
+				"react-transition-group": "4.4.1",
+				"react-visibility-sensor": "5.1.1"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.14.0",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+					"integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@wordpress/element": {
+					"version": "2.19.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.19.0.tgz",
+					"integrity": "sha512-t6GnllujeJU2N7RagWvPSSki+VnIxUQktg+cDAFDWC4XHCVoZKgs/0B48yeZSvd9T/t4ry0aILh+zeEJ+5DuHg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.12.5",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^1.11.0",
+						"lodash": "^4.17.19",
+						"react": "^16.13.1",
+						"react-dom": "^16.13.1"
+					}
+				},
+				"@wordpress/escape-html": {
+					"version": "1.12.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.12.2.tgz",
+					"integrity": "sha512-FabgSwznhdaUwe6hr1CsGpgxQbzqEoGevv73WIL1B9GvlZ6csRWodgHfWh4P6fYqpzxFL4WYB8wPJ1PdO32XFA==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@wordpress/i18n": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.17.0.tgz",
+					"integrity": "sha512-CTZ0oezI6BT5GlmiE4X0fzRY6i7bNsX6hxiROkGlpREY6q4s1pnwhM8ggLIaP18Bvkb/HDkUEENDrv3iwM/LIQ==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.12.5",
+						"gettext-parser": "^1.3.1",
+						"lodash": "^4.17.19",
+						"memize": "^1.1.0",
+						"sprintf-js": "^1.1.1",
+						"tannin": "^1.2.0"
+					}
+				},
+				"sprintf-js": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+					"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+					"dev": true
+				}
+			}
+		},
+		"@woocommerce/navigation": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@woocommerce/navigation/-/navigation-6.0.1.tgz",
+			"integrity": "sha512-nDQlrnjbWurN/bJjzU7m+XxBmPTE/DimibBDJDrtOI8Mb8bruIwTBuuOqZwRS46D8yLbCNzWSOT/qLketuK2mg==",
+			"dev": true,
+			"requires": {
+				"@woocommerce/experimental": "1.0.0",
+				"history": "4.10.1",
+				"qs": "6.9.6"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.13.10",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+					"integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@woocommerce/experimental": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@woocommerce/experimental/-/experimental-1.0.0.tgz",
+					"integrity": "sha512-/kqdqdItisJSYfX62m4ILO6xq8Zwa3MaRr8sMEmw1KxCd1e3aFGV6aKDDwxkvLHbhGclNSZrDc/sgaeSBwiTFg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "7.13.10",
+						"@wordpress/components": "10.2.0"
+					}
+				},
+				"qs": {
+					"version": "6.9.6",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+					"integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==",
+					"dev": true
+				}
+			}
+		},
+		"@woocommerce/number": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@woocommerce/number/-/number-2.1.0.tgz",
+			"integrity": "sha512-3junwiGMZ9u096EqYkeAJQlEstQl1TW79hENJLNwxYBvIGkmby5oF8AOIT81+/mwphKuszUL9fNcY22RTCbA4w==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime-corejs2": "7.10.5",
+				"locutus": "2.0.11"
+			}
+		},
+		"@wordpress/a11y": {
+			"version": "2.15.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-2.15.3.tgz",
+			"integrity": "sha512-uoCznHY3/TaNWeXutLI6juC198ykaBwZ34P51PNHHQqi3WzVoBhFx6AnAR/9Uupl3tZcekefpkVHy7AJHMAPIA==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/dom-ready": "^2.13.2",
+				"@wordpress/i18n": "^3.20.0"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+					"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@wordpress/i18n": {
+					"version": "3.20.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.20.0.tgz",
+					"integrity": "sha512-SIoOJFB4UrrYAScS4H91CYCLW9dX3Ghv8pBKc/yHGculb1AdGr6gRMlmJxZV62Cn3CZ4Ga86c+FfR+GiBu0JPg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/hooks": "^2.12.3",
+						"gettext-parser": "^1.3.1",
+						"lodash": "^4.17.19",
+						"memize": "^1.1.0",
+						"sprintf-js": "^1.1.1",
+						"tannin": "^1.2.0"
+					}
+				},
+				"sprintf-js": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+					"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+					"dev": true
+				}
+			}
+		},
+		"@wordpress/api-fetch": {
+			"version": "3.23.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.23.1.tgz",
+			"integrity": "sha512-dmeigLuvqYAzpQ2hWUQT1P5VQAjkj9hS1z7PgNi1CcULFPbY8BWW+KiBETUu6Wm+rlSbUL2dC8qrA4JDv9ja5A==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/i18n": "^3.19.2",
+				"@wordpress/url": "^2.22.2"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+					"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@wordpress/i18n": {
+					"version": "3.20.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.20.0.tgz",
+					"integrity": "sha512-SIoOJFB4UrrYAScS4H91CYCLW9dX3Ghv8pBKc/yHGculb1AdGr6gRMlmJxZV62Cn3CZ4Ga86c+FfR+GiBu0JPg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/hooks": "^2.12.3",
+						"gettext-parser": "^1.3.1",
+						"lodash": "^4.17.19",
+						"memize": "^1.1.0",
+						"sprintf-js": "^1.1.1",
+						"tannin": "^1.2.0"
+					}
+				},
+				"sprintf-js": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+					"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+					"dev": true
+				}
+			}
+		},
+		"@wordpress/babel-plugin-import-jsx-pragma": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-3.0.5.tgz",
+			"integrity": "sha512-1xzZGFV5Bwox4XcE59I88q0/robJ35LoQNkKPC4tmfzd1XaAoJCZpp5T8LSJJtKKloeoO1JstrvMf3ltZLQ5IA=="
+		},
+		"@wordpress/babel-preset-default": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-6.2.0.tgz",
+			"integrity": "sha512-uNdR8TjUZgTF43psvAPGW/jnKMD+Mr8XiVhJGcVjrKwDoVBvHjtoKSpfafvkrESIHmMz2HgB4+NdqFHL5hhZlg==",
+			"requires": {
+				"@babel/core": "^7.13.10",
 				"@babel/plugin-transform-react-jsx": "^7.12.7",
-				"@babel/plugin-transform-runtime": "^7.12.1",
-				"@babel/preset-env": "^7.12.7",
-				"@babel/runtime": "^7.12.5",
-				"@wordpress/babel-plugin-import-jsx-pragma": "^3.0.1",
-				"@wordpress/browserslist-config": "^3.0.1",
-				"@wordpress/element": "^2.19.1",
-				"@wordpress/warning": "^1.3.1",
-				"core-js": "^3.6.4"
+				"@babel/plugin-transform-runtime": "^7.13.10",
+				"@babel/preset-env": "^7.13.10",
+				"@babel/preset-typescript": "^7.13.0",
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/babel-plugin-import-jsx-pragma": "^3.0.5",
+				"@wordpress/browserslist-config": "^4.0.1",
+				"@wordpress/element": "^3.1.1",
+				"@wordpress/warning": "^2.1.1",
+				"browserslist": "^4.16.6",
+				"core-js": "^3.12.1"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+					"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+					"requires": {
+						"@babel/highlight": "^7.14.5"
+					}
+				},
+				"@babel/compat-data": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz",
+					"integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw=="
+				},
+				"@babel/core": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.6.tgz",
+					"integrity": "sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==",
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/generator": "^7.14.5",
+						"@babel/helper-compilation-targets": "^7.14.5",
+						"@babel/helper-module-transforms": "^7.14.5",
+						"@babel/helpers": "^7.14.6",
+						"@babel/parser": "^7.14.6",
+						"@babel/template": "^7.14.5",
+						"@babel/traverse": "^7.14.5",
+						"@babel/types": "^7.14.5",
+						"convert-source-map": "^1.7.0",
+						"debug": "^4.1.0",
+						"gensync": "^1.0.0-beta.2",
+						"json5": "^2.1.2",
+						"semver": "^6.3.0",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
+					"integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
+					"requires": {
+						"@babel/types": "^7.14.5",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-annotate-as-pure": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.14.5.tgz",
+					"integrity": "sha512-EivH9EgBIb+G8ij1B2jAwSH36WnGvkQSEC6CkX/6v6ZFlw5fVOHvsgGF4uiEHO2GzMvunZb6tDLQEQSdrdocrA==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-builder-binary-assignment-operator-visitor": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.14.5.tgz",
+					"integrity": "sha512-YTA/Twn0vBXDVGJuAX6PwW7x5zQei1luDDo2Pl6q1qZ7hVNl0RZrhHCQG/ArGpR29Vl7ETiB8eJyrvpuRp300w==",
+					"requires": {
+						"@babel/helper-explode-assignable-expression": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-compilation-targets": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
+					"integrity": "sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==",
+					"requires": {
+						"@babel/compat-data": "^7.14.5",
+						"@babel/helper-validator-option": "^7.14.5",
+						"browserslist": "^4.16.6",
+						"semver": "^6.3.0"
+					}
+				},
+				"@babel/helper-create-class-features-plugin": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.6.tgz",
+					"integrity": "sha512-Z6gsfGofTxH/+LQXqYEK45kxmcensbzmk/oi8DmaQytlQCgqNZt9XQF8iqlI/SeXWVjaMNxvYvzaYw+kh42mDg==",
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.14.5",
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/helper-member-expression-to-functions": "^7.14.5",
+						"@babel/helper-optimise-call-expression": "^7.14.5",
+						"@babel/helper-replace-supers": "^7.14.5",
+						"@babel/helper-split-export-declaration": "^7.14.5"
+					}
+				},
+				"@babel/helper-create-regexp-features-plugin": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.14.5.tgz",
+					"integrity": "sha512-TLawwqpOErY2HhWbGJ2nZT5wSkR192QpN+nBg1THfBfftrlvOh+WbhrxXCH4q4xJ9Gl16BGPR/48JA+Ryiho/A==",
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.14.5",
+						"regexpu-core": "^4.7.1"
+					}
+				},
+				"@babel/helper-define-polyfill-provider": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.3.tgz",
+					"integrity": "sha512-RH3QDAfRMzj7+0Nqu5oqgO5q9mFtQEVvCRsi8qCEfzLR9p2BHfn5FzhSB2oj1fF7I2+DcTORkYaQ6aTR9Cofew==",
+					"requires": {
+						"@babel/helper-compilation-targets": "^7.13.0",
+						"@babel/helper-module-imports": "^7.12.13",
+						"@babel/helper-plugin-utils": "^7.13.0",
+						"@babel/traverse": "^7.13.0",
+						"debug": "^4.1.1",
+						"lodash.debounce": "^4.0.8",
+						"resolve": "^1.14.2",
+						"semver": "^6.1.2"
+					}
+				},
+				"@babel/helper-explode-assignable-expression": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.14.5.tgz",
+					"integrity": "sha512-Htb24gnGJdIGT4vnRKMdoXiOIlqOLmdiUYpAQ0mYfgVT/GDm8GOYhgi4GL+hMKrkiPRohO4ts34ELFsGAPQLDQ==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+					"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.14.5",
+						"@babel/template": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+					"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-hoist-variables": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
+					"integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
+					"integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
+					"integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz",
+					"integrity": "sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==",
+					"requires": {
+						"@babel/helper-module-imports": "^7.14.5",
+						"@babel/helper-replace-supers": "^7.14.5",
+						"@babel/helper-simple-access": "^7.14.5",
+						"@babel/helper-split-export-declaration": "^7.14.5",
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"@babel/template": "^7.14.5",
+						"@babel/traverse": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
+					"integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+					"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+				},
+				"@babel/helper-remap-async-to-generator": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.14.5.tgz",
+					"integrity": "sha512-rLQKdQU+HYlxBwQIj8dk4/0ENOUEhA/Z0l4hN8BexpvmSMN9oA9EagjnhnDpNsRdWCfjwa4mn/HyBXO9yhQP6A==",
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.14.5",
+						"@babel/helper-wrap-function": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
+					"integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.14.5",
+						"@babel/helper-optimise-call-expression": "^7.14.5",
+						"@babel/traverse": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz",
+					"integrity": "sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-skip-transparent-expression-wrappers": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.14.5.tgz",
+					"integrity": "sha512-dmqZB7mrb94PZSAOYtr+ZN5qt5owZIAgqtoTuqiFbHFtxgEcmQlRJVI+bO++fciBunXtB6MK7HrzrfcAzIz2NQ==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+					"integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+					"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg=="
+				},
+				"@babel/helper-validator-option": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+					"integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow=="
+				},
+				"@babel/helper-wrap-function": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.14.5.tgz",
+					"integrity": "sha512-YEdjTCq+LNuNS1WfxsDCNpgXkJaIyqco6DAelTUjT4f2KIWC1nBcaCaSdHTBqQVLnTBexBcVcFhLSU1KnYuePQ==",
+					"requires": {
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/template": "^7.14.5",
+						"@babel/traverse": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helpers": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.6.tgz",
+					"integrity": "sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==",
+					"requires": {
+						"@babel/template": "^7.14.5",
+						"@babel/traverse": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+					"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
+					"integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA=="
+				},
+				"@babel/plugin-proposal-async-generator-functions": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.14.7.tgz",
+					"integrity": "sha512-RK8Wj7lXLY3bqei69/cc25gwS5puEc3dknoFPFbqfy3XxYQBQFvu4ioWpafMBAB+L9NyptQK4nMOa5Xz16og8Q==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/helper-remap-async-to-generator": "^7.14.5",
+						"@babel/plugin-syntax-async-generators": "^7.8.4"
+					}
+				},
+				"@babel/plugin-proposal-class-properties": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.14.5.tgz",
+					"integrity": "sha512-q/PLpv5Ko4dVc1LYMpCY7RVAAO4uk55qPwrIuJ5QJ8c6cVuAmhu7I/49JOppXL6gXf7ZHzpRVEUZdYoPLM04Gg==",
+					"requires": {
+						"@babel/helper-create-class-features-plugin": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-proposal-dynamic-import": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.14.5.tgz",
+					"integrity": "sha512-ExjiNYc3HDN5PXJx+bwC50GIx/KKanX2HiggnIUAYedbARdImiCU4RhhHfdf0Kd7JNXGpsBBBCOm+bBVy3Gb0g==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/plugin-syntax-dynamic-import": "^7.8.3"
+					}
+				},
+				"@babel/plugin-proposal-export-namespace-from": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.14.5.tgz",
+					"integrity": "sha512-g5POA32bXPMmSBu5Dx/iZGLGnKmKPc5AiY7qfZgurzrCYgIztDlHFbznSNCoQuv57YQLnQfaDi7dxCtLDIdXdA==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+					}
+				},
+				"@babel/plugin-proposal-json-strings": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.14.5.tgz",
+					"integrity": "sha512-NSq2fczJYKVRIsUJyNxrVUMhB27zb7N7pOFGQOhBKJrChbGcgEAqyZrmZswkPk18VMurEeJAaICbfm57vUeTbQ==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/plugin-syntax-json-strings": "^7.8.3"
+					}
+				},
+				"@babel/plugin-proposal-logical-assignment-operators": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.14.5.tgz",
+					"integrity": "sha512-YGn2AvZAo9TwyhlLvCCWxD90Xq8xJ4aSgaX3G5D/8DW94L8aaT+dS5cSP+Z06+rCJERGSr9GxMBZ601xoc2taw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+					}
+				},
+				"@babel/plugin-proposal-nullish-coalescing-operator": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.14.5.tgz",
+					"integrity": "sha512-gun/SOnMqjSb98Nkaq2rTKMwervfdAoz6NphdY0vTfuzMfryj+tDGb2n6UkDKwez+Y8PZDhE3D143v6Gepp4Hg==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+					}
+				},
+				"@babel/plugin-proposal-numeric-separator": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.14.5.tgz",
+					"integrity": "sha512-yiclALKe0vyZRZE0pS6RXgjUOt87GWv6FYa5zqj15PvhOGFO69R5DusPlgK/1K5dVnCtegTiWu9UaBSrLLJJBg==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/plugin-syntax-numeric-separator": "^7.10.4"
+					}
+				},
+				"@babel/plugin-proposal-object-rest-spread": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.14.7.tgz",
+					"integrity": "sha512-082hsZz+sVabfmDWo1Oct1u1AgbKbUAyVgmX4otIc7bdsRgHBXwTwb3DpDmD4Eyyx6DNiuz5UAATT655k+kL5g==",
+					"requires": {
+						"@babel/compat-data": "^7.14.7",
+						"@babel/helper-compilation-targets": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+						"@babel/plugin-transform-parameters": "^7.14.5"
+					}
+				},
+				"@babel/plugin-proposal-optional-catch-binding": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.14.5.tgz",
+					"integrity": "sha512-3Oyiixm0ur7bzO5ybNcZFlmVsygSIQgdOa7cTfOYCMY+wEPAYhZAJxi3mixKFCTCKUhQXuCTtQ1MzrpL3WT8ZQ==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
+					}
+				},
+				"@babel/plugin-proposal-optional-chaining": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.14.5.tgz",
+					"integrity": "sha512-ycz+VOzo2UbWNI1rQXxIuMOzrDdHGrI23fRiz/Si2R4kv2XZQ1BK8ccdHwehMKBlcH/joGW/tzrUmo67gbJHlQ==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/helper-skip-transparent-expression-wrappers": "^7.14.5",
+						"@babel/plugin-syntax-optional-chaining": "^7.8.3"
+					}
+				},
+				"@babel/plugin-proposal-private-methods": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.14.5.tgz",
+					"integrity": "sha512-838DkdUA1u+QTCplatfq4B7+1lnDa/+QMI89x5WZHBcnNv+47N8QEj2k9I2MUU9xIv8XJ4XvPCviM/Dj7Uwt9g==",
+					"requires": {
+						"@babel/helper-create-class-features-plugin": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-proposal-unicode-property-regex": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.14.5.tgz",
+					"integrity": "sha512-6axIeOU5LnY471KenAB9vI8I5j7NQ2d652hIYwVyRfgaZT5UpiqFKCuVXCDMSrU+3VFafnu2c5m3lrWIlr6A5Q==",
+					"requires": {
+						"@babel/helper-create-regexp-features-plugin": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-syntax-top-level-await": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+					"integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-arrow-functions": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.14.5.tgz",
+					"integrity": "sha512-KOnO0l4+tD5IfOdi4x8C1XmEIRWUjNRV8wc6K2vz/3e8yAOoZZvsRXRRIF/yo/MAOFb4QjtAw9xSxMXbSMRy8A==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-async-to-generator": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.14.5.tgz",
+					"integrity": "sha512-szkbzQ0mNk0rpu76fzDdqSyPu0MuvpXgC+6rz5rpMb5OIRxdmHfQxrktL8CYolL2d8luMCZTR0DpIMIdL27IjA==",
+					"requires": {
+						"@babel/helper-module-imports": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/helper-remap-async-to-generator": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-block-scoped-functions": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.14.5.tgz",
+					"integrity": "sha512-dtqWqdWZ5NqBX3KzsVCWfQI3A53Ft5pWFCT2eCVUftWZgjc5DpDponbIF1+c+7cSGk2wN0YK7HGL/ezfRbpKBQ==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-block-scoping": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.14.5.tgz",
+					"integrity": "sha512-LBYm4ZocNgoCqyxMLoOnwpsmQ18HWTQvql64t3GvMUzLQrNoV1BDG0lNftC8QKYERkZgCCT/7J5xWGObGAyHDw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-classes": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.14.5.tgz",
+					"integrity": "sha512-J4VxKAMykM06K/64z9rwiL6xnBHgB1+FVspqvlgCdwD1KUbQNfszeKVVOMh59w3sztHYIZDgnhOC4WbdEfHFDA==",
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.14.5",
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/helper-optimise-call-expression": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/helper-replace-supers": "^7.14.5",
+						"@babel/helper-split-export-declaration": "^7.14.5",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/plugin-transform-computed-properties": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.14.5.tgz",
+					"integrity": "sha512-pWM+E4283UxaVzLb8UBXv4EIxMovU4zxT1OPnpHJcmnvyY9QbPPTKZfEj31EUvG3/EQRbYAGaYEUZ4yWOBC2xg==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-destructuring": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.14.7.tgz",
+					"integrity": "sha512-0mDE99nK+kVh3xlc5vKwB6wnP9ecuSj+zQCa/n0voENtP/zymdT4HH6QEb65wjjcbqr1Jb/7z9Qp7TF5FtwYGw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-dotall-regex": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.14.5.tgz",
+					"integrity": "sha512-loGlnBdj02MDsFaHhAIJzh7euK89lBrGIdM9EAtHFo6xKygCUGuuWe07o1oZVk287amtW1n0808sQM99aZt3gw==",
+					"requires": {
+						"@babel/helper-create-regexp-features-plugin": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-duplicate-keys": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.14.5.tgz",
+					"integrity": "sha512-iJjbI53huKbPDAsJ8EmVmvCKeeq21bAze4fu9GBQtSLqfvzj2oRuHVx4ZkDwEhg1htQ+5OBZh/Ab0XDf5iBZ7A==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-exponentiation-operator": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.14.5.tgz",
+					"integrity": "sha512-jFazJhMBc9D27o9jDnIE5ZErI0R0m7PbKXVq77FFvqFbzvTMuv8jaAwLZ5PviOLSFttqKIW0/wxNSDbjLk0tYA==",
+					"requires": {
+						"@babel/helper-builder-binary-assignment-operator-visitor": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-for-of": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.14.5.tgz",
+					"integrity": "sha512-CfmqxSUZzBl0rSjpoQSFoR9UEj3HzbGuGNL21/iFTmjb5gFggJp3ph0xR1YBhexmLoKRHzgxuFvty2xdSt6gTA==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-function-name": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.14.5.tgz",
+					"integrity": "sha512-vbO6kv0fIzZ1GpmGQuvbwwm+O4Cbm2NrPzwlup9+/3fdkuzo1YqOZcXw26+YUJB84Ja7j9yURWposEHLYwxUfQ==",
+					"requires": {
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-literals": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.14.5.tgz",
+					"integrity": "sha512-ql33+epql2F49bi8aHXxvLURHkxJbSmMKl9J5yHqg4PLtdE6Uc48CH1GS6TQvZ86eoB/ApZXwm7jlA+B3kra7A==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-member-expression-literals": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.14.5.tgz",
+					"integrity": "sha512-WkNXxH1VXVTKarWFqmso83xl+2V3Eo28YY5utIkbsmXoItO8Q3aZxN4BTS2k0hz9dGUloHK26mJMyQEYfkn/+Q==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-modules-amd": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.14.5.tgz",
+					"integrity": "sha512-3lpOU8Vxmp3roC4vzFpSdEpGUWSMsHFreTWOMMLzel2gNGfHE5UWIh/LN6ghHs2xurUp4jRFYMUIZhuFbody1g==",
+					"requires": {
+						"@babel/helper-module-transforms": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"babel-plugin-dynamic-import-node": "^2.3.3"
+					}
+				},
+				"@babel/plugin-transform-modules-commonjs": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.14.5.tgz",
+					"integrity": "sha512-en8GfBtgnydoao2PS+87mKyw62k02k7kJ9ltbKe0fXTHrQmG6QZZflYuGI1VVG7sVpx4E1n7KBpNlPb8m78J+A==",
+					"requires": {
+						"@babel/helper-module-transforms": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/helper-simple-access": "^7.14.5",
+						"babel-plugin-dynamic-import-node": "^2.3.3"
+					}
+				},
+				"@babel/plugin-transform-modules-systemjs": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.14.5.tgz",
+					"integrity": "sha512-mNMQdvBEE5DcMQaL5LbzXFMANrQjd2W7FPzg34Y4yEz7dBgdaC+9B84dSO+/1Wba98zoDbInctCDo4JGxz1VYA==",
+					"requires": {
+						"@babel/helper-hoist-variables": "^7.14.5",
+						"@babel/helper-module-transforms": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"babel-plugin-dynamic-import-node": "^2.3.3"
+					}
+				},
+				"@babel/plugin-transform-modules-umd": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.14.5.tgz",
+					"integrity": "sha512-RfPGoagSngC06LsGUYyM9QWSXZ8MysEjDJTAea1lqRjNECE3y0qIJF/qbvJxc4oA4s99HumIMdXOrd+TdKaAAA==",
+					"requires": {
+						"@babel/helper-module-transforms": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-named-capturing-groups-regex": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.14.7.tgz",
+					"integrity": "sha512-DTNOTaS7TkW97xsDMrp7nycUVh6sn/eq22VaxWfEdzuEbRsiaOU0pqU7DlyUGHVsbQbSghvjKRpEl+nUCKGQSg==",
+					"requires": {
+						"@babel/helper-create-regexp-features-plugin": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-new-target": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.14.5.tgz",
+					"integrity": "sha512-Nx054zovz6IIRWEB49RDRuXGI4Gy0GMgqG0cII9L3MxqgXz/+rgII+RU58qpo4g7tNEx1jG7rRVH4ihZoP4esQ==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-object-super": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.14.5.tgz",
+					"integrity": "sha512-MKfOBWzK0pZIrav9z/hkRqIk/2bTv9qvxHzPQc12RcVkMOzpIKnFCNYJip00ssKWYkd8Sf5g0Wr7pqJ+cmtuFg==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/helper-replace-supers": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-parameters": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.14.5.tgz",
+					"integrity": "sha512-Tl7LWdr6HUxTmzQtzuU14SqbgrSKmaR77M0OKyq4njZLQTPfOvzblNKyNkGwOfEFCEx7KeYHQHDI0P3F02IVkA==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-property-literals": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.14.5.tgz",
+					"integrity": "sha512-r1uilDthkgXW8Z1vJz2dKYLV1tuw2xsbrp3MrZmD99Wh9vsfKoob+JTgri5VUb/JqyKRXotlOtwgu4stIYCmnw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-regenerator": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.14.5.tgz",
+					"integrity": "sha512-NVIY1W3ITDP5xQl50NgTKlZ0GrotKtLna08/uGY6ErQt6VEQZXla86x/CTddm5gZdcr+5GSsvMeTmWA5Ii6pkg==",
+					"requires": {
+						"regenerator-transform": "^0.14.2"
+					}
+				},
+				"@babel/plugin-transform-reserved-words": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.14.5.tgz",
+					"integrity": "sha512-cv4F2rv1nD4qdexOGsRQXJrOcyb5CrgjUH9PKrrtyhSDBNWGxd0UIitjyJiWagS+EbUGjG++22mGH1Pub8D6Vg==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-shorthand-properties": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.14.5.tgz",
+					"integrity": "sha512-xLucks6T1VmGsTB+GWK5Pl9Jl5+nRXD1uoFdA5TSO6xtiNjtXTjKkmPdFXVLGlK5A2/or/wQMKfmQ2Y0XJfn5g==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-spread": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.14.6.tgz",
+					"integrity": "sha512-Zr0x0YroFJku7n7+/HH3A2eIrGMjbmAIbJSVv0IZ+t3U2WUQUA64S/oeied2e+MaGSjmt4alzBCsK9E8gh+fag==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/helper-skip-transparent-expression-wrappers": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-sticky-regex": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.14.5.tgz",
+					"integrity": "sha512-Z7F7GyvEMzIIbwnziAZmnSNpdijdr4dWt+FJNBnBLz5mwDFkqIXU9wmBcWWad3QeJF5hMTkRe4dAq2sUZiG+8A==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-template-literals": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.14.5.tgz",
+					"integrity": "sha512-22btZeURqiepOfuy/VkFr+zStqlujWaarpMErvay7goJS6BWwdd6BY9zQyDLDa4x2S3VugxFb162IZ4m/S/+Gg==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-typeof-symbol": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.14.5.tgz",
+					"integrity": "sha512-lXzLD30ffCWseTbMQzrvDWqljvZlHkXU+CnseMhkMNqU1sASnCsz3tSzAaH3vCUXb9PHeUb90ZT1BdFTm1xxJw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-unicode-escapes": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.14.5.tgz",
+					"integrity": "sha512-crTo4jATEOjxj7bt9lbYXcBAM3LZaUrbP2uUdxb6WIorLmjNKSpHfIybgY4B8SRpbf8tEVIWH3Vtm7ayCrKocA==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-unicode-regex": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.14.5.tgz",
+					"integrity": "sha512-UygduJpC5kHeCiRw/xDVzC+wj8VaYSoKl5JNVmbP7MadpNinAm3SvZCxZ42H37KZBKztz46YC73i9yV34d0Tzw==",
+					"requires": {
+						"@babel/helper-create-regexp-features-plugin": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/preset-env": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.14.7.tgz",
+					"integrity": "sha512-itOGqCKLsSUl0Y+1nSfhbuuOlTs0MJk2Iv7iSH+XT/mR8U1zRLO7NjWlYXB47yhK4J/7j+HYty/EhFZDYKa/VA==",
+					"requires": {
+						"@babel/compat-data": "^7.14.7",
+						"@babel/helper-compilation-targets": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/helper-validator-option": "^7.14.5",
+						"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.14.5",
+						"@babel/plugin-proposal-async-generator-functions": "^7.14.7",
+						"@babel/plugin-proposal-class-properties": "^7.14.5",
+						"@babel/plugin-proposal-class-static-block": "^7.14.5",
+						"@babel/plugin-proposal-dynamic-import": "^7.14.5",
+						"@babel/plugin-proposal-export-namespace-from": "^7.14.5",
+						"@babel/plugin-proposal-json-strings": "^7.14.5",
+						"@babel/plugin-proposal-logical-assignment-operators": "^7.14.5",
+						"@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
+						"@babel/plugin-proposal-numeric-separator": "^7.14.5",
+						"@babel/plugin-proposal-object-rest-spread": "^7.14.7",
+						"@babel/plugin-proposal-optional-catch-binding": "^7.14.5",
+						"@babel/plugin-proposal-optional-chaining": "^7.14.5",
+						"@babel/plugin-proposal-private-methods": "^7.14.5",
+						"@babel/plugin-proposal-private-property-in-object": "^7.14.5",
+						"@babel/plugin-proposal-unicode-property-regex": "^7.14.5",
+						"@babel/plugin-syntax-async-generators": "^7.8.4",
+						"@babel/plugin-syntax-class-properties": "^7.12.13",
+						"@babel/plugin-syntax-class-static-block": "^7.14.5",
+						"@babel/plugin-syntax-dynamic-import": "^7.8.3",
+						"@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+						"@babel/plugin-syntax-json-strings": "^7.8.3",
+						"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+						"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+						"@babel/plugin-syntax-numeric-separator": "^7.10.4",
+						"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+						"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+						"@babel/plugin-syntax-optional-chaining": "^7.8.3",
+						"@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+						"@babel/plugin-syntax-top-level-await": "^7.14.5",
+						"@babel/plugin-transform-arrow-functions": "^7.14.5",
+						"@babel/plugin-transform-async-to-generator": "^7.14.5",
+						"@babel/plugin-transform-block-scoped-functions": "^7.14.5",
+						"@babel/plugin-transform-block-scoping": "^7.14.5",
+						"@babel/plugin-transform-classes": "^7.14.5",
+						"@babel/plugin-transform-computed-properties": "^7.14.5",
+						"@babel/plugin-transform-destructuring": "^7.14.7",
+						"@babel/plugin-transform-dotall-regex": "^7.14.5",
+						"@babel/plugin-transform-duplicate-keys": "^7.14.5",
+						"@babel/plugin-transform-exponentiation-operator": "^7.14.5",
+						"@babel/plugin-transform-for-of": "^7.14.5",
+						"@babel/plugin-transform-function-name": "^7.14.5",
+						"@babel/plugin-transform-literals": "^7.14.5",
+						"@babel/plugin-transform-member-expression-literals": "^7.14.5",
+						"@babel/plugin-transform-modules-amd": "^7.14.5",
+						"@babel/plugin-transform-modules-commonjs": "^7.14.5",
+						"@babel/plugin-transform-modules-systemjs": "^7.14.5",
+						"@babel/plugin-transform-modules-umd": "^7.14.5",
+						"@babel/plugin-transform-named-capturing-groups-regex": "^7.14.7",
+						"@babel/plugin-transform-new-target": "^7.14.5",
+						"@babel/plugin-transform-object-super": "^7.14.5",
+						"@babel/plugin-transform-parameters": "^7.14.5",
+						"@babel/plugin-transform-property-literals": "^7.14.5",
+						"@babel/plugin-transform-regenerator": "^7.14.5",
+						"@babel/plugin-transform-reserved-words": "^7.14.5",
+						"@babel/plugin-transform-shorthand-properties": "^7.14.5",
+						"@babel/plugin-transform-spread": "^7.14.6",
+						"@babel/plugin-transform-sticky-regex": "^7.14.5",
+						"@babel/plugin-transform-template-literals": "^7.14.5",
+						"@babel/plugin-transform-typeof-symbol": "^7.14.5",
+						"@babel/plugin-transform-unicode-escapes": "^7.14.5",
+						"@babel/plugin-transform-unicode-regex": "^7.14.5",
+						"@babel/preset-modules": "^0.1.4",
+						"@babel/types": "^7.14.5",
+						"babel-plugin-polyfill-corejs2": "^0.2.2",
+						"babel-plugin-polyfill-corejs3": "^0.2.2",
+						"babel-plugin-polyfill-regenerator": "^0.2.2",
+						"core-js-compat": "^3.15.0",
+						"semver": "^6.3.0"
+					}
+				},
+				"@babel/runtime": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+					"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@babel/template": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+					"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/parser": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
+					"integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/generator": "^7.14.5",
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/helper-hoist-variables": "^7.14.5",
+						"@babel/helper-split-export-declaration": "^7.14.5",
+						"@babel/parser": "^7.14.7",
+						"@babel/types": "^7.14.5",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+					"integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"babel-plugin-polyfill-corejs2": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.2.tgz",
+					"integrity": "sha512-kISrENsJ0z5dNPq5eRvcctITNHYXWOA4DUZRFYCz3jYCcvTb/A546LIddmoGNMVYg2U38OyFeNosQwI9ENTqIQ==",
+					"requires": {
+						"@babel/compat-data": "^7.13.11",
+						"@babel/helper-define-polyfill-provider": "^0.2.2",
+						"semver": "^6.1.1"
+					}
+				},
+				"babel-plugin-polyfill-corejs3": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.3.tgz",
+					"integrity": "sha512-rCOFzEIJpJEAU14XCcV/erIf/wZQMmMT5l5vXOpL5uoznyOGfDIjPj6FVytMvtzaKSTSVKouOCTPJ5OMUZH30g==",
+					"requires": {
+						"@babel/helper-define-polyfill-provider": "^0.2.2",
+						"core-js-compat": "^3.14.0"
+					}
+				},
+				"babel-plugin-polyfill-regenerator": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.2.tgz",
+					"integrity": "sha512-Goy5ghsc21HgPDFtzRkSirpZVW35meGoTmTOb2bxqdl60ghub4xOidgNTHaZfQ2FaxQsKmwvXtOAkcIS4SMBWg==",
+					"requires": {
+						"@babel/helper-define-polyfill-provider": "^0.2.2"
+					}
+				},
+				"browserslist": {
+					"version": "4.16.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+					"integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+					"requires": {
+						"caniuse-lite": "^1.0.30001219",
+						"colorette": "^1.2.2",
+						"electron-to-chromium": "^1.3.723",
+						"escalade": "^3.1.1",
+						"node-releases": "^1.1.71"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30001242",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz",
+					"integrity": "sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug=="
+				},
+				"colorette": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+					"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
+				},
+				"core-js-compat": {
+					"version": "3.15.2",
+					"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.15.2.tgz",
+					"integrity": "sha512-Wp+BJVvwopjI+A1EFqm2dwUmWYXrvucmtIB2LgXn/Rb+gWPKYxtmb4GKHGKG/KGF1eK9jfjzT38DITbTOCX/SQ==",
+					"requires": {
+						"browserslist": "^4.16.6",
+						"semver": "7.0.0"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "7.0.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+							"integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="
+						}
+					}
+				},
+				"electron-to-chromium": {
+					"version": "1.3.766",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.766.tgz",
+					"integrity": "sha512-u2quJ862q9reRKh/je3GXis3w38+RoXH1J9N3XjtsS6NzmUAosNsyZgUVFZPN/ZlJ3v6T0rTyZR3q/J5c6Sy5w=="
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+				},
+				"json5": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+					"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+					"requires": {
+						"minimist": "^1.2.5"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				}
 			}
 		},
 		"@wordpress/base-styles": {
@@ -2635,10 +5662,427 @@
 			"dev": true
 		},
 		"@wordpress/browserslist-config": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-3.0.1.tgz",
-			"integrity": "sha512-l0c/X8w2v+NBShzEoykLuaLQNo1qiAONnPKXfIeiI145zAdjA5e8zMR0sUTDVsCxVfqfd2tH+D4wuhf68T3+Aw==",
-			"dev": true
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-4.0.1.tgz",
+			"integrity": "sha512-mmLxc21NWxZSSPvD592tmzpBlme+nB0fbG1xO+EldS4vQkeWIQUZlNbrMijZM/hpFaBqDEJCAZFUPUpw1XwBWg=="
+		},
+		"@wordpress/components": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-10.2.0.tgz",
+			"integrity": "sha512-jXZgNVAlrQk1yR/Zkmmz6nEnKI4GPz5asSWtzVu5Php0ogzC3rgxikggJWrnDq5oCT+kRrar8eSpt6qP3NVfQg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.9.2",
+				"@emotion/core": "^10.0.22",
+				"@emotion/css": "^10.0.22",
+				"@emotion/native": "^10.0.22",
+				"@emotion/styled": "^10.0.23",
+				"@wordpress/a11y": "^2.12.0",
+				"@wordpress/compose": "^3.20.1",
+				"@wordpress/date": "^3.11.1",
+				"@wordpress/deprecated": "^2.9.0",
+				"@wordpress/dom": "^2.14.0",
+				"@wordpress/element": "^2.17.1",
+				"@wordpress/hooks": "^2.9.0",
+				"@wordpress/i18n": "^3.15.0",
+				"@wordpress/icons": "^2.6.0",
+				"@wordpress/is-shallow-equal": "^2.2.0",
+				"@wordpress/keycodes": "^2.15.0",
+				"@wordpress/primitives": "^1.8.1",
+				"@wordpress/rich-text": "^3.21.1",
+				"@wordpress/warning": "^1.3.0",
+				"classnames": "^2.2.5",
+				"dom-scroll-into-view": "^1.2.1",
+				"downshift": "^5.4.0",
+				"gradient-parser": "^0.1.5",
+				"lodash": "^4.17.19",
+				"memize": "^1.1.0",
+				"moment": "^2.22.1",
+				"re-resizable": "^6.4.0",
+				"react-dates": "^17.1.1",
+				"react-merge-refs": "^1.0.0",
+				"react-resize-aware": "^3.0.1",
+				"react-spring": "^8.0.20",
+				"react-use-gesture": "^7.0.15",
+				"reakit": "^1.1.0",
+				"rememo": "^3.0.0",
+				"tinycolor2": "^1.4.1",
+				"uuid": "^7.0.2"
+			},
+			"dependencies": {
+				"@wordpress/deprecated": {
+					"version": "2.12.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.12.3.tgz",
+					"integrity": "sha512-qr+yDfTQfI3M4h6oY6IeHWwoHr4jxbILjSlV+Ht6Jjto9Owap6OuzSqR13Ev4xqIoG4C7b5B3gZXVfwVDae1zg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/hooks": "^2.12.3"
+					},
+					"dependencies": {
+						"@babel/runtime": {
+							"version": "7.14.6",
+							"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+							"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+							"dev": true,
+							"requires": {
+								"regenerator-runtime": "^0.13.4"
+							}
+						}
+					}
+				},
+				"@wordpress/element": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.20.3.tgz",
+					"integrity": "sha512-f4ZPTDf9CxiiOXiMxc4v1K7jcBMT4dsiehVOpkKzCDKboNXp4qVf8oe5PE23VGZNEjcOj5Mkg9hB57R0nqvMTw==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^1.12.2",
+						"lodash": "^4.17.19",
+						"react": "^16.13.1",
+						"react-dom": "^16.13.1"
+					},
+					"dependencies": {
+						"@babel/runtime": {
+							"version": "7.14.6",
+							"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+							"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+							"dev": true,
+							"requires": {
+								"regenerator-runtime": "^0.13.4"
+							}
+						}
+					}
+				},
+				"@wordpress/escape-html": {
+					"version": "1.12.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.12.2.tgz",
+					"integrity": "sha512-FabgSwznhdaUwe6hr1CsGpgxQbzqEoGevv73WIL1B9GvlZ6csRWodgHfWh4P6fYqpzxFL4WYB8wPJ1PdO32XFA==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					},
+					"dependencies": {
+						"@babel/runtime": {
+							"version": "7.14.6",
+							"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+							"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+							"dev": true,
+							"requires": {
+								"regenerator-runtime": "^0.13.4"
+							}
+						}
+					}
+				},
+				"@wordpress/i18n": {
+					"version": "3.20.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.20.0.tgz",
+					"integrity": "sha512-SIoOJFB4UrrYAScS4H91CYCLW9dX3Ghv8pBKc/yHGculb1AdGr6gRMlmJxZV62Cn3CZ4Ga86c+FfR+GiBu0JPg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/hooks": "^2.12.3",
+						"gettext-parser": "^1.3.1",
+						"lodash": "^4.17.19",
+						"memize": "^1.1.0",
+						"sprintf-js": "^1.1.1",
+						"tannin": "^1.2.0"
+					},
+					"dependencies": {
+						"@babel/runtime": {
+							"version": "7.14.6",
+							"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+							"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+							"dev": true,
+							"requires": {
+								"regenerator-runtime": "^0.13.4"
+							}
+						}
+					}
+				},
+				"@wordpress/warning": {
+					"version": "1.4.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-1.4.2.tgz",
+					"integrity": "sha512-MjrkSp6Jyfx+92AE32A83P503noUtGb6//BYUH4GiWzzzSNhDHgbQ0UcOJwJaEYK166DxSNpMk/JXc4YENi1Cw==",
+					"dev": true
+				},
+				"sprintf-js": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+					"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+					"dev": true
+				},
+				"uuid": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+					"integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+					"dev": true
+				}
+			}
+		},
+		"@wordpress/compose": {
+			"version": "3.23.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.23.1.tgz",
+			"integrity": "sha512-42xMoQZghhdErpBAvxcjlNKK21Lewq86KemDtAmbq9R+CYj93LGDYwceWdaqW7TwYuD9AgdI4ggr+dPhYFOCAA==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.12.5",
+				"@wordpress/deprecated": "^2.11.0",
+				"@wordpress/dom": "^2.16.0",
+				"@wordpress/element": "^2.19.0",
+				"@wordpress/is-shallow-equal": "^3.0.0",
+				"@wordpress/keycodes": "^2.18.0",
+				"@wordpress/priority-queue": "^1.10.0",
+				"clipboard": "^2.0.1",
+				"lodash": "^4.17.19",
+				"memize": "^1.1.0",
+				"mousetrap": "^1.6.5",
+				"react-merge-refs": "^1.0.0",
+				"react-resize-aware": "^3.0.1",
+				"use-memo-one": "^1.1.1"
+			},
+			"dependencies": {
+				"@wordpress/deprecated": {
+					"version": "2.12.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.12.3.tgz",
+					"integrity": "sha512-qr+yDfTQfI3M4h6oY6IeHWwoHr4jxbILjSlV+Ht6Jjto9Owap6OuzSqR13Ev4xqIoG4C7b5B3gZXVfwVDae1zg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/hooks": "^2.12.3"
+					},
+					"dependencies": {
+						"@babel/runtime": {
+							"version": "7.14.6",
+							"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+							"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+							"dev": true,
+							"requires": {
+								"regenerator-runtime": "^0.13.4"
+							}
+						}
+					}
+				},
+				"@wordpress/element": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.20.3.tgz",
+					"integrity": "sha512-f4ZPTDf9CxiiOXiMxc4v1K7jcBMT4dsiehVOpkKzCDKboNXp4qVf8oe5PE23VGZNEjcOj5Mkg9hB57R0nqvMTw==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^1.12.2",
+						"lodash": "^4.17.19",
+						"react": "^16.13.1",
+						"react-dom": "^16.13.1"
+					},
+					"dependencies": {
+						"@babel/runtime": {
+							"version": "7.14.6",
+							"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+							"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+							"dev": true,
+							"requires": {
+								"regenerator-runtime": "^0.13.4"
+							}
+						}
+					}
+				},
+				"@wordpress/escape-html": {
+					"version": "1.12.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.12.2.tgz",
+					"integrity": "sha512-FabgSwznhdaUwe6hr1CsGpgxQbzqEoGevv73WIL1B9GvlZ6csRWodgHfWh4P6fYqpzxFL4WYB8wPJ1PdO32XFA==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					},
+					"dependencies": {
+						"@babel/runtime": {
+							"version": "7.14.6",
+							"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+							"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+							"dev": true,
+							"requires": {
+								"regenerator-runtime": "^0.13.4"
+							}
+						}
+					}
+				},
+				"@wordpress/is-shallow-equal": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-3.1.3.tgz",
+					"integrity": "sha512-eDLhfC4aaSgklzqwc6F/F4zmJVpTVTAvhqX+q0SP/8LPcP2HuKErPHVrEc75PMWqIutja2wJg98YSNPdewrj1w==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					},
+					"dependencies": {
+						"@babel/runtime": {
+							"version": "7.14.6",
+							"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+							"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+							"dev": true,
+							"requires": {
+								"regenerator-runtime": "^0.13.4"
+							}
+						}
+					}
+				}
+			}
+		},
+		"@wordpress/data": {
+			"version": "4.27.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.27.3.tgz",
+			"integrity": "sha512-5763NgNV9IIa1CC3Q80dAvrH6108tJtj3IrHfUCZmUk1atSNsOMBCkLdQ7tGTTi2JFejeGEMg1LJI22JD5zM6Q==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/compose": "^3.25.3",
+				"@wordpress/deprecated": "^2.12.3",
+				"@wordpress/element": "^2.20.3",
+				"@wordpress/is-shallow-equal": "^3.1.3",
+				"@wordpress/priority-queue": "^1.11.2",
+				"@wordpress/redux-routine": "^3.14.2",
+				"equivalent-key-map": "^0.2.2",
+				"is-promise": "^4.0.0",
+				"lodash": "^4.17.19",
+				"memize": "^1.1.0",
+				"redux": "^4.0.0",
+				"turbo-combine-reducers": "^1.0.2",
+				"use-memo-one": "^1.1.1"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+					"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@wordpress/compose": {
+					"version": "3.25.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.25.3.tgz",
+					"integrity": "sha512-tCO2EnJCkCH548OqA0uU8V1k/1skz2QwBlHs8ZQSpimqUS4OWWsAlndCEFe4U4vDTqFt2ow7tzAir+05Cw8MAg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/deprecated": "^2.12.3",
+						"@wordpress/dom": "^2.18.0",
+						"@wordpress/element": "^2.20.3",
+						"@wordpress/is-shallow-equal": "^3.1.3",
+						"@wordpress/keycodes": "^2.19.3",
+						"@wordpress/priority-queue": "^1.11.2",
+						"clipboard": "^2.0.1",
+						"lodash": "^4.17.19",
+						"memize": "^1.1.0",
+						"mousetrap": "^1.6.5",
+						"react-resize-aware": "^3.1.0",
+						"use-memo-one": "^1.1.1"
+					}
+				},
+				"@wordpress/deprecated": {
+					"version": "2.12.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.12.3.tgz",
+					"integrity": "sha512-qr+yDfTQfI3M4h6oY6IeHWwoHr4jxbILjSlV+Ht6Jjto9Owap6OuzSqR13Ev4xqIoG4C7b5B3gZXVfwVDae1zg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/hooks": "^2.12.3"
+					}
+				},
+				"@wordpress/dom": {
+					"version": "2.18.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.18.0.tgz",
+					"integrity": "sha512-tM2WeQuSObl3nzWjUTF0/dyLnA7sdl/MXaSe32D64OF89bjSyJvjUipI7gjKzI3kJ7ddGhwcTggGvSB06MOoCQ==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"lodash": "^4.17.19"
+					}
+				},
+				"@wordpress/element": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.20.3.tgz",
+					"integrity": "sha512-f4ZPTDf9CxiiOXiMxc4v1K7jcBMT4dsiehVOpkKzCDKboNXp4qVf8oe5PE23VGZNEjcOj5Mkg9hB57R0nqvMTw==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^1.12.2",
+						"lodash": "^4.17.19",
+						"react": "^16.13.1",
+						"react-dom": "^16.13.1"
+					}
+				},
+				"@wordpress/escape-html": {
+					"version": "1.12.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.12.2.tgz",
+					"integrity": "sha512-FabgSwznhdaUwe6hr1CsGpgxQbzqEoGevv73WIL1B9GvlZ6csRWodgHfWh4P6fYqpzxFL4WYB8wPJ1PdO32XFA==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@wordpress/i18n": {
+					"version": "3.20.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.20.0.tgz",
+					"integrity": "sha512-SIoOJFB4UrrYAScS4H91CYCLW9dX3Ghv8pBKc/yHGculb1AdGr6gRMlmJxZV62Cn3CZ4Ga86c+FfR+GiBu0JPg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/hooks": "^2.12.3",
+						"gettext-parser": "^1.3.1",
+						"lodash": "^4.17.19",
+						"memize": "^1.1.0",
+						"sprintf-js": "^1.1.1",
+						"tannin": "^1.2.0"
+					}
+				},
+				"@wordpress/is-shallow-equal": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-3.1.3.tgz",
+					"integrity": "sha512-eDLhfC4aaSgklzqwc6F/F4zmJVpTVTAvhqX+q0SP/8LPcP2HuKErPHVrEc75PMWqIutja2wJg98YSNPdewrj1w==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@wordpress/keycodes": {
+					"version": "2.19.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.19.3.tgz",
+					"integrity": "sha512-8rNdmP5M1ifTgLIL0dt/N1uTGsq/Rx1ydCXy+gg24WdxBRhyu5sudNVCtascVXo26aIfOH9OJRdqRZZTEORhog==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/i18n": "^3.20.0",
+						"lodash": "^4.17.19"
+					}
+				},
+				"sprintf-js": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+					"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+					"dev": true
+				}
+			}
+		},
+		"@wordpress/date": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.13.0.tgz",
+			"integrity": "sha512-mNN+0NVn1EQtpSk/3fyhuo9cDSrPBsTBdCtmiS3kN8ybkBhqXNTY+HInj0No3ZZ/xii1Hr8xYKm0YijtNtUs9g==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.12.5",
+				"moment": "^2.22.1",
+				"moment-timezone": "^0.5.31"
+			}
 		},
 		"@wordpress/dependency-extraction-webpack-plugin": {
 			"version": "2.9.0",
@@ -2650,28 +6094,106 @@
 				"webpack-sources": "^1.3.0"
 			}
 		},
-		"@wordpress/element": {
-			"version": "2.19.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.19.1.tgz",
-			"integrity": "sha512-mjgFYJzSCNlQBFXvVP806pJiKh9nSIB+NeAVUVwMOntek4aCdKk+t4aTU2cRmktZI2QRySmy+lyDrY2aVkwdyg==",
+		"@wordpress/deprecated": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.1.1.tgz",
+			"integrity": "sha512-0hILlCNhf0DukFo3hMWybf9q507cxnIHhC1GQ1crZtTqzKS2QY2C1/77V4YGPdBShUj5j1dPriYCzfB5jFFgqQ==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/hooks": "^3.1.1"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+					"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@wordpress/hooks": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.1.1.tgz",
+					"integrity": "sha512-9f6H9WBwu6x/MM4ZCVLGGBuMiBcyaLapmAku5IwcWaeB2PtPduwjmk2NfGx35TuhBQD554DUg8WtTjIS019UAg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				}
+			}
+		},
+		"@wordpress/dom": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.16.0.tgz",
+			"integrity": "sha512-IjXPfv9SuEkVbmxD4eaxn01zZmYUxp/4wrMcsHAHGym59k/bN6uJOQprrU/tTiSR4Zlf8Jmo22HWmuL654k8zg==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.12.5",
+				"lodash": "^4.17.19"
+			}
+		},
+		"@wordpress/dom-ready": {
+			"version": "2.13.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.13.2.tgz",
+			"integrity": "sha512-COH7n2uZfBq4FtluSbl37N3nCEcdMXzV42ETCWKUcumiP1Zd3qnkfQKcsxTaHWY8aVt/358RvJ7ghWe3xAd+fg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+					"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				}
+			}
+		},
+		"@wordpress/element": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-3.1.1.tgz",
+			"integrity": "sha512-OaqKQVEV3CCTdrx/G7fMbmxhrxjApobHUAGAVYCCR1MIqScfluYJRLWFLx8tlkl/Qm/UbF9IfdXS1lphufvYog==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
 				"@types/react": "^16.9.0",
 				"@types/react-dom": "^16.9.0",
-				"@wordpress/escape-html": "^1.11.1",
-				"lodash": "^4.17.19",
+				"@wordpress/escape-html": "^2.1.1",
+				"lodash": "^4.17.21",
 				"react": "^16.13.1",
 				"react-dom": "^16.13.1"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+					"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				}
 			}
 		},
 		"@wordpress/escape-html": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.11.1.tgz",
-			"integrity": "sha512-kthpdAijVY1tSGnSy1kuKM5+L/u7uxzSBNDusqKcfeSgczfHlfKwkkA82SMHzsSR/WicXDaWBfcEMqfb4PENiQ==",
-			"dev": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.1.1.tgz",
+			"integrity": "sha512-ZIkLxGLBhXkZu3t0yF82/brPV5aCOGCXGiH0EMV8GCohhXCNIfQwwFrZ5gd5NyNX5Q8alTLsiA84azJd+n0XiQ==",
 			"requires": {
-				"@babel/runtime": "^7.12.5"
+				"@babel/runtime": "^7.13.10"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+					"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				}
 			}
 		},
 		"@wordpress/eslint-plugin": {
@@ -2728,6 +6250,15 @@
 				}
 			}
 		},
+		"@wordpress/html-entities": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-2.10.0.tgz",
+			"integrity": "sha512-D6lWrDOOiI/a/uYZpXMqL9ErT1Q4cauLWRZK/E4kaNOkhRxEUtWFiDD+00HdIkrT5QYPIuWos4h4Vw/HHM8Cgg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.12.5"
+			}
+		},
 		"@wordpress/i18n": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.1.1.tgz",
@@ -2765,6 +6296,61 @@
 				}
 			}
 		},
+		"@wordpress/icons": {
+			"version": "2.10.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.10.3.tgz",
+			"integrity": "sha512-hVXArGOHLE5pL1G3rHNzsUEuTR4/G6lB+enKYwhYSSIqWuSbyXbZq3nvibxpepPrLy9B3d5t6aR6QUmjMVzIcQ==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/element": "^2.20.3",
+				"@wordpress/primitives": "^1.12.3"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+					"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@wordpress/element": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.20.3.tgz",
+					"integrity": "sha512-f4ZPTDf9CxiiOXiMxc4v1K7jcBMT4dsiehVOpkKzCDKboNXp4qVf8oe5PE23VGZNEjcOj5Mkg9hB57R0nqvMTw==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^1.12.2",
+						"lodash": "^4.17.19",
+						"react": "^16.13.1",
+						"react-dom": "^16.13.1"
+					}
+				},
+				"@wordpress/escape-html": {
+					"version": "1.12.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.12.2.tgz",
+					"integrity": "sha512-FabgSwznhdaUwe6hr1CsGpgxQbzqEoGevv73WIL1B9GvlZ6csRWodgHfWh4P6fYqpzxFL4WYB8wPJ1PdO32XFA==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				}
+			}
+		},
+		"@wordpress/is-shallow-equal": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-2.3.0.tgz",
+			"integrity": "sha512-BUVCYZNDoT5fRJGoam/nI2Sn8QELu5z/pFe7UL+szFqQqNnMibdWqN/KoW/YO7WLJqqqTRhAs/Fa51g4oXRyHQ==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.11.2"
+			}
+		},
 		"@wordpress/jest-console": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-4.0.1.tgz",
@@ -2787,6 +6373,51 @@
 				"enzyme": "^3.11.0",
 				"enzyme-adapter-react-16": "^1.15.2",
 				"enzyme-to-json": "^3.4.4"
+			}
+		},
+		"@wordpress/keycodes": {
+			"version": "2.18.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.18.0.tgz",
+			"integrity": "sha512-f4Dk3S2jAFDBT6TXBkKpbWmkpXm2iOxirDNovHSdCdbp23gl7Xl4o7+K52XSS5MCYs8x9uTTI/uBJrEUe9vWCQ==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.12.5",
+				"@wordpress/i18n": "^3.17.0",
+				"lodash": "^4.17.19"
+			},
+			"dependencies": {
+				"@wordpress/i18n": {
+					"version": "3.20.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.20.0.tgz",
+					"integrity": "sha512-SIoOJFB4UrrYAScS4H91CYCLW9dX3Ghv8pBKc/yHGculb1AdGr6gRMlmJxZV62Cn3CZ4Ga86c+FfR+GiBu0JPg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/hooks": "^2.12.3",
+						"gettext-parser": "^1.3.1",
+						"lodash": "^4.17.19",
+						"memize": "^1.1.0",
+						"sprintf-js": "^1.1.1",
+						"tannin": "^1.2.0"
+					},
+					"dependencies": {
+						"@babel/runtime": {
+							"version": "7.14.6",
+							"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+							"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+							"dev": true,
+							"requires": {
+								"regenerator-runtime": "^0.13.4"
+							}
+						}
+					}
+				},
+				"sprintf-js": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+					"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/npm-package-json-lint-config": {
@@ -2821,6 +6452,232 @@
 			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-1.0.0.tgz",
 			"integrity": "sha512-s8EXokSxce1rnOY2gaL0tZgp7epg9qmmkg+z7nu3UWM61tPAXO9VWpzIUUVk5oF0lf1TARyrOMf3ZgdE3jl4Nw==",
 			"dev": true
+		},
+		"@wordpress/primitives": {
+			"version": "1.12.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-1.12.3.tgz",
+			"integrity": "sha512-LIF44bVlJS7CJEVmk6TLuV6HZMdj5iwkyM8do4ukGY6qnZIzrXpBablgJeDBcyjzWrWRLn+w+tiZ/8l+2egoVA==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/element": "^2.20.3",
+				"classnames": "^2.2.5"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+					"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@wordpress/element": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.20.3.tgz",
+					"integrity": "sha512-f4ZPTDf9CxiiOXiMxc4v1K7jcBMT4dsiehVOpkKzCDKboNXp4qVf8oe5PE23VGZNEjcOj5Mkg9hB57R0nqvMTw==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^1.12.2",
+						"lodash": "^4.17.19",
+						"react": "^16.13.1",
+						"react-dom": "^16.13.1"
+					}
+				},
+				"@wordpress/escape-html": {
+					"version": "1.12.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.12.2.tgz",
+					"integrity": "sha512-FabgSwznhdaUwe6hr1CsGpgxQbzqEoGevv73WIL1B9GvlZ6csRWodgHfWh4P6fYqpzxFL4WYB8wPJ1PdO32XFA==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				}
+			}
+		},
+		"@wordpress/priority-queue": {
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.11.2.tgz",
+			"integrity": "sha512-ulwmUOklY3orn1xXpcPnTyGWV5B/oycxI+cHZ6EevBVgM5sq+BW3xo0PKLR/MMm6UNBtFTu/71QAJrNZcD6V1g==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+					"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				}
+			}
+		},
+		"@wordpress/redux-routine": {
+			"version": "3.14.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.14.2.tgz",
+			"integrity": "sha512-aqi4UtvMP/+NhULxyCR8ktG0v4BJVTRcMpByAqDg7Oabq2sz2LPuShxd5UY8vxQYQY9t1uUJbslhom4ytcohWg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"is-promise": "^4.0.0",
+				"lodash": "^4.17.19",
+				"rungen": "^0.3.2"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+					"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				}
+			}
+		},
+		"@wordpress/rich-text": {
+			"version": "3.25.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.25.3.tgz",
+			"integrity": "sha512-FdqL1/rHTsRxZ1gW1UEWuy0URmUEqMzj5hcAbOhHFPO5m0ENrkzC9bBa195KqZBSNSmBmXnDZdHu4UJUolzcZg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/compose": "^3.25.3",
+				"@wordpress/data": "^4.27.3",
+				"@wordpress/dom": "^2.18.0",
+				"@wordpress/element": "^2.20.3",
+				"@wordpress/escape-html": "^1.12.2",
+				"@wordpress/is-shallow-equal": "^3.1.3",
+				"@wordpress/keycodes": "^2.19.3",
+				"classnames": "^2.2.5",
+				"lodash": "^4.17.19",
+				"memize": "^1.1.0",
+				"rememo": "^3.0.0"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+					"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@wordpress/compose": {
+					"version": "3.25.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.25.3.tgz",
+					"integrity": "sha512-tCO2EnJCkCH548OqA0uU8V1k/1skz2QwBlHs8ZQSpimqUS4OWWsAlndCEFe4U4vDTqFt2ow7tzAir+05Cw8MAg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/deprecated": "^2.12.3",
+						"@wordpress/dom": "^2.18.0",
+						"@wordpress/element": "^2.20.3",
+						"@wordpress/is-shallow-equal": "^3.1.3",
+						"@wordpress/keycodes": "^2.19.3",
+						"@wordpress/priority-queue": "^1.11.2",
+						"clipboard": "^2.0.1",
+						"lodash": "^4.17.19",
+						"memize": "^1.1.0",
+						"mousetrap": "^1.6.5",
+						"react-resize-aware": "^3.1.0",
+						"use-memo-one": "^1.1.1"
+					}
+				},
+				"@wordpress/deprecated": {
+					"version": "2.12.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.12.3.tgz",
+					"integrity": "sha512-qr+yDfTQfI3M4h6oY6IeHWwoHr4jxbILjSlV+Ht6Jjto9Owap6OuzSqR13Ev4xqIoG4C7b5B3gZXVfwVDae1zg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/hooks": "^2.12.3"
+					}
+				},
+				"@wordpress/dom": {
+					"version": "2.18.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.18.0.tgz",
+					"integrity": "sha512-tM2WeQuSObl3nzWjUTF0/dyLnA7sdl/MXaSe32D64OF89bjSyJvjUipI7gjKzI3kJ7ddGhwcTggGvSB06MOoCQ==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"lodash": "^4.17.19"
+					}
+				},
+				"@wordpress/element": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.20.3.tgz",
+					"integrity": "sha512-f4ZPTDf9CxiiOXiMxc4v1K7jcBMT4dsiehVOpkKzCDKboNXp4qVf8oe5PE23VGZNEjcOj5Mkg9hB57R0nqvMTw==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^1.12.2",
+						"lodash": "^4.17.19",
+						"react": "^16.13.1",
+						"react-dom": "^16.13.1"
+					}
+				},
+				"@wordpress/escape-html": {
+					"version": "1.12.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.12.2.tgz",
+					"integrity": "sha512-FabgSwznhdaUwe6hr1CsGpgxQbzqEoGevv73WIL1B9GvlZ6csRWodgHfWh4P6fYqpzxFL4WYB8wPJ1PdO32XFA==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@wordpress/i18n": {
+					"version": "3.20.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.20.0.tgz",
+					"integrity": "sha512-SIoOJFB4UrrYAScS4H91CYCLW9dX3Ghv8pBKc/yHGculb1AdGr6gRMlmJxZV62Cn3CZ4Ga86c+FfR+GiBu0JPg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/hooks": "^2.12.3",
+						"gettext-parser": "^1.3.1",
+						"lodash": "^4.17.19",
+						"memize": "^1.1.0",
+						"sprintf-js": "^1.1.1",
+						"tannin": "^1.2.0"
+					}
+				},
+				"@wordpress/is-shallow-equal": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-3.1.3.tgz",
+					"integrity": "sha512-eDLhfC4aaSgklzqwc6F/F4zmJVpTVTAvhqX+q0SP/8LPcP2HuKErPHVrEc75PMWqIutja2wJg98YSNPdewrj1w==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@wordpress/keycodes": {
+					"version": "2.19.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.19.3.tgz",
+					"integrity": "sha512-8rNdmP5M1ifTgLIL0dt/N1uTGsq/Rx1ydCXy+gg24WdxBRhyu5sudNVCtascVXo26aIfOH9OJRdqRZZTEORhog==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/i18n": "^3.20.0",
+						"lodash": "^4.17.19"
+					}
+				},
+				"sprintf-js": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+					"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+					"dev": true
+				}
+			}
 		},
 		"@wordpress/scripts": {
 			"version": "13.0.3",
@@ -2875,6 +6732,950 @@
 				"webpack-sources": "^2.2.0"
 			},
 			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+					"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.14.5"
+					}
+				},
+				"@babel/compat-data": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz",
+					"integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==",
+					"dev": true
+				},
+				"@babel/generator": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
+					"integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+							"dev": true
+						}
+					}
+				},
+				"@babel/helper-annotate-as-pure": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.14.5.tgz",
+					"integrity": "sha512-EivH9EgBIb+G8ij1B2jAwSH36WnGvkQSEC6CkX/6v6ZFlw5fVOHvsgGF4uiEHO2GzMvunZb6tDLQEQSdrdocrA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-builder-binary-assignment-operator-visitor": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.14.5.tgz",
+					"integrity": "sha512-YTA/Twn0vBXDVGJuAX6PwW7x5zQei1luDDo2Pl6q1qZ7hVNl0RZrhHCQG/ArGpR29Vl7ETiB8eJyrvpuRp300w==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-explode-assignable-expression": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-compilation-targets": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
+					"integrity": "sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==",
+					"dev": true,
+					"requires": {
+						"@babel/compat-data": "^7.14.5",
+						"@babel/helper-validator-option": "^7.14.5",
+						"browserslist": "^4.16.6",
+						"semver": "^6.3.0"
+					}
+				},
+				"@babel/helper-create-class-features-plugin": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.6.tgz",
+					"integrity": "sha512-Z6gsfGofTxH/+LQXqYEK45kxmcensbzmk/oi8DmaQytlQCgqNZt9XQF8iqlI/SeXWVjaMNxvYvzaYw+kh42mDg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.14.5",
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/helper-member-expression-to-functions": "^7.14.5",
+						"@babel/helper-optimise-call-expression": "^7.14.5",
+						"@babel/helper-replace-supers": "^7.14.5",
+						"@babel/helper-split-export-declaration": "^7.14.5"
+					}
+				},
+				"@babel/helper-create-regexp-features-plugin": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.14.5.tgz",
+					"integrity": "sha512-TLawwqpOErY2HhWbGJ2nZT5wSkR192QpN+nBg1THfBfftrlvOh+WbhrxXCH4q4xJ9Gl16BGPR/48JA+Ryiho/A==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.14.5",
+						"regexpu-core": "^4.7.1"
+					}
+				},
+				"@babel/helper-define-polyfill-provider": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.3.tgz",
+					"integrity": "sha512-RH3QDAfRMzj7+0Nqu5oqgO5q9mFtQEVvCRsi8qCEfzLR9p2BHfn5FzhSB2oj1fF7I2+DcTORkYaQ6aTR9Cofew==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-compilation-targets": "^7.13.0",
+						"@babel/helper-module-imports": "^7.12.13",
+						"@babel/helper-plugin-utils": "^7.13.0",
+						"@babel/traverse": "^7.13.0",
+						"debug": "^4.1.1",
+						"lodash.debounce": "^4.0.8",
+						"resolve": "^1.14.2",
+						"semver": "^6.1.2"
+					}
+				},
+				"@babel/helper-explode-assignable-expression": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.14.5.tgz",
+					"integrity": "sha512-Htb24gnGJdIGT4vnRKMdoXiOIlqOLmdiUYpAQ0mYfgVT/GDm8GOYhgi4GL+hMKrkiPRohO4ts34ELFsGAPQLDQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+					"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.14.5",
+						"@babel/template": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+					"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-hoist-variables": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
+					"integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
+					"integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
+					"integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz",
+					"integrity": "sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.14.5",
+						"@babel/helper-replace-supers": "^7.14.5",
+						"@babel/helper-simple-access": "^7.14.5",
+						"@babel/helper-split-export-declaration": "^7.14.5",
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"@babel/template": "^7.14.5",
+						"@babel/traverse": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
+					"integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+					"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+					"dev": true
+				},
+				"@babel/helper-remap-async-to-generator": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.14.5.tgz",
+					"integrity": "sha512-rLQKdQU+HYlxBwQIj8dk4/0ENOUEhA/Z0l4hN8BexpvmSMN9oA9EagjnhnDpNsRdWCfjwa4mn/HyBXO9yhQP6A==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.14.5",
+						"@babel/helper-wrap-function": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
+					"integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.14.5",
+						"@babel/helper-optimise-call-expression": "^7.14.5",
+						"@babel/traverse": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz",
+					"integrity": "sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-skip-transparent-expression-wrappers": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.14.5.tgz",
+					"integrity": "sha512-dmqZB7mrb94PZSAOYtr+ZN5qt5owZIAgqtoTuqiFbHFtxgEcmQlRJVI+bO++fciBunXtB6MK7HrzrfcAzIz2NQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+					"integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+					"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+					"dev": true
+				},
+				"@babel/helper-validator-option": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+					"integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+					"dev": true
+				},
+				"@babel/helper-wrap-function": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.14.5.tgz",
+					"integrity": "sha512-YEdjTCq+LNuNS1WfxsDCNpgXkJaIyqco6DAelTUjT4f2KIWC1nBcaCaSdHTBqQVLnTBexBcVcFhLSU1KnYuePQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/template": "^7.14.5",
+						"@babel/traverse": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+					"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"dev": true,
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"chalk": {
+							"version": "2.4.2",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"color-convert": {
+							"version": "1.9.3",
+							"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+							"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+							"dev": true,
+							"requires": {
+								"color-name": "1.1.3"
+							}
+						},
+						"color-name": {
+							"version": "1.1.3",
+							"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+							"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+							"dev": true
+						},
+						"has-flag": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+							"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+							"dev": true
+						},
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"@babel/parser": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
+					"integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
+					"dev": true
+				},
+				"@babel/plugin-proposal-async-generator-functions": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.14.7.tgz",
+					"integrity": "sha512-RK8Wj7lXLY3bqei69/cc25gwS5puEc3dknoFPFbqfy3XxYQBQFvu4ioWpafMBAB+L9NyptQK4nMOa5Xz16og8Q==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/helper-remap-async-to-generator": "^7.14.5",
+						"@babel/plugin-syntax-async-generators": "^7.8.4"
+					}
+				},
+				"@babel/plugin-proposal-class-properties": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.14.5.tgz",
+					"integrity": "sha512-q/PLpv5Ko4dVc1LYMpCY7RVAAO4uk55qPwrIuJ5QJ8c6cVuAmhu7I/49JOppXL6gXf7ZHzpRVEUZdYoPLM04Gg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-create-class-features-plugin": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-proposal-dynamic-import": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.14.5.tgz",
+					"integrity": "sha512-ExjiNYc3HDN5PXJx+bwC50GIx/KKanX2HiggnIUAYedbARdImiCU4RhhHfdf0Kd7JNXGpsBBBCOm+bBVy3Gb0g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/plugin-syntax-dynamic-import": "^7.8.3"
+					}
+				},
+				"@babel/plugin-proposal-export-namespace-from": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.14.5.tgz",
+					"integrity": "sha512-g5POA32bXPMmSBu5Dx/iZGLGnKmKPc5AiY7qfZgurzrCYgIztDlHFbznSNCoQuv57YQLnQfaDi7dxCtLDIdXdA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+					}
+				},
+				"@babel/plugin-proposal-json-strings": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.14.5.tgz",
+					"integrity": "sha512-NSq2fczJYKVRIsUJyNxrVUMhB27zb7N7pOFGQOhBKJrChbGcgEAqyZrmZswkPk18VMurEeJAaICbfm57vUeTbQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/plugin-syntax-json-strings": "^7.8.3"
+					}
+				},
+				"@babel/plugin-proposal-logical-assignment-operators": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.14.5.tgz",
+					"integrity": "sha512-YGn2AvZAo9TwyhlLvCCWxD90Xq8xJ4aSgaX3G5D/8DW94L8aaT+dS5cSP+Z06+rCJERGSr9GxMBZ601xoc2taw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+					}
+				},
+				"@babel/plugin-proposal-nullish-coalescing-operator": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.14.5.tgz",
+					"integrity": "sha512-gun/SOnMqjSb98Nkaq2rTKMwervfdAoz6NphdY0vTfuzMfryj+tDGb2n6UkDKwez+Y8PZDhE3D143v6Gepp4Hg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+					}
+				},
+				"@babel/plugin-proposal-numeric-separator": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.14.5.tgz",
+					"integrity": "sha512-yiclALKe0vyZRZE0pS6RXgjUOt87GWv6FYa5zqj15PvhOGFO69R5DusPlgK/1K5dVnCtegTiWu9UaBSrLLJJBg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/plugin-syntax-numeric-separator": "^7.10.4"
+					}
+				},
+				"@babel/plugin-proposal-object-rest-spread": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.14.7.tgz",
+					"integrity": "sha512-082hsZz+sVabfmDWo1Oct1u1AgbKbUAyVgmX4otIc7bdsRgHBXwTwb3DpDmD4Eyyx6DNiuz5UAATT655k+kL5g==",
+					"dev": true,
+					"requires": {
+						"@babel/compat-data": "^7.14.7",
+						"@babel/helper-compilation-targets": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+						"@babel/plugin-transform-parameters": "^7.14.5"
+					}
+				},
+				"@babel/plugin-proposal-optional-catch-binding": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.14.5.tgz",
+					"integrity": "sha512-3Oyiixm0ur7bzO5ybNcZFlmVsygSIQgdOa7cTfOYCMY+wEPAYhZAJxi3mixKFCTCKUhQXuCTtQ1MzrpL3WT8ZQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
+					}
+				},
+				"@babel/plugin-proposal-optional-chaining": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.14.5.tgz",
+					"integrity": "sha512-ycz+VOzo2UbWNI1rQXxIuMOzrDdHGrI23fRiz/Si2R4kv2XZQ1BK8ccdHwehMKBlcH/joGW/tzrUmo67gbJHlQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/helper-skip-transparent-expression-wrappers": "^7.14.5",
+						"@babel/plugin-syntax-optional-chaining": "^7.8.3"
+					}
+				},
+				"@babel/plugin-proposal-private-methods": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.14.5.tgz",
+					"integrity": "sha512-838DkdUA1u+QTCplatfq4B7+1lnDa/+QMI89x5WZHBcnNv+47N8QEj2k9I2MUU9xIv8XJ4XvPCviM/Dj7Uwt9g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-create-class-features-plugin": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-proposal-unicode-property-regex": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.14.5.tgz",
+					"integrity": "sha512-6axIeOU5LnY471KenAB9vI8I5j7NQ2d652hIYwVyRfgaZT5UpiqFKCuVXCDMSrU+3VFafnu2c5m3lrWIlr6A5Q==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-create-regexp-features-plugin": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-syntax-top-level-await": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+					"integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-arrow-functions": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.14.5.tgz",
+					"integrity": "sha512-KOnO0l4+tD5IfOdi4x8C1XmEIRWUjNRV8wc6K2vz/3e8yAOoZZvsRXRRIF/yo/MAOFb4QjtAw9xSxMXbSMRy8A==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-async-to-generator": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.14.5.tgz",
+					"integrity": "sha512-szkbzQ0mNk0rpu76fzDdqSyPu0MuvpXgC+6rz5rpMb5OIRxdmHfQxrktL8CYolL2d8luMCZTR0DpIMIdL27IjA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/helper-remap-async-to-generator": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-block-scoped-functions": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.14.5.tgz",
+					"integrity": "sha512-dtqWqdWZ5NqBX3KzsVCWfQI3A53Ft5pWFCT2eCVUftWZgjc5DpDponbIF1+c+7cSGk2wN0YK7HGL/ezfRbpKBQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-block-scoping": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.14.5.tgz",
+					"integrity": "sha512-LBYm4ZocNgoCqyxMLoOnwpsmQ18HWTQvql64t3GvMUzLQrNoV1BDG0lNftC8QKYERkZgCCT/7J5xWGObGAyHDw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-classes": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.14.5.tgz",
+					"integrity": "sha512-J4VxKAMykM06K/64z9rwiL6xnBHgB1+FVspqvlgCdwD1KUbQNfszeKVVOMh59w3sztHYIZDgnhOC4WbdEfHFDA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.14.5",
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/helper-optimise-call-expression": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/helper-replace-supers": "^7.14.5",
+						"@babel/helper-split-export-declaration": "^7.14.5",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/plugin-transform-computed-properties": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.14.5.tgz",
+					"integrity": "sha512-pWM+E4283UxaVzLb8UBXv4EIxMovU4zxT1OPnpHJcmnvyY9QbPPTKZfEj31EUvG3/EQRbYAGaYEUZ4yWOBC2xg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-destructuring": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.14.7.tgz",
+					"integrity": "sha512-0mDE99nK+kVh3xlc5vKwB6wnP9ecuSj+zQCa/n0voENtP/zymdT4HH6QEb65wjjcbqr1Jb/7z9Qp7TF5FtwYGw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-dotall-regex": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.14.5.tgz",
+					"integrity": "sha512-loGlnBdj02MDsFaHhAIJzh7euK89lBrGIdM9EAtHFo6xKygCUGuuWe07o1oZVk287amtW1n0808sQM99aZt3gw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-create-regexp-features-plugin": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-duplicate-keys": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.14.5.tgz",
+					"integrity": "sha512-iJjbI53huKbPDAsJ8EmVmvCKeeq21bAze4fu9GBQtSLqfvzj2oRuHVx4ZkDwEhg1htQ+5OBZh/Ab0XDf5iBZ7A==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-exponentiation-operator": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.14.5.tgz",
+					"integrity": "sha512-jFazJhMBc9D27o9jDnIE5ZErI0R0m7PbKXVq77FFvqFbzvTMuv8jaAwLZ5PviOLSFttqKIW0/wxNSDbjLk0tYA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-builder-binary-assignment-operator-visitor": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-for-of": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.14.5.tgz",
+					"integrity": "sha512-CfmqxSUZzBl0rSjpoQSFoR9UEj3HzbGuGNL21/iFTmjb5gFggJp3ph0xR1YBhexmLoKRHzgxuFvty2xdSt6gTA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-function-name": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.14.5.tgz",
+					"integrity": "sha512-vbO6kv0fIzZ1GpmGQuvbwwm+O4Cbm2NrPzwlup9+/3fdkuzo1YqOZcXw26+YUJB84Ja7j9yURWposEHLYwxUfQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-literals": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.14.5.tgz",
+					"integrity": "sha512-ql33+epql2F49bi8aHXxvLURHkxJbSmMKl9J5yHqg4PLtdE6Uc48CH1GS6TQvZ86eoB/ApZXwm7jlA+B3kra7A==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-member-expression-literals": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.14.5.tgz",
+					"integrity": "sha512-WkNXxH1VXVTKarWFqmso83xl+2V3Eo28YY5utIkbsmXoItO8Q3aZxN4BTS2k0hz9dGUloHK26mJMyQEYfkn/+Q==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-modules-amd": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.14.5.tgz",
+					"integrity": "sha512-3lpOU8Vxmp3roC4vzFpSdEpGUWSMsHFreTWOMMLzel2gNGfHE5UWIh/LN6ghHs2xurUp4jRFYMUIZhuFbody1g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-transforms": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"babel-plugin-dynamic-import-node": "^2.3.3"
+					}
+				},
+				"@babel/plugin-transform-modules-commonjs": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.14.5.tgz",
+					"integrity": "sha512-en8GfBtgnydoao2PS+87mKyw62k02k7kJ9ltbKe0fXTHrQmG6QZZflYuGI1VVG7sVpx4E1n7KBpNlPb8m78J+A==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-transforms": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/helper-simple-access": "^7.14.5",
+						"babel-plugin-dynamic-import-node": "^2.3.3"
+					}
+				},
+				"@babel/plugin-transform-modules-systemjs": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.14.5.tgz",
+					"integrity": "sha512-mNMQdvBEE5DcMQaL5LbzXFMANrQjd2W7FPzg34Y4yEz7dBgdaC+9B84dSO+/1Wba98zoDbInctCDo4JGxz1VYA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-hoist-variables": "^7.14.5",
+						"@babel/helper-module-transforms": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"babel-plugin-dynamic-import-node": "^2.3.3"
+					}
+				},
+				"@babel/plugin-transform-modules-umd": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.14.5.tgz",
+					"integrity": "sha512-RfPGoagSngC06LsGUYyM9QWSXZ8MysEjDJTAea1lqRjNECE3y0qIJF/qbvJxc4oA4s99HumIMdXOrd+TdKaAAA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-transforms": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-named-capturing-groups-regex": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.14.7.tgz",
+					"integrity": "sha512-DTNOTaS7TkW97xsDMrp7nycUVh6sn/eq22VaxWfEdzuEbRsiaOU0pqU7DlyUGHVsbQbSghvjKRpEl+nUCKGQSg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-create-regexp-features-plugin": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-new-target": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.14.5.tgz",
+					"integrity": "sha512-Nx054zovz6IIRWEB49RDRuXGI4Gy0GMgqG0cII9L3MxqgXz/+rgII+RU58qpo4g7tNEx1jG7rRVH4ihZoP4esQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-object-super": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.14.5.tgz",
+					"integrity": "sha512-MKfOBWzK0pZIrav9z/hkRqIk/2bTv9qvxHzPQc12RcVkMOzpIKnFCNYJip00ssKWYkd8Sf5g0Wr7pqJ+cmtuFg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/helper-replace-supers": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-parameters": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.14.5.tgz",
+					"integrity": "sha512-Tl7LWdr6HUxTmzQtzuU14SqbgrSKmaR77M0OKyq4njZLQTPfOvzblNKyNkGwOfEFCEx7KeYHQHDI0P3F02IVkA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-property-literals": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.14.5.tgz",
+					"integrity": "sha512-r1uilDthkgXW8Z1vJz2dKYLV1tuw2xsbrp3MrZmD99Wh9vsfKoob+JTgri5VUb/JqyKRXotlOtwgu4stIYCmnw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-regenerator": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.14.5.tgz",
+					"integrity": "sha512-NVIY1W3ITDP5xQl50NgTKlZ0GrotKtLna08/uGY6ErQt6VEQZXla86x/CTddm5gZdcr+5GSsvMeTmWA5Ii6pkg==",
+					"dev": true,
+					"requires": {
+						"regenerator-transform": "^0.14.2"
+					}
+				},
+				"@babel/plugin-transform-reserved-words": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.14.5.tgz",
+					"integrity": "sha512-cv4F2rv1nD4qdexOGsRQXJrOcyb5CrgjUH9PKrrtyhSDBNWGxd0UIitjyJiWagS+EbUGjG++22mGH1Pub8D6Vg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-shorthand-properties": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.14.5.tgz",
+					"integrity": "sha512-xLucks6T1VmGsTB+GWK5Pl9Jl5+nRXD1uoFdA5TSO6xtiNjtXTjKkmPdFXVLGlK5A2/or/wQMKfmQ2Y0XJfn5g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-spread": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.14.6.tgz",
+					"integrity": "sha512-Zr0x0YroFJku7n7+/HH3A2eIrGMjbmAIbJSVv0IZ+t3U2WUQUA64S/oeied2e+MaGSjmt4alzBCsK9E8gh+fag==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/helper-skip-transparent-expression-wrappers": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-sticky-regex": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.14.5.tgz",
+					"integrity": "sha512-Z7F7GyvEMzIIbwnziAZmnSNpdijdr4dWt+FJNBnBLz5mwDFkqIXU9wmBcWWad3QeJF5hMTkRe4dAq2sUZiG+8A==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-template-literals": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.14.5.tgz",
+					"integrity": "sha512-22btZeURqiepOfuy/VkFr+zStqlujWaarpMErvay7goJS6BWwdd6BY9zQyDLDa4x2S3VugxFb162IZ4m/S/+Gg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-typeof-symbol": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.14.5.tgz",
+					"integrity": "sha512-lXzLD30ffCWseTbMQzrvDWqljvZlHkXU+CnseMhkMNqU1sASnCsz3tSzAaH3vCUXb9PHeUb90ZT1BdFTm1xxJw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-unicode-escapes": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.14.5.tgz",
+					"integrity": "sha512-crTo4jATEOjxj7bt9lbYXcBAM3LZaUrbP2uUdxb6WIorLmjNKSpHfIybgY4B8SRpbf8tEVIWH3Vtm7ayCrKocA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/plugin-transform-unicode-regex": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.14.5.tgz",
+					"integrity": "sha512-UygduJpC5kHeCiRw/xDVzC+wj8VaYSoKl5JNVmbP7MadpNinAm3SvZCxZ42H37KZBKztz46YC73i9yV34d0Tzw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-create-regexp-features-plugin": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/preset-env": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.14.7.tgz",
+					"integrity": "sha512-itOGqCKLsSUl0Y+1nSfhbuuOlTs0MJk2Iv7iSH+XT/mR8U1zRLO7NjWlYXB47yhK4J/7j+HYty/EhFZDYKa/VA==",
+					"dev": true,
+					"requires": {
+						"@babel/compat-data": "^7.14.7",
+						"@babel/helper-compilation-targets": "^7.14.5",
+						"@babel/helper-plugin-utils": "^7.14.5",
+						"@babel/helper-validator-option": "^7.14.5",
+						"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.14.5",
+						"@babel/plugin-proposal-async-generator-functions": "^7.14.7",
+						"@babel/plugin-proposal-class-properties": "^7.14.5",
+						"@babel/plugin-proposal-class-static-block": "^7.14.5",
+						"@babel/plugin-proposal-dynamic-import": "^7.14.5",
+						"@babel/plugin-proposal-export-namespace-from": "^7.14.5",
+						"@babel/plugin-proposal-json-strings": "^7.14.5",
+						"@babel/plugin-proposal-logical-assignment-operators": "^7.14.5",
+						"@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
+						"@babel/plugin-proposal-numeric-separator": "^7.14.5",
+						"@babel/plugin-proposal-object-rest-spread": "^7.14.7",
+						"@babel/plugin-proposal-optional-catch-binding": "^7.14.5",
+						"@babel/plugin-proposal-optional-chaining": "^7.14.5",
+						"@babel/plugin-proposal-private-methods": "^7.14.5",
+						"@babel/plugin-proposal-private-property-in-object": "^7.14.5",
+						"@babel/plugin-proposal-unicode-property-regex": "^7.14.5",
+						"@babel/plugin-syntax-async-generators": "^7.8.4",
+						"@babel/plugin-syntax-class-properties": "^7.12.13",
+						"@babel/plugin-syntax-class-static-block": "^7.14.5",
+						"@babel/plugin-syntax-dynamic-import": "^7.8.3",
+						"@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+						"@babel/plugin-syntax-json-strings": "^7.8.3",
+						"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+						"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+						"@babel/plugin-syntax-numeric-separator": "^7.10.4",
+						"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+						"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+						"@babel/plugin-syntax-optional-chaining": "^7.8.3",
+						"@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+						"@babel/plugin-syntax-top-level-await": "^7.14.5",
+						"@babel/plugin-transform-arrow-functions": "^7.14.5",
+						"@babel/plugin-transform-async-to-generator": "^7.14.5",
+						"@babel/plugin-transform-block-scoped-functions": "^7.14.5",
+						"@babel/plugin-transform-block-scoping": "^7.14.5",
+						"@babel/plugin-transform-classes": "^7.14.5",
+						"@babel/plugin-transform-computed-properties": "^7.14.5",
+						"@babel/plugin-transform-destructuring": "^7.14.7",
+						"@babel/plugin-transform-dotall-regex": "^7.14.5",
+						"@babel/plugin-transform-duplicate-keys": "^7.14.5",
+						"@babel/plugin-transform-exponentiation-operator": "^7.14.5",
+						"@babel/plugin-transform-for-of": "^7.14.5",
+						"@babel/plugin-transform-function-name": "^7.14.5",
+						"@babel/plugin-transform-literals": "^7.14.5",
+						"@babel/plugin-transform-member-expression-literals": "^7.14.5",
+						"@babel/plugin-transform-modules-amd": "^7.14.5",
+						"@babel/plugin-transform-modules-commonjs": "^7.14.5",
+						"@babel/plugin-transform-modules-systemjs": "^7.14.5",
+						"@babel/plugin-transform-modules-umd": "^7.14.5",
+						"@babel/plugin-transform-named-capturing-groups-regex": "^7.14.7",
+						"@babel/plugin-transform-new-target": "^7.14.5",
+						"@babel/plugin-transform-object-super": "^7.14.5",
+						"@babel/plugin-transform-parameters": "^7.14.5",
+						"@babel/plugin-transform-property-literals": "^7.14.5",
+						"@babel/plugin-transform-regenerator": "^7.14.5",
+						"@babel/plugin-transform-reserved-words": "^7.14.5",
+						"@babel/plugin-transform-shorthand-properties": "^7.14.5",
+						"@babel/plugin-transform-spread": "^7.14.6",
+						"@babel/plugin-transform-sticky-regex": "^7.14.5",
+						"@babel/plugin-transform-template-literals": "^7.14.5",
+						"@babel/plugin-transform-typeof-symbol": "^7.14.5",
+						"@babel/plugin-transform-unicode-escapes": "^7.14.5",
+						"@babel/plugin-transform-unicode-regex": "^7.14.5",
+						"@babel/preset-modules": "^0.1.4",
+						"@babel/types": "^7.14.5",
+						"babel-plugin-polyfill-corejs2": "^0.2.2",
+						"babel-plugin-polyfill-corejs3": "^0.2.2",
+						"babel-plugin-polyfill-regenerator": "^0.2.2",
+						"core-js-compat": "^3.15.0",
+						"semver": "^6.3.0"
+					}
+				},
+				"@babel/runtime": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+					"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@babel/template": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+					"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/parser": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.14.7",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
+					"integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/generator": "^7.14.5",
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/helper-hoist-variables": "^7.14.5",
+						"@babel/helper-split-export-declaration": "^7.14.5",
+						"@babel/parser": "^7.14.7",
+						"@babel/types": "^7.14.5",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+					"integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"@wordpress/babel-preset-default": {
+					"version": "5.2.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-5.2.2.tgz",
+					"integrity": "sha512-xn/uOJRrkXBZoVv/iR4vc6GOAmmBpNSujO+ZoJzdy0zSJqV8vgzt7y/uZZetpJuyZAD8lR3aHxL7MUWos2PtfA==",
+					"dev": true,
+					"requires": {
+						"@babel/core": "^7.13.10",
+						"@babel/plugin-transform-react-jsx": "^7.12.7",
+						"@babel/plugin-transform-runtime": "^7.13.10",
+						"@babel/preset-env": "^7.13.10",
+						"@babel/preset-typescript": "^7.13.0",
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/babel-plugin-import-jsx-pragma": "^3.0.3",
+						"@wordpress/browserslist-config": "^3.0.3",
+						"@wordpress/element": "^2.20.3",
+						"@wordpress/warning": "^1.4.2",
+						"core-js": "^3.6.4"
+					}
+				},
+				"@wordpress/browserslist-config": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-3.0.3.tgz",
+					"integrity": "sha512-hbGJt0+EKiVaa1VhVnm4nwWEzXH7/KMJVsEwk3IZjoYTqKLOWw3zQa6E7eh+jdJifEFrPkQNZs4QcICv6Z+1kQ==",
+					"dev": true
+				},
 				"@wordpress/dependency-extraction-webpack-plugin": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-3.0.1.tgz",
@@ -2885,10 +7686,40 @@
 						"webpack-sources": "^2.2.0"
 					}
 				},
+				"@wordpress/element": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.20.3.tgz",
+					"integrity": "sha512-f4ZPTDf9CxiiOXiMxc4v1K7jcBMT4dsiehVOpkKzCDKboNXp4qVf8oe5PE23VGZNEjcOj5Mkg9hB57R0nqvMTw==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^1.12.2",
+						"lodash": "^4.17.19",
+						"react": "^16.13.1",
+						"react-dom": "^16.13.1"
+					}
+				},
+				"@wordpress/escape-html": {
+					"version": "1.12.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.12.2.tgz",
+					"integrity": "sha512-FabgSwznhdaUwe6hr1CsGpgxQbzqEoGevv73WIL1B9GvlZ6csRWodgHfWh4P6fYqpzxFL4WYB8wPJ1PdO32XFA==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
 				"@wordpress/prettier-config": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-1.0.1.tgz",
 					"integrity": "sha512-LgnivcSTWqUgy5JE24+AKygtQsVvcdvNUGEyeM4K4urWgnyvmkeyZDfbN1nuK2b7E1oRMSSCCwxqQJDoxlFgUg==",
+					"dev": true
+				},
+				"@wordpress/warning": {
+					"version": "1.4.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-1.4.2.tgz",
+					"integrity": "sha512-MjrkSp6Jyfx+92AE32A83P503noUtGb6//BYUH4GiWzzzSNhDHgbQ0UcOJwJaEYK166DxSNpMk/JXc4YENi1Cw==",
 					"dev": true
 				},
 				"ansi-styles": {
@@ -2899,6 +7730,55 @@
 					"requires": {
 						"color-convert": "^2.0.1"
 					}
+				},
+				"babel-plugin-polyfill-corejs2": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.2.tgz",
+					"integrity": "sha512-kISrENsJ0z5dNPq5eRvcctITNHYXWOA4DUZRFYCz3jYCcvTb/A546LIddmoGNMVYg2U38OyFeNosQwI9ENTqIQ==",
+					"dev": true,
+					"requires": {
+						"@babel/compat-data": "^7.13.11",
+						"@babel/helper-define-polyfill-provider": "^0.2.2",
+						"semver": "^6.1.1"
+					}
+				},
+				"babel-plugin-polyfill-corejs3": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.3.tgz",
+					"integrity": "sha512-rCOFzEIJpJEAU14XCcV/erIf/wZQMmMT5l5vXOpL5uoznyOGfDIjPj6FVytMvtzaKSTSVKouOCTPJ5OMUZH30g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-define-polyfill-provider": "^0.2.2",
+						"core-js-compat": "^3.14.0"
+					}
+				},
+				"babel-plugin-polyfill-regenerator": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.2.tgz",
+					"integrity": "sha512-Goy5ghsc21HgPDFtzRkSirpZVW35meGoTmTOb2bxqdl60ghub4xOidgNTHaZfQ2FaxQsKmwvXtOAkcIS4SMBWg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-define-polyfill-provider": "^0.2.2"
+					}
+				},
+				"browserslist": {
+					"version": "4.16.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+					"integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30001219",
+						"colorette": "^1.2.2",
+						"electron-to-chromium": "^1.3.723",
+						"escalade": "^3.1.1",
+						"node-releases": "^1.1.71"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30001242",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz",
+					"integrity": "sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug==",
+					"dev": true
 				},
 				"chalk": {
 					"version": "4.1.0",
@@ -2925,6 +7805,30 @@
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
+				"colorette": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+					"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+					"dev": true
+				},
+				"core-js-compat": {
+					"version": "3.15.2",
+					"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.15.2.tgz",
+					"integrity": "sha512-Wp+BJVvwopjI+A1EFqm2dwUmWYXrvucmtIB2LgXn/Rb+gWPKYxtmb4GKHGKG/KGF1eK9jfjzT38DITbTOCX/SQ==",
+					"dev": true,
+					"requires": {
+						"browserslist": "^4.16.6",
+						"semver": "7.0.0"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "7.0.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+							"integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+							"dev": true
+						}
+					}
+				},
 				"cross-spawn": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -2936,6 +7840,12 @@
 						"which": "^1.2.9"
 					}
 				},
+				"electron-to-chromium": {
+					"version": "1.3.766",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.766.tgz",
+					"integrity": "sha512-u2quJ862q9reRKh/je3GXis3w38+RoXH1J9N3XjtsS6NzmUAosNsyZgUVFZPN/ZlJ3v6T0rTyZR3q/J5c6Sy5w==",
+					"dev": true
+				},
 				"find-up": {
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
@@ -2945,6 +7855,12 @@
 						"path-exists": "^2.0.0",
 						"pinkie-promise": "^2.0.0"
 					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
 				},
 				"has-flag": {
 					"version": "4.0.0",
@@ -2965,6 +7881,17 @@
 						"strip-bom": "^2.0.0"
 					}
 				},
+				"loader-utils": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+					"dev": true,
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^1.0.1"
+					}
+				},
 				"locate-path": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -2982,6 +7909,30 @@
 					"requires": {
 						"pseudomap": "^1.0.2",
 						"yallist": "^2.1.2"
+					}
+				},
+				"mini-css-extract-plugin": {
+					"version": "0.9.0",
+					"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.0.tgz",
+					"integrity": "sha512-lp3GeY7ygcgAmVIcRPBVhIkf8Us7FZjA+ILpal44qLdSu11wmjKQ3d9k15lfD7pO4esu9eUIAW7qiYIBppv40A==",
+					"dev": true,
+					"requires": {
+						"loader-utils": "^1.1.0",
+						"normalize-url": "1.9.1",
+						"schema-utils": "^1.0.0",
+						"webpack-sources": "^1.1.0"
+					},
+					"dependencies": {
+						"webpack-sources": {
+							"version": "1.4.3",
+							"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+							"integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+							"dev": true,
+							"requires": {
+								"source-list-map": "^2.0.0",
+								"source-map": "~0.6.1"
+							}
+						}
 					}
 				},
 				"p-limit": {
@@ -3111,6 +8062,23 @@
 						"read-pkg": "^1.0.0"
 					}
 				},
+				"schema-utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+					"dev": true,
+					"requires": {
+						"ajv": "^6.1.0",
+						"ajv-errors": "^1.0.0",
+						"ajv-keywords": "^3.1.0"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
 				"shebang-command": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -3182,11 +8150,44 @@
 				"stylelint-scss": "^3.17.2"
 			}
 		},
+		"@wordpress/url": {
+			"version": "2.22.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.22.2.tgz",
+			"integrity": "sha512-aqpYKQXzyzkCOm+GzZRYlLb+wh58g0cwR1PaKAl0UXaBS4mdS+X6biMriylb4P8CVC/RR7CSw5XI20JC24KDwQ==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"lodash": "^4.17.19",
+				"react-native-url-polyfill": "^1.1.2"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.14.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+					"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				}
+			}
+		},
+		"@wordpress/viewport": {
+			"version": "2.24.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.24.0.tgz",
+			"integrity": "sha512-JaJ7BVGDQJ8jzcus5XXu5Kb2m4B0lMG0J4FS2Yu/foZXOzfPCciPrJ/xo84gttL1SUwUKG5CkI9BOkQQq6npmw==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.11.2",
+				"@wordpress/compose": "^3.22.0",
+				"@wordpress/data": "^4.25.0",
+				"lodash": "^4.17.19"
+			}
+		},
 		"@wordpress/warning": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-1.3.1.tgz",
-			"integrity": "sha512-MdZ/4k2KmdH4h71KfKUXPCm8eR4fnD1t9W70vIX5+MsdiA7uplkwcDWxybITYVOmVT0Zk4F5CJ29AcsJAvtgZg==",
-			"dev": true
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.1.1.tgz",
+			"integrity": "sha512-EX+/6P2bWO0zRrKJYx1yck0rY2K5z5aPb67DTU+2ggcowW8JRP7hBzGdzhXqoE32oMS7RO97nG3uD9sZtn2DJA=="
 		},
 		"@xtuc/ieee754": {
 			"version": "1.2.0",
@@ -3271,7 +8272,6 @@
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -3288,8 +8288,7 @@
 		"ajv-keywords": {
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-			"dev": true
+			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
 		},
 		"ansi-colors": {
 			"version": "4.1.1",
@@ -3324,7 +8323,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
@@ -3479,6 +8477,11 @@
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
 			"dev": true
 		},
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+		},
 		"asn1": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -3579,6 +8582,12 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
+		},
+		"at-least-node": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
 			"dev": true
 		},
 		"atob": {
@@ -3711,7 +8720,6 @@
 			"version": "8.2.2",
 			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.2.tgz",
 			"integrity": "sha512-JvTd0/D889PQBtUXJ2PXaKU/pjZDMtHA9V2ecm+eNRmmBCMR09a+fmpGTNwnJtFmFl5Ei7Vy47LjBb+L0wQ99g==",
-			"dev": true,
 			"requires": {
 				"find-cache-dir": "^3.3.1",
 				"loader-utils": "^1.4.0",
@@ -3723,7 +8731,6 @@
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
 					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-					"dev": true,
 					"requires": {
 						"big.js": "^5.2.2",
 						"emojis-list": "^3.0.0",
@@ -3736,9 +8743,34 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
 			"integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
-			"dev": true,
 			"requires": {
 				"object.assign": "^4.1.0"
+			}
+		},
+		"babel-plugin-emotion": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.2.2.tgz",
+			"integrity": "sha512-SMSkGoqTbTyUTDeuVuPIWifPdUGkTk1Kf9BWRiXIOIcuyMfsdp2EjeiiFvOzX8NOBvEh/ypKYvUh2rkgAJMCLA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.0.0",
+				"@emotion/hash": "0.8.0",
+				"@emotion/memoize": "0.7.4",
+				"@emotion/serialize": "^0.11.16",
+				"babel-plugin-macros": "^2.0.0",
+				"babel-plugin-syntax-jsx": "^6.18.0",
+				"convert-source-map": "^1.5.0",
+				"escape-string-regexp": "^1.0.5",
+				"find-root": "^1.1.0",
+				"source-map": "^0.5.7"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
 			}
 		},
 		"babel-plugin-istanbul": {
@@ -3764,6 +8796,32 @@
 				"@babel/types": "^7.3.3",
 				"@types/babel__core": "^7.0.0",
 				"@types/babel__traverse": "^7.0.6"
+			}
+		},
+		"babel-plugin-macros": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+			"integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.7.2",
+				"cosmiconfig": "^6.0.0",
+				"resolve": "^1.12.0"
+			},
+			"dependencies": {
+				"cosmiconfig": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+					"integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+					"dev": true,
+					"requires": {
+						"@types/parse-json": "^4.0.0",
+						"import-fresh": "^3.1.0",
+						"parse-json": "^5.0.0",
+						"path-type": "^4.0.0",
+						"yaml": "^1.7.2"
+					}
+				}
 			}
 		},
 		"babel-plugin-polyfill-corejs2": {
@@ -3803,6 +8861,12 @@
 			"requires": {
 				"@babel/helper-define-polyfill-provider": "^0.1.2"
 			}
+		},
+		"babel-plugin-syntax-jsx": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+			"dev": true
 		},
 		"babel-preset-current-node-syntax": {
 			"version": "1.0.1",
@@ -3919,8 +8983,7 @@
 		"big.js": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-			"dev": true
+			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
 		},
 		"binary-extensions": {
 			"version": "2.2.0",
@@ -3973,6 +9036,12 @@
 				"safe-json-parse": "~1.0.1"
 			}
 		},
+		"body-scroll-lock": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-3.1.5.tgz",
+			"integrity": "sha512-Yi1Xaml0EvNA0OYWxXiYNqY24AfWkbA6w5vxE7GWxtKfzIbZM+Qw+aSmkgsbWzbHiy/RCSkUZBplVxTA+E4jJg==",
+			"dev": true
+		},
 		"boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -3998,10 +9067,22 @@
 				"fill-range": "^7.0.1"
 			}
 		},
+		"brcast": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brcast/-/brcast-2.0.2.tgz",
+			"integrity": "sha512-Tfn5JSE7hrUlFcOoaLzVvkbgIemIorMIyoMr3TgvszWW7jFt2C9PdeMLtysYD9RU0MmU17b69+XJG1eRY2OBRg==",
+			"dev": true
+		},
 		"brorand": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
 			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+			"dev": true
+		},
+		"browser-filesaver": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/browser-filesaver/-/browser-filesaver-1.1.1.tgz",
+			"integrity": "sha1-HDUbL1dvWwDx0p1EIcTAQo7uX6E=",
 			"dev": true
 		},
 		"browser-process-hrtime": {
@@ -4095,7 +9176,6 @@
 			"version": "4.16.3",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
 			"integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
-			"dev": true,
 			"requires": {
 				"caniuse-lite": "^1.0.30001181",
 				"colorette": "^1.2.1",
@@ -4222,7 +9302,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
 			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1",
 				"get-intrinsic": "^1.0.2"
@@ -4285,11 +9364,16 @@
 				}
 			}
 		},
+		"camelize": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
+			"integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=",
+			"dev": true
+		},
 		"caniuse-lite": {
 			"version": "1.0.30001191",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001191.tgz",
-			"integrity": "sha512-xJJqzyd+7GCJXkcoBiQ1GuxEiOBCLQ0aVW9HMekifZsAVGdj5eJ4mFB9fEhSHipq9IOk/QXFJUiIr9lZT+EsGw==",
-			"dev": true
+			"integrity": "sha512-xJJqzyd+7GCJXkcoBiQ1GuxEiOBCLQ0aVW9HMekifZsAVGdj5eJ4mFB9fEhSHipq9IOk/QXFJUiIr9lZT+EsGw=="
 		},
 		"capture-exit": {
 			"version": "2.0.0",
@@ -4310,7 +9394,6 @@
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -4339,6 +9422,12 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
 			"integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+			"dev": true
+		},
+		"charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
 			"dev": true
 		},
 		"check-node-version": {
@@ -4543,6 +9632,12 @@
 				}
 			}
 		},
+		"classnames": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+			"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
+			"dev": true
+		},
 		"clean-stack": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -4559,6 +9654,17 @@
 				"del": "^4.1.1"
 			}
 		},
+		"clipboard": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
+			"integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
+			"dev": true,
+			"requires": {
+				"good-listener": "^1.2.2",
+				"select": "^1.1.2",
+				"tiny-emitter": "^2.0.0"
+			}
+		},
 		"cliui": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -4569,6 +9675,12 @@
 				"strip-ansi": "^6.0.0",
 				"wrap-ansi": "^6.2.0"
 			}
+		},
+		"clone": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+			"dev": true
 		},
 		"clone-deep": {
 			"version": "0.2.4",
@@ -4646,7 +9758,6 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -4654,14 +9765,39 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"colorette": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-			"integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
-			"dev": true
+			"integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw=="
+		},
+		"columnify": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.1.tgz",
+			"integrity": "sha1-Ff3agDo4dfh/nTArO8goky1mQAM=",
+			"dev": true,
+			"requires": {
+				"strip-ansi": "^2.0.1",
+				"wcwidth": "^1.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+					"integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+					"integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^1.0.0"
+					}
+				}
+			}
 		},
 		"combined-stream": {
 			"version": "1.0.8",
@@ -4687,13 +9823,18 @@
 		"commondir": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-			"dev": true
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
 		},
 		"component-emitter": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
 			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+			"dev": true
+		},
+		"compute-scroll-into-view": {
+			"version": "1.0.17",
+			"resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
+			"integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg==",
 			"dev": true
 		},
 		"concat-map": {
@@ -4746,6 +9887,12 @@
 			"integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
 			"dev": true
 		},
+		"consolidated-events": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/consolidated-events/-/consolidated-events-2.0.2.tgz",
+			"integrity": "sha512-2/uRVMdRypf5z/TW/ncD/66l75P5hH2vM/GR8Jf8HLc2xnfJtmina6F6du8+v4Z2vTrMo7jC+W1tmEEuuELgkQ==",
+			"dev": true
+		},
 		"constants-browserify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
@@ -4768,7 +9915,6 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
 			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			}
@@ -4805,10 +9951,9 @@
 			"dev": true
 		},
 		"core-js": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.0.tgz",
-			"integrity": "sha512-PyFBJaLq93FlyYdsndE5VaueA9K5cNB7CGzeCj191YYLhkQM0gdZR2SKihM70oF0wdqKSKClv/tEBOpoRmdOVQ==",
-			"dev": true
+			"version": "3.15.2",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.2.tgz",
+			"integrity": "sha512-tKs41J7NJVuaya8DxIOCnl8QuPHx5/ZVbFo1oKgVl1qHFBBrDctzQGtuLjPpRdNTWmKPH6oEvgN/MUID+l485Q=="
 		},
 		"core-js-compat": {
 			"version": "3.9.0",
@@ -4909,6 +10054,12 @@
 				"which": "^2.0.1"
 			}
 		},
+		"crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+			"dev": true
+		},
 		"crypto-browserify": {
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -4927,6 +10078,12 @@
 				"randombytes": "^2.0.0",
 				"randomfill": "^1.0.3"
 			}
+		},
+		"css-color-keywords": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+			"integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=",
+			"dev": true
 		},
 		"css-loader": {
 			"version": "3.6.0",
@@ -4991,6 +10148,25 @@
 			"resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
 			"integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
 			"dev": true
+		},
+		"css-to-react-native": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.2.tgz",
+			"integrity": "sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==",
+			"dev": true,
+			"requires": {
+				"camelize": "^1.0.0",
+				"css-color-keywords": "^1.0.0",
+				"postcss-value-parser": "^3.3.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
+			}
 		},
 		"css-tree": {
 			"version": "1.0.0-alpha.37",
@@ -5065,10 +10241,9 @@
 			}
 		},
 		"csstype": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.7.tgz",
-			"integrity": "sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g==",
-			"dev": true
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+			"integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
 		},
 		"cwd": {
 			"version": "0.10.0",
@@ -5085,6 +10260,105 @@
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
 			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
 			"dev": true
+		},
+		"d3-array": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+			"integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
+			"dev": true
+		},
+		"d3-axis": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.12.tgz",
+			"integrity": "sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ==",
+			"dev": true
+		},
+		"d3-collection": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+			"integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==",
+			"dev": true
+		},
+		"d3-color": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+			"integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==",
+			"dev": true
+		},
+		"d3-format": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+			"integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==",
+			"dev": true
+		},
+		"d3-interpolate": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+			"integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+			"dev": true,
+			"requires": {
+				"d3-color": "1"
+			}
+		},
+		"d3-path": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+			"integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+			"dev": true
+		},
+		"d3-scale": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-2.2.2.tgz",
+			"integrity": "sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==",
+			"dev": true,
+			"requires": {
+				"d3-array": "^1.2.0",
+				"d3-collection": "1",
+				"d3-format": "1",
+				"d3-interpolate": "1",
+				"d3-time": "1",
+				"d3-time-format": "2"
+			}
+		},
+		"d3-scale-chromatic": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz",
+			"integrity": "sha512-ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==",
+			"dev": true,
+			"requires": {
+				"d3-color": "1",
+				"d3-interpolate": "1"
+			}
+		},
+		"d3-selection": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz",
+			"integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==",
+			"dev": true
+		},
+		"d3-shape": {
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+			"integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+			"dev": true,
+			"requires": {
+				"d3-path": "1"
+			}
+		},
+		"d3-time": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+			"integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==",
+			"dev": true
+		},
+		"d3-time-format": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+			"integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+			"dev": true,
+			"requires": {
+				"d3-time": "1"
+			}
 		},
 		"damerau-levenshtein": {
 			"version": "1.0.6",
@@ -5116,7 +10390,6 @@
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
 			"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-			"dev": true,
 			"requires": {
 				"ms": "2.1.2"
 			}
@@ -5175,11 +10448,19 @@
 			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
 			"dev": true
 		},
+		"defaults": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+			"dev": true,
+			"requires": {
+				"clone": "^1.0.2"
+			}
+		},
 		"define-properties": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
 			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-			"dev": true,
 			"requires": {
 				"object-keys": "^1.0.12"
 			}
@@ -5293,6 +10574,12 @@
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"dev": true
 		},
+		"delegate": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+			"integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+			"dev": true
+		},
 		"des.js": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -5355,6 +10642,12 @@
 				"path-type": "^4.0.0"
 			}
 		},
+		"direction": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz",
+			"integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==",
+			"dev": true
+		},
 		"discontinuous-range": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
@@ -5370,6 +10663,31 @@
 				"esutils": "^2.0.2",
 				"isarray": "^1.0.0"
 			}
+		},
+		"document.contains": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/document.contains/-/document.contains-1.0.2.tgz",
+			"integrity": "sha512-YcvYFs15mX8m3AO1QNQy3BlIpSMfNRj3Ujk2BEJxsZG+HZf7/hZ6jr7mDpXrF8q+ff95Vef5yjhiZxm8CGJr6Q==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3"
+			}
+		},
+		"dom-helpers": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+			"integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.8.7",
+				"csstype": "^3.0.2"
+			}
+		},
+		"dom-scroll-into-view": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/dom-scroll-into-view/-/dom-scroll-into-view-1.2.1.tgz",
+			"integrity": "sha1-6PNnMt0ImwIBqI14Fdw/iObWbH4=",
+			"dev": true
 		},
 		"dom-serializer": {
 			"version": "0.2.2",
@@ -5435,6 +10753,12 @@
 				}
 			}
 		},
+		"dompurify": {
+			"version": "2.2.9",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.9.tgz",
+			"integrity": "sha512-+9MqacuigMIZ+1+EwoEltogyWGFTJZWU3258Rupxs+2CGs4H914G9er6pZbsme/bvb5L67o2rade9n21e4RW/w==",
+			"dev": true
+		},
 		"domutils": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
@@ -5443,6 +10767,18 @@
 			"requires": {
 				"dom-serializer": "0",
 				"domelementtype": "1"
+			}
+		},
+		"downshift": {
+			"version": "5.4.7",
+			"resolved": "https://registry.npmjs.org/downshift/-/downshift-5.4.7.tgz",
+			"integrity": "sha512-xaH0RNqwJ5pAsyk9qBmR9XJWmg1OOWMfrhzYv0NH2NjJxn77S3zBcfClw341UfhGyKg5v+qVqg/CQzvAgBNCXQ==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.10.2",
+				"compute-scroll-into-view": "^1.0.14",
+				"prop-types": "^15.7.2",
+				"react-is": "^16.13.1"
 			}
 		},
 		"duplexer": {
@@ -5502,8 +10838,7 @@
 		"electron-to-chromium": {
 			"version": "1.3.673",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.673.tgz",
-			"integrity": "sha512-ms+QR2ckfrrpEAjXweLx6kNCbpAl66DcW//3BZD4BV5KhUgr0RZRce1ON/9J3QyA3JO28nzgb5Xv8DnPr05ILg==",
-			"dev": true
+			"integrity": "sha512-ms+QR2ckfrrpEAjXweLx6kNCbpAl66DcW//3BZD4BV5KhUgr0RZRce1ON/9J3QyA3JO28nzgb5Xv8DnPr05ILg=="
 		},
 		"elliptic": {
 			"version": "6.5.4",
@@ -5534,6 +10869,16 @@
 			"integrity": "sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==",
 			"dev": true
 		},
+		"emoji-flags": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/emoji-flags/-/emoji-flags-1.3.0.tgz",
+			"integrity": "sha512-cw6zdVlLPtFhpTurp9AM7c6+dBeCQAu0PrGpUQ9lA1XWsWW9lNEEbnAF9gtf8acb4jTSpUTOFZ1hHsBdSTQZGg==",
+			"dev": true,
+			"requires": {
+				"columnify": "1.5.1",
+				"lodash.find": "3.2.1"
+			}
+		},
 		"emoji-regex": {
 			"version": "9.2.1",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.1.tgz",
@@ -5543,8 +10888,7 @@
 		"emojis-list": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-			"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-			"dev": true
+			"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
 		},
 		"encoding": {
 			"version": "0.1.13",
@@ -5718,6 +11062,12 @@
 				"react-is": "^16.12.0"
 			}
 		},
+		"equivalent-key-map": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/equivalent-key-map/-/equivalent-key-map-0.2.2.tgz",
+			"integrity": "sha512-xvHeyCDbZzkpN4VHQj/n+j2lOwL0VWszG30X4cOrc9Y7Tuo2qCdZK/0AMod23Z5dCtNUbaju6p0rwOhHUk05ew==",
+			"dev": true
+		},
 		"errno": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
@@ -5778,17 +11128,21 @@
 				"is-symbol": "^1.0.2"
 			}
 		},
+		"es6-promise": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+			"dev": true
+		},
 		"escalade": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-			"dev": true
+			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escodegen": {
 			"version": "1.14.3",
@@ -6336,8 +11690,7 @@
 		"esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-			"dev": true
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
 		},
 		"events": {
 			"version": "3.2.0",
@@ -6665,8 +12018,7 @@
 		"fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"fast-diff": {
 			"version": "1.2.0",
@@ -6691,13 +12043,18 @@
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
+		},
+		"fast-memoize": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
+			"integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==",
 			"dev": true
 		},
 		"fastest-levenshtein": {
@@ -6731,6 +12088,27 @@
 			"dev": true,
 			"requires": {
 				"bser": "2.1.1"
+			}
+		},
+		"fbjs": {
+			"version": "0.8.17",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+			"requires": {
+				"core-js": "^1.0.0",
+				"isomorphic-fetch": "^2.1.1",
+				"loose-envify": "^1.0.0",
+				"object-assign": "^4.1.0",
+				"promise": "^7.1.1",
+				"setimmediate": "^1.0.5",
+				"ua-parser-js": "^0.7.18"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+				}
 			}
 		},
 		"fd-slicer": {
@@ -6800,7 +12178,6 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
 			"integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
-			"dev": true,
 			"requires": {
 				"commondir": "^1.0.1",
 				"make-dir": "^3.0.2",
@@ -6811,7 +12188,6 @@
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
 					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
 					"requires": {
 						"locate-path": "^5.0.0",
 						"path-exists": "^4.0.0"
@@ -6821,7 +12197,6 @@
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
 					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
 					"requires": {
 						"p-locate": "^4.1.0"
 					}
@@ -6830,7 +12205,6 @@
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
 					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
 					}
@@ -6839,7 +12213,6 @@
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
 					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
 					"requires": {
 						"p-limit": "^2.2.0"
 					}
@@ -6847,20 +12220,17 @@
 				"p-try": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 				},
 				"path-exists": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
 				},
 				"pkg-dir": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
 					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-					"dev": true,
 					"requires": {
 						"find-up": "^4.0.0"
 					}
@@ -6959,6 +12329,12 @@
 					}
 				}
 			}
+		},
+		"find-root": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+			"dev": true
 		},
 		"find-up": {
 			"version": "2.1.0",
@@ -7211,6 +12587,111 @@
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
 			"dev": true
 		},
+		"fork-ts-checker-webpack-plugin": {
+			"version": "6.2.12",
+			"resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.2.12.tgz",
+			"integrity": "sha512-BzXGIfM47q1WFwXsNLl22dQVMFwSBgldL07lvqRJFxgrhT76QQ3nri5PX01Rxfa2RYvv/hqACULO8K5gT8fFuA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.8.3",
+				"@types/json-schema": "^7.0.5",
+				"chalk": "^4.1.0",
+				"chokidar": "^3.4.2",
+				"cosmiconfig": "^6.0.0",
+				"deepmerge": "^4.2.2",
+				"fs-extra": "^9.0.0",
+				"glob": "^7.1.6",
+				"memfs": "^3.1.2",
+				"minimatch": "^3.0.4",
+				"schema-utils": "2.7.0",
+				"semver": "^7.3.2",
+				"tapable": "^1.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+					"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"cosmiconfig": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+					"integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+					"dev": true,
+					"requires": {
+						"@types/parse-json": "^4.0.0",
+						"import-fresh": "^3.1.0",
+						"parse-json": "^5.0.0",
+						"path-type": "^4.0.0",
+						"yaml": "^1.7.2"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"schema-utils": {
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+					"integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+					"dev": true,
+					"requires": {
+						"@types/json-schema": "^7.0.4",
+						"ajv": "^6.12.2",
+						"ajv-keywords": "^3.4.1"
+					}
+				},
+				"semver": {
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"form-data": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
@@ -7279,6 +12760,18 @@
 			"integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
 			"dev": true
 		},
+		"fs-extra": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"dev": true,
+			"requires": {
+				"at-least-node": "^1.0.0",
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			}
+		},
 		"fs-minipass": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -7287,6 +12780,18 @@
 			"requires": {
 				"minipass": "^3.0.0"
 			}
+		},
+		"fs-monkey": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz",
+			"integrity": "sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==",
+			"dev": true
+		},
+		"fs-readdir-recursive": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+			"dev": true
 		},
 		"fs-write-stream-atomic": {
 			"version": "1.0.10",
@@ -7342,8 +12847,7 @@
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
 		"function.prototype.name": {
 			"version": "1.1.4",
@@ -7372,8 +12876,7 @@
 		"gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-			"dev": true
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
 		},
 		"get-caller-file": {
 			"version": "2.0.5",
@@ -7385,7 +12888,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
 			"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
@@ -7458,6 +12960,16 @@
 			"dev": true,
 			"requires": {
 				"is-glob": "^4.0.1"
+			}
+		},
+		"global-cache": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/global-cache/-/global-cache-1.2.1.tgz",
+			"integrity": "sha512-EOeUaup5DgWKlCMhA9YFqNRIlZwoxt731jCh47WBV9fQqHgXhr3Fa55hfgIUqilIcPsfdNKN7LHjrNY+Km40KA==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"is-symbol": "^1.0.1"
 			}
 		},
 		"global-modules": {
@@ -7545,6 +13057,15 @@
 				"minimist": "^1.2.5"
 			}
 		},
+		"good-listener": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+			"integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+			"dev": true,
+			"requires": {
+				"delegate": "^3.1.2"
+			}
+		},
 		"graceful-fs": {
 			"version": "4.2.6",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
@@ -7556,6 +13077,21 @@
 			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
 			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
 			"dev": true
+		},
+		"gradient-parser": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-0.1.5.tgz",
+			"integrity": "sha1-DH4heVWeXOfY1x9EI6+TcQCyJIw=",
+			"dev": true
+		},
+		"gridicons": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/gridicons/-/gridicons-3.3.1.tgz",
+			"integrity": "sha512-eQsmujjLptLtyhGuu31US3mXkcptYHkgEE/s277HWv+j6c3Z2gYyjoHcBKwSFbQwxbfhToRd5uzYimR2ExWJdQ==",
+			"dev": true,
+			"requires": {
+				"prop-types": "^15.5.7"
+			}
 		},
 		"growly": {
 			"version": "1.3.0",
@@ -7599,7 +13135,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1"
 			}
@@ -7607,14 +13142,12 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"has-symbols": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-			"dev": true
+			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -7697,6 +13230,20 @@
 				"minimalistic-assert": "^1.0.1"
 			}
 		},
+		"history": {
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+			"integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.1.2",
+				"loose-envify": "^1.2.0",
+				"resolve-pathname": "^3.0.0",
+				"tiny-invariant": "^1.0.2",
+				"tiny-warning": "^1.0.0",
+				"value-equal": "^1.0.1"
+			}
+		},
 		"hmac-drbg": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -7706,6 +13253,15 @@
 				"hash.js": "^1.0.3",
 				"minimalistic-assert": "^1.0.0",
 				"minimalistic-crypto-utils": "^1.0.1"
+			}
+		},
+		"hoist-non-react-statics": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+			"dev": true,
+			"requires": {
+				"react-is": "^16.7.0"
 			}
 		},
 		"homedir-polyfill": {
@@ -8046,6 +13602,16 @@
 				"side-channel": "^1.0.4"
 			}
 		},
+		"interpolate-components": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/interpolate-components/-/interpolate-components-1.1.1.tgz",
+			"integrity": "sha1-aZ//RdFSXpjHzntxWVkdmStd1t8=",
+			"requires": {
+				"react": "^0.14.3 || ^15.1.0 || ^16.0.0",
+				"react-addons-create-fragment": "^0.14.3 || ^15.1.0",
+				"react-dom": "^0.14.3 || ^15.1.0 || ^16.0.0"
+			}
+		},
 		"interpret": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
@@ -8149,7 +13715,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
 			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
-			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
 			}
@@ -8320,6 +13885,12 @@
 			"integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
 			"dev": true
 		},
+		"is-promise": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+			"dev": true
+		},
 		"is-regex": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
@@ -8339,8 +13910,7 @@
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-			"dev": true
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
 		"is-string": {
 			"version": "1.0.5",
@@ -8362,6 +13932,12 @@
 			"requires": {
 				"has-symbols": "^1.0.1"
 			}
+		},
+		"is-touch-device": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-touch-device/-/is-touch-device-1.0.1.tgz",
+			"integrity": "sha512-LAYzo9kMT1b2p19L/1ATGt2XcSilnzNlyvq6c0pbPRVisLbAPpLqr53tIJS00kvrTkj0HtR8U7+u8X0yR8lPSw==",
+			"dev": true
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
@@ -8426,6 +14002,26 @@
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"requires": {
+				"node-fetch": "^1.0.1",
+				"whatwg-fetch": ">=0.10.0"
+			},
+			"dependencies": {
+				"node-fetch": {
+					"version": "1.7.3",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+					"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+					"requires": {
+						"encoding": "^0.1.11",
+						"is-stream": "^1.0.1"
+					}
+				}
+			}
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -9944,8 +15540,7 @@
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"js-yaml": {
 			"version": "3.14.1",
@@ -10014,8 +15609,7 @@
 		"jsesc": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-			"dev": true
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
 		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
@@ -10038,8 +15632,7 @@
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
@@ -10063,7 +15656,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
 			"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-			"dev": true,
 			"requires": {
 				"minimist": "^1.2.0"
 			}
@@ -10073,6 +15665,16 @@
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
 			"integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w==",
 			"dev": true
+		},
+		"jsonfile": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.6",
+				"universalify": "^2.0.0"
+			}
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -10233,16 +15835,80 @@
 				"path-exists": "^3.0.0"
 			}
 		},
+		"locutus": {
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.11.tgz",
+			"integrity": "sha512-C0q1L38lK5q1t+wE0KY21/9szrBHxye6o2z5EJzU+5B79tubNOC+nLAEzTTn1vPUGoUuehKh8kYKqiVUTWRyaQ==",
+			"dev": true,
+			"requires": {
+				"es6-promise": "^4.2.5"
+			}
+		},
 		"lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
+		"lodash._basecallback": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
+			"integrity": "sha1-t7K7Q9whYEJKIczybFfkQ3cqjic=",
+			"dev": true,
+			"requires": {
+				"lodash._baseisequal": "^3.0.0",
+				"lodash._bindcallback": "^3.0.0",
+				"lodash.isarray": "^3.0.0",
+				"lodash.pairs": "^3.0.0"
+			}
+		},
+		"lodash._baseeach": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
+			"integrity": "sha1-z4cGVyyhROjZ11InyZDamC+TKvM=",
+			"dev": true,
+			"requires": {
+				"lodash.keys": "^3.0.0"
+			}
+		},
+		"lodash._basefind": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._basefind/-/lodash._basefind-3.0.0.tgz",
+			"integrity": "sha1-srugXMZF+XLeLPkl+iv2Og9gyK4=",
+			"dev": true
+		},
+		"lodash._basefindindex": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/lodash._basefindindex/-/lodash._basefindindex-3.6.0.tgz",
+			"integrity": "sha1-8IM2ChsCJBjtgbyJm+sxLiHnSk8=",
+			"dev": true
+		},
+		"lodash._baseisequal": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
+			"integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
+			"dev": true,
+			"requires": {
+				"lodash.isarray": "^3.0.0",
+				"lodash.istypedarray": "^3.0.0",
+				"lodash.keys": "^3.0.0"
+			}
+		},
+		"lodash._bindcallback": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+			"integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+			"dev": true
+		},
+		"lodash._getnative": {
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+			"dev": true
+		},
 		"lodash.debounce": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-			"dev": true
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
 		},
 		"lodash.differencewith": {
 			"version": "4.5.0",
@@ -10256,6 +15922,20 @@
 			"integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=",
 			"dev": true
 		},
+		"lodash.find": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-3.2.1.tgz",
+			"integrity": "sha1-BG4xnzrOkSrGySRsf2g8XsB7Nq0=",
+			"dev": true,
+			"requires": {
+				"lodash._basecallback": "^3.0.0",
+				"lodash._baseeach": "^3.0.0",
+				"lodash._basefind": "^3.0.0",
+				"lodash._basefindindex": "^3.0.0",
+				"lodash.isarray": "^3.0.0",
+				"lodash.keys": "^3.0.0"
+			}
+		},
 		"lodash.flatten": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
@@ -10268,11 +15948,49 @@
 			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
 			"dev": true
 		},
+		"lodash.isarguments": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+			"dev": true
+		},
+		"lodash.isarray": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+			"dev": true
+		},
 		"lodash.isequal": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
 			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
 			"dev": true
+		},
+		"lodash.istypedarray": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+			"integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I=",
+			"dev": true
+		},
+		"lodash.keys": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+			"dev": true,
+			"requires": {
+				"lodash._getnative": "^3.0.0",
+				"lodash.isarguments": "^3.0.0",
+				"lodash.isarray": "^3.0.0"
+			}
+		},
+		"lodash.pairs": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz",
+			"integrity": "sha1-u+CNV4bu6qCaFckevw3LfSvjJqk=",
+			"dev": true,
+			"requires": {
+				"lodash.keys": "^3.0.0"
+			}
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
@@ -10350,7 +16068,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
@@ -10368,7 +16085,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
 			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-			"dev": true,
 			"requires": {
 				"semver": "^6.0.0"
 			},
@@ -10376,8 +16092,7 @@
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},
@@ -10507,6 +16222,17 @@
 			"integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
 			"dev": true
 		},
+		"md5": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+			"dev": true,
+			"requires": {
+				"charenc": "0.0.2",
+				"crypt": "0.0.2",
+				"is-buffer": "~1.1.6"
+			}
+		},
 		"md5.js": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -10604,10 +16330,25 @@
 			"integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
 			"dev": true
 		},
+		"memfs": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-3.2.2.tgz",
+			"integrity": "sha512-RE0CwmIM3CEvpcdK3rZ19BC4E6hv9kADkMN5rPduRak58cNArWLi/9jFLsa4rhsjfVxMP3v0jO7FHXq7SvFY5Q==",
+			"dev": true,
+			"requires": {
+				"fs-monkey": "1.0.3"
+			}
+		},
 		"memize": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
 			"integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg=="
+		},
+		"memoize-one": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+			"integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==",
+			"dev": true
 		},
 		"memory-fs": {
 			"version": "0.4.1",
@@ -10881,38 +16622,34 @@
 			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
 			"dev": true
 		},
-		"mini-css-extract-plugin": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.0.tgz",
-			"integrity": "sha512-lp3GeY7ygcgAmVIcRPBVhIkf8Us7FZjA+ILpal44qLdSu11wmjKQ3d9k15lfD7pO4esu9eUIAW7qiYIBppv40A==",
+		"mini-create-react-context": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
+			"integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
 			"dev": true,
 			"requires": {
-				"loader-utils": "^1.1.0",
-				"normalize-url": "1.9.1",
-				"schema-utils": "^1.0.0",
-				"webpack-sources": "^1.1.0"
+				"@babel/runtime": "^7.12.1",
+				"tiny-warning": "^1.0.3"
+			}
+		},
+		"mini-css-extract-plugin": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.0.0.tgz",
+			"integrity": "sha512-LzJaninAMkfVAUDldZ4lUidAeS8GD0w8tSUbZLscYXWmdTOjYuEoiIhwKvwHX6+42D2cRAl35pA9DHtvAv71JQ==",
+			"dev": true,
+			"requires": {
+				"schema-utils": "^3.0.0"
 			},
 			"dependencies": {
-				"loader-utils": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-					"dev": true,
-					"requires": {
-						"big.js": "^5.2.2",
-						"emojis-list": "^3.0.0",
-						"json5": "^1.0.1"
-					}
-				},
 				"schema-utils": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+					"integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
 					"dev": true,
 					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-errors": "^1.0.0",
-						"ajv-keywords": "^3.1.0"
+						"@types/json-schema": "^7.0.6",
+						"ajv": "^6.12.5",
+						"ajv-keywords": "^3.5.2"
 					}
 				}
 			}
@@ -10941,8 +16678,7 @@
 		"minimist": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-			"dev": true
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 		},
 		"minimist-options": {
 			"version": "4.1.0",
@@ -11073,10 +16809,31 @@
 			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
 			"dev": true
 		},
+		"moment": {
+			"version": "2.29.1",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+			"integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+			"dev": true
+		},
+		"moment-timezone": {
+			"version": "0.5.33",
+			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
+			"integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
+			"dev": true,
+			"requires": {
+				"moment": ">= 2.9.0"
+			}
+		},
 		"moo": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
 			"integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==",
+			"dev": true
+		},
+		"mousetrap": {
+			"version": "1.6.5",
+			"resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
+			"integrity": "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA==",
 			"dev": true
 		},
 		"move-concurrently": {
@@ -11107,8 +16864,7 @@
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"nan": {
 			"version": "2.14.2",
@@ -11290,8 +17046,7 @@
 		"node-releases": {
 			"version": "1.1.71",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
-			"integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
-			"dev": true
+			"integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg=="
 		},
 		"normalize-package-data": {
 			"version": "2.5.0",
@@ -11484,8 +17239,7 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"dev": true
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-copy": {
 			"version": "0.1.0",
@@ -11543,8 +17297,7 @@
 		"object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-			"dev": true
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
 		},
 		"object-visit": {
 			"version": "1.0.1",
@@ -11559,7 +17312,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
 			"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",
@@ -11873,8 +17625,24 @@
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-			"dev": true
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+		},
+		"path-to-regexp": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+			"integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+			"dev": true,
+			"requires": {
+				"isarray": "0.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				}
+			}
 		},
 		"path-type": {
 			"version": "4.0.0",
@@ -12295,7 +18063,8 @@
 		"prettier": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
-			"integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ=="
+			"integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
+			"dev": true
 		},
 		"prettier-linter-helpers": {
 			"version": "1.0.0",
@@ -12368,6 +18137,14 @@
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
 		},
+		"promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"requires": {
+				"asap": "~2.0.3"
+			}
+		},
 		"promise-inflight": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -12388,7 +18165,6 @@
 			"version": "15.7.2",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
 			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
@@ -12488,8 +18264,7 @@
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"dev": true
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
 		"q": {
 			"version": "1.5.1",
@@ -12625,22 +18400,69 @@
 				}
 			}
 		},
+		"re-resizable": {
+			"version": "6.9.0",
+			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.0.tgz",
+			"integrity": "sha512-3cUDG81ylyqI0Pdgle/RHwwRYq0ORZzsUaySOCO8IbEtNyaRtrIHYm/jMQ5pjcNiKCxR3vsSymIQZHwJq4gg2Q==",
+			"dev": true,
+			"requires": {
+				"fast-memoize": "^2.5.1"
+			}
+		},
 		"react": {
 			"version": "16.14.0",
 			"resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
 			"integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2"
 			}
 		},
+		"react-addons-create-fragment": {
+			"version": "15.6.2",
+			"resolved": "https://registry.npmjs.org/react-addons-create-fragment/-/react-addons-create-fragment-15.6.2.tgz",
+			"integrity": "sha1-o5TefCx77Na1R1uhuXrEcs58dPg=",
+			"requires": {
+				"fbjs": "^0.8.4",
+				"loose-envify": "^1.3.1",
+				"object-assign": "^4.1.0"
+			}
+		},
+		"react-addons-shallow-compare": {
+			"version": "15.6.3",
+			"resolved": "https://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.3.tgz",
+			"integrity": "sha512-EDJbgKTtGRLhr3wiGDXK/+AEJ59yqGS+tKE6mue0aNXT6ZMR7VJbbzIiT6akotmHg1BLj46ElJSb+NBMp80XBg==",
+			"dev": true,
+			"requires": {
+				"object-assign": "^4.1.0"
+			}
+		},
+		"react-dates": {
+			"version": "17.2.0",
+			"resolved": "https://registry.npmjs.org/react-dates/-/react-dates-17.2.0.tgz",
+			"integrity": "sha512-RDlerU8DdRRrlYS0MQ7Z9igPWABGLDwz6+ykBNff67RM3Sset2TDqeuOr+R5o00Ggn5U47GeLsGcSDxlZd9cHw==",
+			"dev": true,
+			"requires": {
+				"airbnb-prop-types": "^2.10.0",
+				"consolidated-events": "^1.1.1 || ^2.0.0",
+				"is-touch-device": "^1.0.1",
+				"lodash": "^4.1.1",
+				"object.assign": "^4.1.0",
+				"object.values": "^1.0.4",
+				"prop-types": "^15.6.1",
+				"react-addons-shallow-compare": "^15.6.2",
+				"react-moment-proptypes": "^1.6.0",
+				"react-outside-click-handler": "^1.2.0",
+				"react-portal": "^4.1.5",
+				"react-with-styles": "^3.2.0",
+				"react-with-styles-interface-css": "^4.0.2"
+			}
+		},
 		"react-dom": {
 			"version": "16.14.0",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
 			"integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -12651,8 +18473,102 @@
 		"react-is": {
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+		},
+		"react-merge-refs": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz",
+			"integrity": "sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==",
 			"dev": true
+		},
+		"react-moment-proptypes": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/react-moment-proptypes/-/react-moment-proptypes-1.8.1.tgz",
+			"integrity": "sha512-Er940DxWoObfIqPrZNfwXKugjxMIuk1LAuEzn23gytzV6hKS/sw108wibi9QubfMN4h+nrlje8eUCSbQRJo2fQ==",
+			"dev": true,
+			"requires": {
+				"moment": ">=1.6.0"
+			}
+		},
+		"react-native-url-polyfill": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-1.3.0.tgz",
+			"integrity": "sha512-w9JfSkvpqqlix9UjDvJjm1EjSt652zVQ6iwCIj1cVVkwXf4jQhQgTNXY6EVTwuAmUjg6BC6k9RHCBynoLFo3IQ==",
+			"dev": true,
+			"requires": {
+				"whatwg-url-without-unicode": "8.0.0-3"
+			}
+		},
+		"react-outside-click-handler": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.3.0.tgz",
+			"integrity": "sha512-Te/7zFU0oHpAnctl//pP3hEAeobfeHMyygHB8MnjP6sX5OR8KHT1G3jmLsV3U9RnIYo+Yn+peJYWu+D5tUS8qQ==",
+			"dev": true,
+			"requires": {
+				"airbnb-prop-types": "^2.15.0",
+				"consolidated-events": "^1.1.1 || ^2.0.0",
+				"document.contains": "^1.0.1",
+				"object.values": "^1.1.0",
+				"prop-types": "^15.7.2"
+			}
+		},
+		"react-portal": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.2.1.tgz",
+			"integrity": "sha512-fE9kOBagwmTXZ3YGRYb4gcMy+kSA+yLO0xnPankjRlfBv4uCpFXqKPfkpsGQQR15wkZ9EssnvTOl1yMzbkxhPQ==",
+			"dev": true,
+			"requires": {
+				"prop-types": "^15.5.8"
+			}
+		},
+		"react-resize-aware": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/react-resize-aware/-/react-resize-aware-3.1.0.tgz",
+			"integrity": "sha512-bIhHlxVTX7xKUz14ksXMEHjzCZPTpQZKZISY3nbTD273pDKPABGFNFBP6Tr42KECxzC5YQiKpMchjTVJCqaxpA==",
+			"dev": true
+		},
+		"react-router": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+			"integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.1.2",
+				"history": "^4.9.0",
+				"hoist-non-react-statics": "^3.1.0",
+				"loose-envify": "^1.3.1",
+				"mini-create-react-context": "^0.4.0",
+				"path-to-regexp": "^1.7.0",
+				"prop-types": "^15.6.2",
+				"react-is": "^16.6.0",
+				"tiny-invariant": "^1.0.2",
+				"tiny-warning": "^1.0.0"
+			}
+		},
+		"react-router-dom": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+			"integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.1.2",
+				"history": "^4.9.0",
+				"loose-envify": "^1.3.1",
+				"prop-types": "^15.6.2",
+				"react-router": "5.2.0",
+				"tiny-invariant": "^1.0.2",
+				"tiny-warning": "^1.0.0"
+			}
+		},
+		"react-spring": {
+			"version": "8.0.27",
+			"resolved": "https://registry.npmjs.org/react-spring/-/react-spring-8.0.27.tgz",
+			"integrity": "sha512-nDpWBe3ZVezukNRandTeLSPcwwTMjNVu1IDq9qA/AMiUqHuRN4BeSWvKr3eIxxg1vtiYiOLy4FqdfCP5IoP77g==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.3.1",
+				"prop-types": "^15.5.8"
+			}
 		},
 		"react-test-renderer": {
 			"version": "16.14.0",
@@ -12664,6 +18580,79 @@
 				"prop-types": "^15.6.2",
 				"react-is": "^16.8.6",
 				"scheduler": "^0.19.1"
+			}
+		},
+		"react-transition-group": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+			"integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.5.5",
+				"dom-helpers": "^5.0.1",
+				"loose-envify": "^1.4.0",
+				"prop-types": "^15.6.2"
+			}
+		},
+		"react-use-gesture": {
+			"version": "7.0.16",
+			"resolved": "https://registry.npmjs.org/react-use-gesture/-/react-use-gesture-7.0.16.tgz",
+			"integrity": "sha512-gwgX+E+WQG0T1uFVl3z8j3ZwH3QQGIgVl7VtQEC2m0IscSs668sSps4Ss3CFp3Vns8xx0j9TVK4aBXH6+YrpEg==",
+			"dev": true
+		},
+		"react-visibility-sensor": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/react-visibility-sensor/-/react-visibility-sensor-5.1.1.tgz",
+			"integrity": "sha512-cTUHqIK+zDYpeK19rzW6zF9YfT4486TIgizZW53wEZ+/GPBbK7cNS0EHyJVyHYacwFEvvHLEKfgJndbemWhB/w==",
+			"dev": true,
+			"requires": {
+				"prop-types": "^15.7.2"
+			}
+		},
+		"react-with-direction": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/react-with-direction/-/react-with-direction-1.3.1.tgz",
+			"integrity": "sha512-aGcM21ZzhqeXFvDCfPj0rVNYuaVXfTz5D3Rbn0QMz/unZe+CCiLHthrjQWO7s6qdfXORgYFtmS7OVsRgSk5LXQ==",
+			"dev": true,
+			"requires": {
+				"airbnb-prop-types": "^2.10.0",
+				"brcast": "^2.0.2",
+				"deepmerge": "^1.5.2",
+				"direction": "^1.0.2",
+				"hoist-non-react-statics": "^3.3.0",
+				"object.assign": "^4.1.0",
+				"object.values": "^1.0.4",
+				"prop-types": "^15.6.2"
+			},
+			"dependencies": {
+				"deepmerge": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.2.tgz",
+					"integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ==",
+					"dev": true
+				}
+			}
+		},
+		"react-with-styles": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/react-with-styles/-/react-with-styles-3.2.3.tgz",
+			"integrity": "sha512-MTI1UOvMHABRLj5M4WpODfwnveHaip6X7QUMI2x6zovinJiBXxzhA9AJP7MZNaKqg1JRFtHPXZdroUC8KcXwlQ==",
+			"dev": true,
+			"requires": {
+				"hoist-non-react-statics": "^3.2.1",
+				"object.assign": "^4.1.0",
+				"prop-types": "^15.6.2",
+				"react-with-direction": "^1.3.0"
+			}
+		},
+		"react-with-styles-interface-css": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/react-with-styles-interface-css/-/react-with-styles-interface-css-4.0.3.tgz",
+			"integrity": "sha512-wE43PIyjal2dexxyyx4Lhbcb+E42amoYPnkunRZkb9WTA+Z+9LagbyxwsI352NqMdFmghR0opg29dzDO4/YXbw==",
+			"dev": true,
+			"requires": {
+				"array.prototype.flat": "^1.2.1",
+				"global-cache": "^1.2.1"
 			}
 		},
 		"read-pkg": {
@@ -12718,6 +18707,43 @@
 				"picomatch": "^2.2.1"
 			}
 		},
+		"reakit": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.3.8.tgz",
+			"integrity": "sha512-8SVejx6FUaFi2+Q9eXoDAd4wWi/xAn6v8JgXH8x2xnzye8pb6v5bYvegACVpYVZnrS5w/JUgMTGh1Xy8MkkPww==",
+			"dev": true,
+			"requires": {
+				"@popperjs/core": "^2.5.4",
+				"body-scroll-lock": "^3.1.5",
+				"reakit-system": "^0.15.1",
+				"reakit-utils": "^0.15.1",
+				"reakit-warning": "^0.6.1"
+			}
+		},
+		"reakit-system": {
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.1.tgz",
+			"integrity": "sha512-PkqfAyEohtcEu/gUvKriCv42NywDtUgvocEN3147BI45dOFAB89nrT7wRIbIcKJiUT598F+JlPXAZZVLWhc1Kg==",
+			"dev": true,
+			"requires": {
+				"reakit-utils": "^0.15.1"
+			}
+		},
+		"reakit-utils": {
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.1.tgz",
+			"integrity": "sha512-6cZgKGvOkAMQgkwU9jdYbHfkuIN1Pr+vwcB19plLvcTfVN0Or10JhIuj9X+JaPZyI7ydqTDFaKNdUcDP69o/+Q==",
+			"dev": true
+		},
+		"reakit-warning": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.6.1.tgz",
+			"integrity": "sha512-poFUV0EyxB+CcV9uTNBAFmcgsnR2DzAbOTkld4Ul+QOKSeEHZB3b3+MoZQgcYHmbvG19Na1uWaM7ES+/Eyr8tQ==",
+			"dev": true,
+			"requires": {
+				"reakit-utils": "^0.15.1"
+			}
+		},
 		"redent": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -12726,6 +18752,15 @@
 			"requires": {
 				"indent-string": "^4.0.0",
 				"strip-indent": "^3.0.0"
+			}
+		},
+		"redux": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-4.1.0.tgz",
+			"integrity": "sha512-uI2dQN43zqLWCt6B/BMGRMY6db7TTY4qeHHfGeKb3EOhmOKjU3KdWvNLJyqaHRksv/ErdNH7cFZWg9jXtewy4g==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.9.2"
 			}
 		},
 		"reflect.ownkeys": {
@@ -12737,14 +18772,12 @@
 		"regenerate": {
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
-			"integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
-			"dev": true
+			"integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A=="
 		},
 		"regenerate-unicode-properties": {
 			"version": "8.2.0",
 			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
 			"integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
-			"dev": true,
 			"requires": {
 				"regenerate": "^1.4.0"
 			}
@@ -12758,7 +18791,6 @@
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
 			"integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.8.4"
 			}
@@ -12793,7 +18825,6 @@
 			"version": "4.7.1",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.1.tgz",
 			"integrity": "sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==",
-			"dev": true,
 			"requires": {
 				"regenerate": "^1.4.0",
 				"regenerate-unicode-properties": "^8.2.0",
@@ -12812,14 +18843,12 @@
 		"regjsgen": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
-			"integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==",
-			"dev": true
+			"integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A=="
 		},
 		"regjsparser": {
 			"version": "0.6.7",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.7.tgz",
 			"integrity": "sha512-ib77G0uxsA2ovgiYbCVGx4Pv3PSttAx2vIwidqQzbL2U5S4Q+j00HdSAneSBuyVcMvEnTXMjiGgB+DlXozVhpQ==",
-			"dev": true,
 			"requires": {
 				"jsesc": "~0.5.0"
 			},
@@ -12827,8 +18856,7 @@
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-					"dev": true
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
 				}
 			}
 		},
@@ -12942,6 +18970,12 @@
 			"requires": {
 				"mdast-util-to-markdown": "^0.6.0"
 			}
+		},
+		"rememo": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+			"integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ==",
+			"dev": true
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
@@ -13073,7 +19107,6 @@
 			"version": "1.20.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
 			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-			"dev": true,
 			"requires": {
 				"is-core-module": "^2.2.0",
 				"path-parse": "^1.0.6"
@@ -13119,6 +19152,12 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+			"dev": true
+		},
+		"resolve-pathname": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+			"integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
 			"dev": true
 		},
 		"resolve-url": {
@@ -13191,6 +19230,12 @@
 			"requires": {
 				"aproba": "^1.1.1"
 			}
+		},
+		"rungen": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/rungen/-/rungen-0.3.2.tgz",
+			"integrity": "sha1-QAwJ6+kU57F+C27zJjQA/Cq8fLM=",
+			"dev": true
 		},
 		"rx": {
 			"version": "4.1.0",
@@ -13444,7 +19489,6 @@
 			"version": "0.19.1",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
 			"integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -13454,12 +19498,17 @@
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
 			"integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
-			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.5",
 				"ajv": "^6.12.4",
 				"ajv-keywords": "^3.5.2"
 			}
+		},
+		"select": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+			"integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+			"dev": true
 		},
 		"semver": {
 			"version": "5.7.1",
@@ -13508,8 +19557,7 @@
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"dev": true
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"sha.js": {
 			"version": "2.4.11",
@@ -14603,7 +20651,6 @@
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
@@ -14920,6 +20967,18 @@
 				"setimmediate": "^1.0.4"
 			}
 		},
+		"tiny-emitter": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+			"dev": true
+		},
+		"tiny-invariant": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+			"integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==",
+			"dev": true
+		},
 		"tiny-lr": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
@@ -14945,6 +21004,18 @@
 				}
 			}
 		},
+		"tiny-warning": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+			"integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
+			"dev": true
+		},
+		"tinycolor2": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
+			"integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==",
+			"dev": true
+		},
 		"tmpl": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -14960,8 +21031,7 @@
 		"to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-			"dev": true
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
 		},
 		"to-object-path": {
 			"version": "0.3.0",
@@ -15102,6 +21172,12 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
+		"turbo-combine-reducers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/turbo-combine-reducers/-/turbo-combine-reducers-1.0.2.tgz",
+			"integrity": "sha512-gHbdMZlA6Ym6Ur5pSH/UWrNQMIM9IqTH6SoL1DbHpqEdQ8i+cFunSmSlFykPt0eGQwZ4d/XTHOl74H0/kFBVWw==",
+			"dev": true
+		},
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -15144,6 +21220,17 @@
 				"is-typedarray": "^1.0.0"
 			}
 		},
+		"typescript": {
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+			"integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+			"dev": true
+		},
+		"ua-parser-js": {
+			"version": "0.7.28",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
+			"integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
+		},
 		"uc.micro": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -15173,14 +21260,12 @@
 		"unicode-canonical-property-names-ecmascript": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
-			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
-			"dev": true
+			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
 		},
 		"unicode-match-property-ecmascript": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
 			"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
-			"dev": true,
 			"requires": {
 				"unicode-canonical-property-names-ecmascript": "^1.0.4",
 				"unicode-property-aliases-ecmascript": "^1.0.4"
@@ -15189,14 +21274,12 @@
 		"unicode-match-property-value-ecmascript": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
-			"integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ==",
-			"dev": true
+			"integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ=="
 		},
 		"unicode-property-aliases-ecmascript": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
-			"integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==",
-			"dev": true
+			"integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg=="
 		},
 		"unified": {
 			"version": "6.2.0",
@@ -15304,6 +21387,12 @@
 				"unist-util-is": "^3.0.0"
 			}
 		},
+		"universalify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+			"dev": true
+		},
 		"unquote": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
@@ -15361,7 +21450,6 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -15418,6 +21506,12 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+			"dev": true
+		},
+		"use-memo-one": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
+			"integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==",
 			"dev": true
 		},
 		"util": {
@@ -15517,6 +21611,12 @@
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
 			}
+		},
+		"value-equal": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+			"integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
+			"dev": true
 		},
 		"verror": {
 			"version": "1.10.0",
@@ -15895,6 +21995,15 @@
 						"repeat-string": "^1.6.1"
 					}
 				}
+			}
+		},
+		"wcwidth": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+			"dev": true,
+			"requires": {
+				"defaults": "^1.0.3"
 			}
 		},
 		"webidl-conversions": {
@@ -16643,6 +22752,11 @@
 				"iconv-lite": "0.4.24"
 			}
 		},
+		"whatwg-fetch": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+			"integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
+		},
 		"whatwg-mimetype": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
@@ -16658,6 +22772,25 @@
 				"lodash.sortby": "^4.7.0",
 				"tr46": "^2.0.2",
 				"webidl-conversions": "^6.1.0"
+			}
+		},
+		"whatwg-url-without-unicode": {
+			"version": "8.0.0-3",
+			"resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz",
+			"integrity": "sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==",
+			"dev": true,
+			"requires": {
+				"buffer": "^5.4.3",
+				"punycode": "^2.1.1",
+				"webidl-conversions": "^5.0.0"
+			},
+			"dependencies": {
+				"webidl-conversions": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+					"integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+					"dev": true
+				}
 			}
 		},
 		"which": {
@@ -16680,6 +22813,41 @@
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
 			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
 			"dev": true
+		},
+		"wordpress-element": {
+			"version": "npm:@wordpress/element@2.11.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
+			"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.8.3",
+				"@wordpress/escape-html": "^1.7.0",
+				"lodash": "^4.17.15",
+				"react": "^16.9.0",
+				"react-dom": "^16.9.0"
+			},
+			"dependencies": {
+				"@wordpress/escape-html": {
+					"version": "1.12.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.12.2.tgz",
+					"integrity": "sha512-FabgSwznhdaUwe6hr1CsGpgxQbzqEoGevv73WIL1B9GvlZ6csRWodgHfWh4P6fYqpzxFL4WYB8wPJ1PdO32XFA==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					},
+					"dependencies": {
+						"@babel/runtime": {
+							"version": "7.14.6",
+							"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+							"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+							"dev": true,
+							"requires": {
+								"regenerator-runtime": "^0.13.4"
+							}
+						}
+					}
+				}
+			}
 		},
 		"worker-farm": {
 			"version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -20,13 +20,25 @@
 		"test:unit": "wp-scripts test-unit-js"
 	},
 	"devDependencies": {
+		"@babel/cli": "^7.14.5",
+		"@babel/core": "^7.14.6",
+		"@babel/preset-typescript": "^7.14.5",
+		"@typescript-eslint/eslint-plugin": "^4.28.1",
+		"@woocommerce/components": "^7.0.0",
 		"@woocommerce/dependency-extraction-webpack-plugin": "1.4.0",
 		"@woocommerce/eslint-plugin": "1.1.0",
 		"@wordpress/scripts": "^13.0.3",
-		"prettier": "^2.3.2"
+		"fork-ts-checker-webpack-plugin": "^6.2.12",
+		"mini-css-extract-plugin": "^2.0.0",
+		"prettier": "^2.3.2",
+		"typescript": "^4.3.5",
+		"wordpress-element": "npm:@wordpress/element@2.11.0"
 	},
 	"dependencies": {
+		"@wordpress/babel-preset-default": "^6.2.0",
 		"@wordpress/hooks": "^2.12.3",
-		"@wordpress/i18n": "^4.1.1"
+		"@wordpress/i18n": "^4.1.1",
+		"babel-loader": "^8.2.2",
+		"interpolate-components": "^1.1.1"
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    "compilerOptions": {
+        "outDir": "./build/",
+        // Target latest version of ECMAScript.
+        "target": "esnext",
+        // Search under node_modules for non-relative imports.
+        "moduleResolution": "node",
+        // Process & infer types from .js files.
+        "allowJs": true,
+        "jsx": "preserve",
+        // Don't emit; allow Babel to transform files.
+        "noEmit": true,
+        // Enable strictest settings like strictNullChecks & noImplicitAny.
+        "strict": true,
+        // Import non-ES modules as default imports.
+        "esModuleInterop": true,
+        "skipLibCheck": false,
+        "module": "esnext",
+        "typeRoots": [
+            "./typings",
+            "./node_modules/@types",
+            "packages/**/node_modules/@types"
+        ],
+        "baseUrl": "./",
+        "paths": {
+            "~/*": [
+                "src/*"
+            ]
+        }
+    },
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 const WooCommerceDependencyExtractionWebpackPlugin = require( '@woocommerce/dependency-extraction-webpack-plugin' );
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 module.exports = {
 	...defaultConfig,
@@ -9,5 +10,20 @@ module.exports = {
 				plugin.constructor.name !== 'DependencyExtractionWebpackPlugin'
 		),
 		new WooCommerceDependencyExtractionWebpackPlugin(),
+		new ForkTsCheckerWebpackPlugin(),
 	],
+	module: {
+		...defaultConfig.module,
+		rules: [
+			...defaultConfig.module.rules,
+			{
+				test: /\.tsx?$/,
+				use: 'babel-loader',
+				exclude: /node_modules/,
+			},
+		],
+	},
+	resolve: {
+		extensions: ['.json', '.js', '.jsx', '.ts', '.tsx'],
+	},
 };


### PR DESCRIPTION
Adds TypeScript support, using a similar setup to WooCommerce Admin.

### Testing Instructions.

- Run `npm start`
- Change an existing `.js` file to `.tsx`, for example `src/payments-welcome/index.tsx`
- See that it builds ok
- Make an intentional type error, for example `const PaymentsWelcomePage = () : number => (`
- See that a build error occurs.