### PR TITLE
Add Payments Welcome Page Exit Survey

### DIFF
--- a/src/payments-welcome/exit-survey-modal.tsx
+++ b/src/payments-welcome/exit-survey-modal.tsx
@@ -1,0 +1,113 @@
+/**
+ * External dependencies
+ */
+import { useState } from '@wordpress/element';
+import {
+	Button,
+	Modal,
+	CheckboxControl,
+	TextareaControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import strings from './strings';
+import wcpayTracks from './tracks';
+
+/**
+ * Provides a modal requesting customer feedback.
+ *
+ */
+function ExitSurveyModal(): JSX.Element | null {
+	const [ isOpen, setOpen ] = useState( true );
+	const [ isHappyChecked, setHappyChecked ] = useState(false);
+	const [ isInstallChecked, setInstallChecked ] = useState(false);
+	const [ isMoreInfoChecked, setMoreInfoChecked ] = useState(false);
+	const [ isAnotherTimeChecked, setAnotherTimeChecked ] = useState(false);
+	const [ isSomethingElseChecked, setSomethingElseChecked ] = useState(false);
+	const [ comments, setComments ] = useState( '' );
+	
+	const closeModal = () => setOpen( false );
+
+	const sendFeedback = () => {
+		wcpayTracks.recordEvent(wcpayTracks.events.SURVEY_FEEDBACK, {
+			happy: isHappyChecked ? 'Yes' : 'No',
+			install: isInstallChecked ? 'Yes' : 'No',
+			moreInfo: isMoreInfoChecked ? 'Yes' : 'No',
+			anotherTime: isAnotherTimeChecked ? 'Yes' : 'No',
+			somethingElse: isSomethingElseChecked ? 'Yes' : 'No',
+			comments: comments,
+		});
+		setOpen( false );
+	};
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			className="wc-calypso-bridge-payments-welcome-survey"
+			title={ __( 'Remove WooCommerce Payments', 'wc-calypso-bridge' ) }
+			onRequestClose={ closeModal }
+			shouldCloseOnClickOutside={ false }
+		>
+			<p className="wc-calypso-bridge-payments-welcome-survey__intro">{strings.surveyIntro}</p>
+
+			<p className="wc-calypso-bridge-payments-welcome-survey__question" >{strings.surveyQuestion}</p>
+			
+			<div className="wc-calypso-bridge-payments-welcome-survey__selection">
+				<CheckboxControl
+					label={ __('I’m already happy with my payments setup') }
+					checked={ isHappyChecked }
+					onChange={ setHappyChecked }
+				/>
+				<CheckboxControl
+					label={ __('I don’t want to install another plugin') }
+					checked={ isInstallChecked }
+					onChange={ setInstallChecked }
+				/>
+				<CheckboxControl
+					label={ __('I need more information about WooCommerce Payments') }
+					checked={ isMoreInfoChecked }
+					onChange={ setMoreInfoChecked }
+				/>
+				<CheckboxControl
+					label={ __('I’m open to installing it another time') }
+					checked={ isAnotherTimeChecked }
+					onChange={ setAnotherTimeChecked }
+				/>
+				<CheckboxControl
+					label={ __('It’s something else (Please share below)') }
+					checked={ isSomethingElseChecked }
+					onChange={ setSomethingElseChecked }
+				/>
+			</div>
+
+			<div className="wc-calypso-bridge-payments-welcome-survey__comments">
+				<TextareaControl
+					label={ __(
+						'Comments (Optional)',
+						'woocommerce-admin'
+					) }
+					value={ comments }
+					onChange={ ( value: string ) => setComments( value ) }
+					rows={ 3 }
+				/>
+			</div>
+
+			<div className="wc-calypso-bridge-payments-welcome-survey__buttons">
+				<Button isTertiary isDestructive onClick={ closeModal } name="cancel">
+					{ __( 'Just remove WooCommerce Payments', 'wc-calypso-bridge' ) }
+				</Button>
+				<Button isSecondary onClick={ sendFeedback } name="send">
+					{ __( 'Remove and send feedback', 'wc-calypso-bridge' ) }
+				</Button>
+			</div>
+		</Modal>
+	);
+}
+
+export default ExitSurveyModal;

--- a/src/payments-welcome/exit-survey-modal.tsx
+++ b/src/payments-welcome/exit-survey-modal.tsx
@@ -8,7 +8,6 @@ import {
 	CheckboxControl,
 	TextareaControl,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -50,7 +49,7 @@ function ExitSurveyModal(): JSX.Element | null {
 	return (
 		<Modal
 			className="wc-calypso-bridge-payments-welcome-survey"
-			title={ __( 'Remove WooCommerce Payments', 'wc-calypso-bridge' ) }
+			title={ strings.surveyTitle }
 			onRequestClose={ closeModal }
 			shouldCloseOnClickOutside={ false }
 		>
@@ -60,27 +59,27 @@ function ExitSurveyModal(): JSX.Element | null {
 			
 			<div className="wc-calypso-bridge-payments-welcome-survey__selection">
 				<CheckboxControl
-					label={ __('I’m already happy with my payments setup') }
+					label={ strings.surveyHappyLabel }
 					checked={ isHappyChecked }
 					onChange={ setHappyChecked }
 				/>
 				<CheckboxControl
-					label={ __('I don’t want to install another plugin') }
+					label={ strings.surveyInstallLabel }
 					checked={ isInstallChecked }
 					onChange={ setInstallChecked }
 				/>
 				<CheckboxControl
-					label={ __('I need more information about WooCommerce Payments') }
+					label={ strings.surveyMoreInfoLabel }
 					checked={ isMoreInfoChecked }
 					onChange={ setMoreInfoChecked }
 				/>
 				<CheckboxControl
-					label={ __('I’m open to installing it another time') }
+					label={ strings.surveyAnotherTimeLabel }
 					checked={ isAnotherTimeChecked }
 					onChange={ setAnotherTimeChecked }
 				/>
 				<CheckboxControl
-					label={ __('It’s something else (Please share below)') }
+					label={ strings.surveySomethingElseLabel }
 					checked={ isSomethingElseChecked }
 					onChange={ setSomethingElseChecked }
 				/>
@@ -88,10 +87,7 @@ function ExitSurveyModal(): JSX.Element | null {
 
 			<div className="wc-calypso-bridge-payments-welcome-survey__comments">
 				<TextareaControl
-					label={ __(
-						'Comments (Optional)',
-						'woocommerce-admin'
-					) }
+					label={ strings.surveyCommentsLabel }
 					value={ comments }
 					onChange={ ( value: string ) => setComments( value ) }
 					rows={ 3 }
@@ -100,10 +96,10 @@ function ExitSurveyModal(): JSX.Element | null {
 
 			<div className="wc-calypso-bridge-payments-welcome-survey__buttons">
 				<Button isTertiary isDestructive onClick={ closeModal } name="cancel">
-					{ __( 'Just remove WooCommerce Payments', 'wc-calypso-bridge' ) }
+					{ strings.surveyCancelButton }
 				</Button>
 				<Button isSecondary onClick={ sendFeedback } name="send">
-					{ __( 'Remove and send feedback', 'wc-calypso-bridge' ) }
+					{ strings.surveySubmitButton }
 				</Button>
 			</div>
 		</Modal>

--- a/src/payments-welcome/index.tsx
+++ b/src/payments-welcome/index.tsx
@@ -3,7 +3,7 @@
  */
 // @ts-ignore
 import { Card } from '@woocommerce/components';
-import { Button, Notice } from '@wordpress/components';
+import { Button, Modal, Notice } from '@wordpress/components';
 // @ts-ignore
 import { useState } from 'wordpress-element';
 
@@ -25,6 +25,7 @@ import UnionPay from './cards/unionpay';
 import './style.scss';
 import FrequentlyAskedQuestions from './faq';
 import wcpayTracks from './tracks';
+import ExitSurveyModal from './exit-survey-modal';
 
 declare global {
 	interface Window { 
@@ -102,6 +103,8 @@ const ConnectPageOnboarding = ({
 	const [isSubmitted, setSubmitted] = useState(false);
 	const [isNoThanksClicked, setNoThanksClicked] = useState(false);
 
+	const [ isExitSurveyModalOpen, setExitSurveyModalOpen ] = useState( false );
+
 	const handleSetup = async () => {
 		setSubmitted(true);
 		wcpayTracks.recordEvent(wcpayTracks.events.CONNECT_ACCOUNT_CLICKED, {
@@ -123,6 +126,7 @@ const ConnectPageOnboarding = ({
 
 	const handleNoThanks = () => {
 		setNoThanksClicked(true);
+		setExitSurveyModalOpen( true );
 	};
 
 	return (
@@ -155,6 +159,9 @@ const ConnectPageOnboarding = ({
 				>
 					{strings.nothanks}
 				</Button>
+				{ isExitSurveyModalOpen && (
+					<ExitSurveyModal />
+				) }
 			</p>
 		</>
 	);

--- a/src/payments-welcome/strings.tsx
+++ b/src/payments-welcome/strings.tsx
@@ -30,6 +30,21 @@ export default {
 
 	paymentMethodsHeading: __('Accepted payment methods', 'wc-calypso-bridge'),
 
+	surveyIntro: createInterpolateElement(
+		// Note: \xa0 is used to create a non-breaking space.
+		__(
+			'Please take a moment to tell us why you’d like to remove WooCommerce Payments. This will remove WooCommerce\xa0Payments from the navigation. In order to enable it again, go to <strong>WooCommerce\xa0Settings\xa0>\xa0Payments</strong>.',
+			'wc-calypso-bridge'
+		),
+		{
+			strong: (
+				<strong />
+			),
+		}
+	),
+
+	surveyQuestion: __('What made you disable the new payments experience?', 'wc-calypso-bridge'),
+
 	terms: createInterpolateElement(
 		__(
 			'Upon clicking "Get started", you agree to the <a>Terms of Service</a>. Next we\'ll ask you to share a few details about your business to create your account.',

--- a/src/payments-welcome/strings.tsx
+++ b/src/payments-welcome/strings.tsx
@@ -30,6 +30,8 @@ export default {
 
 	paymentMethodsHeading: __('Accepted payment methods', 'wc-calypso-bridge'),
 
+	surveyTitle: __( 'Remove WooCommerce Payments', 'wc-calypso-bridge' ) ,
+
 	surveyIntro: createInterpolateElement(
 		// Note: \xa0 is used to create a non-breaking space.
 		__(
@@ -44,6 +46,22 @@ export default {
 	),
 
 	surveyQuestion: __('What made you disable the new payments experience?', 'wc-calypso-bridge'),
+
+	surveyHappyLabel: __('I’m already happy with my payments setup', 'wc-calypso-bridge'),
+
+	surveyInstallLabel: __('I don’t want to install another plugin', 'wc-calypso-bridge'),
+
+	surveyMoreInfoLabel: __('I need more information about WooCommerce Payments', 'wc-calypso-bridge'),
+
+	surveyAnotherTimeLabel: __('I’m open to installing it another time', 'wc-calypso-bridge'),
+
+	surveySomethingElseLabel: __('It’s something else (Please share below', 'wc-calypso-bridge'),
+
+	surveyCommentsLabel: __('Comments (Optional)', 'wc-calypso-bridge'),
+	
+	surveyCancelButton: __('Just remove WooCommerce Payments', 'wc-calypso-bridge'),
+	
+	surveySubmitButton: __('Remove and send feedback', 'wc-calypso-bridge'),
 
 	terms: createInterpolateElement(
 		__(

--- a/src/payments-welcome/style.scss
+++ b/src/payments-welcome/style.scss
@@ -110,3 +110,42 @@
 		background: url( '../../assets/images/wcpay-banner.svg' ) no-repeat right;
 	}
 }
+
+.wc-calypso-bridge-payments-welcome-survey {
+	p {
+		margin-bottom: 1em;
+	}
+}
+
+.wc-calypso-bridge-payments-welcome-survey__intro{
+	max-width: 500px;
+}
+
+.wc-calypso-bridge-payments-welcome-survey__question{
+	font-weight: bold;
+}
+
+
+.wc-calypso-bridge-payments-welcome-survey__selection {
+	margin: 1em 0;
+}
+.wc-calypso-bridge-payments-welcome-survey__comment {
+	margin-top: 1em;
+}
+
+.wc-calypso-bridge-payments-welcome-survey__buttons {
+	text-align: right;
+	
+	button {
+		margin-left: 0.5em;
+	}
+
+	button.is-destructive {
+		background-color: #cc1818;
+		color: white;
+		&:hover {
+			color: white !important;
+		}
+	}
+}
+

--- a/src/payments-welcome/tracks.ts
+++ b/src/payments-welcome/tracks.ts
@@ -38,6 +38,7 @@ function recordEvent(eventName: string, eventProperties?: object) {
 const events = {
 	CONNECT_ACCOUNT_CLICKED: 'wcpay_connect_account_clicked',
 	CONNECT_ACCOUNT_LEARN_MORE: 'wcpay_welcome_learn_more',
+	SURVEY_FEEDBACK: 'wcpay_exit_survey'
 };
 
 export default {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wc-calypso-bridge/issues/694

Adds the exit survey when sites opt out of Payments.

<img width="569" alt="Screen Shot 2021-07-08 at 9 45 39 am" src="https://user-images.githubusercontent.com/9312929/124849402-4a248b80-dfd1-11eb-8bdf-0414a681cf37.png">

### Testing Instructions

1. Enable tracks debugging in browser console: `localStorage.setItem( 'debug', 'wc-admin:*' );`
2. Click on Payments in WP Admin menu.
3. Click "No thanks"
4. See that the survey appears in a modal.
5. Fill at the survey and add a comment.
6. Press "Remove and send feedback" button.
6. See that a tracks event is logged in the browser console containing the survey feedback. For example: <img width="1309" alt="Screen Shot 2021-07-08 at 10 07 50 am" src="https://user-images.githubusercontent.com/9312929/124851090-72fa5000-dfd4-11eb-81b6-8d7d74d900c4.png">
7.  Reload welcome screen
8. Click "No thanks"
9. Press "Just remove WooCommerce Payments" button.
10. See that **no** tracks event is logged in the browser console