### PR TITLE
Conditionally load the WC Pay menu

### DIFF
--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -171,17 +171,17 @@ class WC_Calypso_Bridge_Setup {
 			return;
 		}
 
-		// WC Payment must not be installed.
-		if ( array_key_exists( 'woocommerce-payments/woocommerce-payments.php', get_plugins() ) ) {
+		// WC Payment must not be active.
+		if ( is_plugin_active( 'woocommerce-payments/woocommerce-payments.php' ) ) {
 			return;
 		}
 
-		// User country must be US.
+		// Store country must be the US.
 		if ( 'US' !== WC()->countries->get_base_country() ) {
 			return;
 		}
 
-		if ( 'yes' === get_option( 'wc_calypso_brdige_wcpay_welcome_page_opt_out', 'no' ) ) {
+		if ( 'yes' === get_option( 'wc_calypso_bridge_payments_dismissed', 'no' ) ) {
 			return;
 		}
 

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -166,6 +166,25 @@ class WC_Calypso_Bridge_Setup {
 	public function register_payments_welcome_page() {
 		global $menu;
 
+		// WooCommerce must be active.
+		if ( !is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
+			return;
+		}
+
+		// WC Payment must not be installed.
+		if ( array_key_exists( 'woocommerce-payments/woocommerce-payments.php', get_plugins() ) ) {
+			return;
+		}
+
+		// User country must be US.
+		if ( 'US' !== WC()->countries->get_base_country() ) {
+			return;
+		}
+
+		if ( 'yes' === get_option( 'wc_calypso_brdige_wcpay_welcome_page_opt_out', 'no' ) ) {
+			return;
+		}
+
 		wc_admin_register_page( array(
 			'id'       => 'wc-calypso-bridge-payments-welcome-page',
 			'title'    => __( 'Payments', 'wc-calypso-bridge' ),


### PR DESCRIPTION
This PR conditionally loads the WC Pay menu

- WooCommerce must be active.
- WC Payments plugin must not be installed.
- User country must be the US.
- Use has not opted out of the welcome page.

### Tesing instructions 

1. Deactivate WooCommerce and confirm that the menu doesn't render.
2. Activate WooCommerce again and install WC Payments. The menu should not be rendered. Completely delete WC Payments plugin.
3. Change store address to non-US and confirm the menu doesn't render.
4. Manually add `wc_calypso_brdige_wcpay_welcome_page_opt_out` in `wp_options` table with `yes` value. The menu should not be rendered.