### PR TITLE
Install WCPay and redirect merchant KYC flow

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -157,7 +157,8 @@ class WC_Calypso_Bridge {
 		wp_add_inline_script( 'wc-calypso-bridge', 'window.wcCalypsoBridge = ' . wp_json_encode(
 			array(
 				'isWooPage' => $is_woo_page,
-				'homeUrl'   => get_home_url()
+				'homeUrl'   => get_home_url(),
+				'wcpayConnectUrl' => 'admin.php?page=wc-admin&path=%2Fpayments%2Fconnect&wcpay-connect=1&_wpnonce=' . wp_create_nonce( 'wcpay-connect' )
 			)
 		), 'before' );
 	

--- a/src/payments-welcome/index.js
+++ b/src/payments-welcome/index.js
@@ -89,7 +89,7 @@ const ConnectPageOnboarding = ({
 		setSubmitted(true);
 		wcpayTracks.recordEvent(wcpayTracks.events.CONNECT_ACCOUNT_CLICKED, {
 			// eslint-disable-next-line camelcase
-			wpcom_connection: isJetpackConnected,
+			wpcom_connection: isJetpackConnected ? 'Yes' : 'No',
 		});
 
 		const installAndActivateResponse = await installAndActivatePlugins(['woocommerce-payments']);

--- a/src/payments-welcome/index.js
+++ b/src/payments-welcome/index.js
@@ -94,10 +94,9 @@ const ConnectPageOnboarding = ({
 
 		const installAndActivateResponse = await installAndActivatePlugins(['woocommerce-payments']);
 		if (installAndActivateResponse?.success) {
-			// Redirect to KYC
+			// Redirect to KYC.
 			window.location = connectUrl;
 		} else {
-			// Display error
 			setErrorMessage(installAndActivateResponse.message);
 			setSubmitted(false);
 		}

--- a/src/payments-welcome/index.js
+++ b/src/payments-welcome/index.js
@@ -3,7 +3,7 @@
  */
 import { Card } from '@woocommerce/components';
 import { Button, Notice } from '@wordpress/components';
-import { useState, useEffect } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -23,10 +23,6 @@ import UnionPay from './cards/unionpay.js';
 import './style.scss';
 import FrequentlyAskedQuestions from './faq';
 import wcpayTracks from './tracks';
-
-const wcpaySettings = {
-	connectUrl: wcCalypsoBridge.wcpayConnectUrl,
-};
 
 const LearnMore = () => {
 	const handleClick = () => {
@@ -65,42 +61,45 @@ const TermsOfService = () => (
 	</span>
 );
 
-const ConnectPageError = ( { errorMessage } ) => {
-	if ( ! errorMessage ) {
+const ConnectPageError = ({ errorMessage }) => {
+	if (!errorMessage) {
 		return null;
 	}
 	return (
 		<Notice
 			className="wcpay-connect-error-notice"
 			status="error"
-			isDismissible={ false }
+			isDismissible={false}
 		>
-			{ errorMessage }
+			{errorMessage}
 		</Notice>
 	);
 };
 
-const ConnectPageOnboarding = ( { setErrorMessage } ) => {
+const ConnectPageOnboarding = ({
+	isJetpackConnected,
+	installAndActivatePlugins,
+	setErrorMessage,
+	connectUrl,
+}) => {
 	const [isSubmitted, setSubmitted] = useState(false);
 	const [isNoThanksClicked, setNoThanksClicked] = useState(false);
-	const { connectUrl } = wcpaySettings;
 
 	const handleSetup = async () => {
 		setSubmitted(true);
 		wcpayTracks.recordEvent(wcpayTracks.events.CONNECT_ACCOUNT_CLICKED, {
-			// Since we're in WPCOM where users can't disconnect Jetpack, this can be safely hardcoded.
 			// eslint-disable-next-line camelcase
-			wpcom_connection: 'Yes',
+			wpcom_connection: isJetpackConnected,
 		});
 
-		const installAndActivateResponse = await wp.data.dispatch('wc/admin/plugins').installAndActivatePlugins( [ 'woocommerce-payments' ] );
-		if ( installAndActivateResponse?.success ) {
+		const installAndActivateResponse = await installAndActivatePlugins(['woocommerce-payments']);
+		if (installAndActivateResponse?.success) {
 			// Redirect to KYC
 			window.location = connectUrl;
 		} else {
 			// Display error
-			setErrorMessage( installAndActivateResponse.message );
-			setSubmitted( false );
+			setErrorMessage(installAndActivateResponse.message);
+			setSubmitted(false);
 		}
 	};
 
@@ -144,22 +143,25 @@ const ConnectPageOnboarding = ( { setErrorMessage } ) => {
 };
 
 const ConnectAccountPage = () => {
-	useEffect(() => {
-		wcpayTracks.recordEvent(wcpayTracks.events.CONNECT_ACCOUNT_VIEW, {
-			path: 'payments_connect_v2',
-		});
-	}, []);
-
-	const [ errorMessage, setErrorMessage ] = useState('');
+	const [errorMessage, setErrorMessage] = useState('');
+	const onboardingProps = {
+		isJetpackConnected: wp.data
+			.select('wc/admin/plugins')
+			.isJetpackConnected(),
+		installAndActivatePlugins:
+			wp.data.dispatch('wc/admin/plugins').installAndActivatePlugins,
+		setErrorMessage,
+		connectUrl: wcCalypsoBridge.wcpayConnectUrl,
+	};
 
 	return (
 		<div className="connect-account-page">
 			<div className="woocommerce-payments-page is-narrow connect-account">
-			<ConnectPageError errorMessage={ errorMessage }/>
+				<ConnectPageError errorMessage={errorMessage} />
 				<Card className="connect-account__card">
 					<Banner style="account-page" />
 					<div className="content">
-						<ConnectPageOnboarding setErrorMessage={ setErrorMessage }/>
+						<ConnectPageOnboarding {...onboardingProps} />
 					</div>
 				</Card>
 				<Card className="faq__card">


### PR DESCRIPTION
This PR adds the following:
- Install and activate WCPay plugin when click on "Get started"
- Redirect to KYC after successful activation
- Remove redundant pageview track `CONNECT_ACCOUNT_VIEW` (wcadmin already tracks `wcadmin_page_view`)
- Adds local state for displaying errors
- Change `ConnectPageOnboarding` to use props for better testability

What it doesn't do:
- Detect if WCPay plugin is already installed (I think this is better handled at disabling menu instead)

Todo in a follow-up:
- Potentially add a prop to a track to differentiate between this project's connect and WCPay original connect. Ongoing discussion [here](https://github.com/Automattic/wc-calypso-bridge/issues/690#issuecomment-874401258).

### Testing instructions
- Make sure WCPay is not installed.
- Go to the new welcome page, click on "Get started".
- Observe the loading animation and wait until it finishes, it should automatically redirect to KYC.
- Don't need to complete KYC, instead look at the plugins page and notice that WooCommerce Payments plugin is installed & activated.