### PR TITLE
Call activate promo REST API 

### DIFF
--- a/includes/class-wc-calypso-bridge-payments.php
+++ b/includes/class-wc-calypso-bridge-payments.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Notes.
+ *
+ * @package WC_Calypso_Bridge/Classes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Calypso_Bridge_Payments Class.
+ */
+class WC_Calypso_Bridge_Payments {
+
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var object
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return object Instance.
+	 */
+	final public static function get_instance() {
+		if ( null === static::$instance ) {
+			static::$instance = new static();
+		}
+		return static::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->init();
+	}
+
+	/**
+	 * Include notes and initialize note hooks.
+	 */
+	public function init() {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ), 20 );
+	}
+
+	/**
+	 * Register REST API routes.
+	 *
+	 * New endpoints/controllers can be added here.
+	 */
+	public function register_routes() {
+		/** API includes */
+		include_once dirname( __FILE__ ) . '/payments/class-wc-payments-controller.php';
+		$controller = new WC_Payments_Controller();
+		$controller->register_routes();
+	}
+}
+
+WC_Calypso_Bridge_Payments::get_instance();

--- a/includes/payments/class-wc-payments-controller.php
+++ b/includes/payments/class-wc-payments-controller.php
@@ -27,7 +27,7 @@ class WC_Payments_Controller extends WC_REST_Controller {
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc-calypso-brdige/v1';
+	protected $namespace = 'wc-calypso-bridge/v1';
 
 	/**
 	 * Route base.
@@ -56,8 +56,7 @@ class WC_Payments_Controller extends WC_REST_Controller {
 	 * Override this method if custom permissions required.
 	 */
 	public function check_permission() {
-		return true;
-//		return current_user_can( 'manage_woocommerce' );
+		return current_user_can( 'manage_woocommerce' );
 	}
 
 	/**
@@ -88,7 +87,12 @@ class WC_Payments_Controller extends WC_REST_Controller {
 			$note->set_status( Note::E_WC_ADMIN_NOTE_ACTIONED );
 			$data_store->create( $note );
 		}
-		return true;
+
+		return rest_ensure_response(
+			array(
+				'success' => true
+			)
+		);
 	}
 
 }

--- a/includes/payments/class-wc-payments-controller.php
+++ b/includes/payments/class-wc-payments-controller.php
@@ -27,7 +27,7 @@ class WC_Payments_Controller extends WC_REST_Controller {
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v3';
+	protected $namespace = 'wc-calypso-brdige/v1';
 
 	/**
 	 * Route base.
@@ -40,9 +40,9 @@ class WC_Payments_Controller extends WC_REST_Controller {
 	 * Register routes.
 	 */
 	public function register_routes() {
-		register_rest_route( $this->namespace, '/' . $this->rest_base . '/post-install', array(
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/activate-promo', array(
 			array(
-				'methods'             => WP_REST_Server::READABLE,
+				'methods'             => 'POST',
 				'callback'            => array( $this, 'activate_promo_note' ),
 				'permission_callback' => array( $this, 'check_permission' ),
 			),
@@ -56,7 +56,8 @@ class WC_Payments_Controller extends WC_REST_Controller {
 	 * Override this method if custom permissions required.
 	 */
 	public function check_permission() {
-		return current_user_can( 'manage_woocommerce' );
+		return true;
+//		return current_user_can( 'manage_woocommerce' );
 	}
 
 	/**
@@ -87,6 +88,7 @@ class WC_Payments_Controller extends WC_REST_Controller {
 			$note->set_status( Note::E_WC_ADMIN_NOTE_ACTIONED );
 			$data_store->create( $note );
 		}
+		return true;
 	}
 
 }

--- a/includes/payments/class-wc-payments-controller.php
+++ b/includes/payments/class-wc-payments-controller.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * REST API Payments Controller
+ *
+ * Handles requests to the /payments endpoint.
+ *
+ * @author   Automattic
+ * @category API
+ * @package  WooCommerce/API
+ */
+
+use Automattic\WooCommerce\Admin\Notes\Note;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * REST API Settings controller class.
+ *
+ * @package WooCommerce/API
+ */
+class WC_Payments_Controller extends WC_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'payments';
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/post-install', array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'activate_promo_note' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+			),
+			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
+	}
+
+	/**
+	 * Verify access.
+	 *
+	 * Override this method if custom permissions required.
+	 */
+	public function check_permission() {
+		return current_user_can( 'manage_woocommerce' );
+	}
+
+	/**
+	 * Set action to promo note to give the user discount eligibility.
+	 *
+	 */
+	public function activate_promo_note() {
+		$promo_name = 'wcpay-promo-2021-6-incentive-2';
+		$data_store = WC_Data_Store::load( 'admin-note' );
+		$add_where_clause = function( $where_clause ) use ( $promo_name ) {
+			return $where_clause . " AND name = '$promo_name'";
+		};
+
+		add_filter( 'woocommerce_note_where_clauses', $add_where_clause );
+		$notes = $data_store->get_notes();
+		remove_filter( 'woocommerce_note_where_clauses', $add_where_clause );
+
+		if (! empty( $notes ) ) {
+			$note = new Note( $notes[0] );
+			$note->set_status( Note::E_WC_ADMIN_NOTE_ACTIONED );
+			$data_store->update( $note );
+		} else {
+			// Promo note doesn't exist, this could happen in cases where
+			// user might have disabled RemoteInboxNotications via disabling
+			// marketing suggestions. Thus we'd have to manually add the note.
+			$note = new Note();
+			$note->set_name( $promo_name );
+			$note->set_status( Note::E_WC_ADMIN_NOTE_ACTIONED );
+			$data_store->create( $note );
+		}
+	}
+
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3021,6 +3021,34 @@
 				"react-transition-group": "4.4.1"
 			},
 			"dependencies": {
+				"@wordpress/api-fetch": {
+					"version": "3.23.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.23.1.tgz",
+					"integrity": "sha512-dmeigLuvqYAzpQ2hWUQT1P5VQAjkj9hS1z7PgNi1CcULFPbY8BWW+KiBETUu6Wm+rlSbUL2dC8qrA4JDv9ja5A==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/i18n": "^3.19.2",
+						"@wordpress/url": "^2.22.2"
+					},
+					"dependencies": {
+						"@wordpress/i18n": {
+							"version": "3.20.0",
+							"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.20.0.tgz",
+							"integrity": "sha512-SIoOJFB4UrrYAScS4H91CYCLW9dX3Ghv8pBKc/yHGculb1AdGr6gRMlmJxZV62Cn3CZ4Ga86c+FfR+GiBu0JPg==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.13.10",
+								"@wordpress/hooks": "^2.12.3",
+								"gettext-parser": "^1.3.1",
+								"lodash": "^4.17.19",
+								"memize": "^1.1.0",
+								"sprintf-js": "^1.1.1",
+								"tannin": "^1.2.0"
+							}
+						}
+					}
+				},
 				"@wordpress/components": {
 					"version": "10.2.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-10.2.0.tgz",
@@ -3113,6 +3141,17 @@
 						"memize": "^1.1.0",
 						"sprintf-js": "^1.1.1",
 						"tannin": "^1.2.0"
+					}
+				},
+				"@wordpress/url": {
+					"version": "2.22.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.22.2.tgz",
+					"integrity": "sha512-aqpYKQXzyzkCOm+GzZRYlLb+wh58g0cwR1PaKAl0UXaBS4mdS+X6biMriylb4P8CVC/RR7CSw5XI20JC24KDwQ==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"lodash": "^4.17.19",
+						"react-native-url-polyfill": "^1.1.2"
 					}
 				},
 				"@wordpress/warning": {
@@ -3595,31 +3634,14 @@
 			}
 		},
 		"@wordpress/api-fetch": {
-			"version": "3.23.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.23.1.tgz",
-			"integrity": "sha512-dmeigLuvqYAzpQ2hWUQT1P5VQAjkj9hS1z7PgNi1CcULFPbY8BWW+KiBETUu6Wm+rlSbUL2dC8qrA4JDv9ja5A==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-5.1.1.tgz",
+			"integrity": "sha512-pThYQhoKiePeGgb5aZnc4A9YT5WktfZkejSk4JIfFxdzXF7YXunyMoA9Aib2YvY94IkItLzBeTl/jDk9yYL2hw==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.13.10",
-				"@wordpress/i18n": "^3.19.2",
-				"@wordpress/url": "^2.22.2"
-			},
-			"dependencies": {
-				"@wordpress/i18n": {
-					"version": "3.20.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.20.0.tgz",
-					"integrity": "sha512-SIoOJFB4UrrYAScS4H91CYCLW9dX3Ghv8pBKc/yHGculb1AdGr6gRMlmJxZV62Cn3CZ4Ga86c+FfR+GiBu0JPg==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.13.10",
-						"@wordpress/hooks": "^2.12.3",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.19",
-						"memize": "^1.1.0",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.2.0"
-					}
-				}
+				"@wordpress/i18n": "^4.1.1",
+				"@wordpress/url": "^3.1.1"
 			}
 		},
 		"@wordpress/babel-plugin-import-jsx-pragma": {
@@ -4691,6 +4713,12 @@
 					"integrity": "sha512-MjrkSp6Jyfx+92AE32A83P503noUtGb6//BYUH4GiWzzzSNhDHgbQ0UcOJwJaEYK166DxSNpMk/JXc4YENi1Cw==",
 					"dev": true
 				},
+				"agent-base": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+					"integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
+					"dev": true
+				},
 				"ansi-styles": {
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -4752,6 +4780,16 @@
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
 				},
+				"https-proxy-agent": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+					"integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+					"dev": true,
+					"requires": {
+						"agent-base": "5",
+						"debug": "4"
+					}
+				},
 				"load-json-file": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -4799,6 +4837,12 @@
 						}
 					}
 				},
+				"node-fetch": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+					"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+					"dev": true
+				},
 				"parse-json": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -4839,6 +4883,26 @@
 					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
 					"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
 					"dev": true
+				},
+				"puppeteer": {
+					"version": "npm:puppeteer-core@5.5.0",
+					"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
+					"integrity": "sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==",
+					"dev": true,
+					"requires": {
+						"debug": "^4.1.0",
+						"devtools-protocol": "0.0.818844",
+						"extract-zip": "^2.0.0",
+						"https-proxy-agent": "^4.0.0",
+						"node-fetch": "^2.6.1",
+						"pkg-dir": "^4.2.0",
+						"progress": "^2.0.1",
+						"proxy-from-env": "^1.0.0",
+						"rimraf": "^3.0.2",
+						"tar-fs": "^2.0.0",
+						"unbzip2-stream": "^1.3.3",
+						"ws": "^7.2.3"
+					}
 				},
 				"read-pkg": {
 					"version": "1.1.0",
@@ -4950,13 +5014,13 @@
 			}
 		},
 		"@wordpress/url": {
-			"version": "2.22.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.22.2.tgz",
-			"integrity": "sha512-aqpYKQXzyzkCOm+GzZRYlLb+wh58g0cwR1PaKAl0UXaBS4mdS+X6biMriylb4P8CVC/RR7CSw5XI20JC24KDwQ==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.1.1.tgz",
+			"integrity": "sha512-I+yEw+a66wZ+FrpYU1F78/3c5p7/323UIrfnPUN51hIJcatsqJyQZW9Z1CNZeN5SuCobha0GPq4lw8517+VUMw==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.13.10",
-				"lodash": "^4.17.19",
+				"lodash": "^4.17.21",
 				"react-native-url-polyfill": "^1.1.2"
 			}
 		},
@@ -15247,50 +15311,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-		},
-		"puppeteer": {
-			"version": "npm:puppeteer-core@5.5.0",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
-			"integrity": "sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==",
-			"dev": true,
-			"requires": {
-				"debug": "^4.1.0",
-				"devtools-protocol": "0.0.818844",
-				"extract-zip": "^2.0.0",
-				"https-proxy-agent": "^4.0.0",
-				"node-fetch": "^2.6.1",
-				"pkg-dir": "^4.2.0",
-				"progress": "^2.0.1",
-				"proxy-from-env": "^1.0.0",
-				"rimraf": "^3.0.2",
-				"tar-fs": "^2.0.0",
-				"unbzip2-stream": "^1.3.3",
-				"ws": "^7.2.3"
-			},
-			"dependencies": {
-				"agent-base": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-					"integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
-					"dev": true
-				},
-				"https-proxy-agent": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-					"integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
-					"dev": true,
-					"requires": {
-						"agent-base": "5",
-						"debug": "4"
-					}
-				},
-				"node-fetch": {
-					"version": "2.6.1",
-					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-					"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-					"dev": true
-				}
-			}
 		},
 		"q": {
 			"version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"@woocommerce/components": "^7.0.0",
 		"@woocommerce/dependency-extraction-webpack-plugin": "1.4.0",
 		"@woocommerce/eslint-plugin": "1.1.0",
+		"@wordpress/api-fetch": "^5.1.1",
 		"@wordpress/components": "^14.1.5",
 		"@wordpress/dom-ready": "^3.1.1",
 		"@wordpress/scripts": "^13.0.3",

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -65,6 +65,9 @@ require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-events.php
 // Also prevent Crowdsignal from redirecting during onboarding in all both wp-admin and calypsoified ecommerce plan.
 require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-crowdsignal-redirect.php';
 
+// Load WCPay in core experiment
+require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-payments.php';
+
 if ( ! wc_calypso_bridge_is_ecommerce_plan() ) {
 	include_once dirname( __FILE__ ) . '/store-on-wpcom/class-wc-calypso-bridge.php';
 	return;


### PR DESCRIPTION
Fixes #689 

This PR calls activate promo REST API to activate the WC Pay incentive promotion.

### Testing instructions

1. Make sure you don't have `wcpay-promo-2021-6-incentive-2` note in your `wp_wc_admin_notes` table. If you have it already, make sure the status is `unactioned` 
2. Navigate to the welcome page.
3. Click "Get started" button. You should be redirected. 
4. Open `wp_wc_admin_notes` table and confirm that the `wcpay-promo-2021-6-incentive-2` status is now `actioned` 

You can also finish the KYC and confirm your account has the promotion applied.

### Screenshots

![Screen Shot 2021-07-07 at 2 44 00 PM](https://user-images.githubusercontent.com/4723145/124833910-b8b30c00-df33-11eb-9f3d-8d4a5f13a9a9.jpg)
