### PR TITLE
Update/allow merchants to remove wcpay menu

### DIFF
--- a/src/payments-welcome/exit-survey-modal.tsx
+++ b/src/payments-welcome/exit-survey-modal.tsx
@@ -8,6 +8,7 @@ import {
 	CheckboxControl,
 	TextareaControl,
 } from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -28,7 +29,19 @@ function ExitSurveyModal(): JSX.Element | null {
 	const [ isSomethingElseChecked, setSomethingElseChecked ] = useState(false);
 	const [ comments, setComments ] = useState( '' );
 	
-	const closeModal = () => setOpen( false );
+	const closeModal = () => {
+		setOpen( false );
+
+		apiFetch({
+			path: 'wc-admin/options',
+			method: 'POST',
+			data: {
+				wc_calypso_bridge_payments_dismissed: 'yes'
+			}
+		}).then( () => {
+			window.location.href = 'admin.php?page=wc-admin';
+		});
+	}
 
 	const sendFeedback = () => {
 		wcpayTracks.recordEvent(wcpayTracks.events.SURVEY_FEEDBACK, {
@@ -39,7 +52,8 @@ function ExitSurveyModal(): JSX.Element | null {
 			somethingElse: isSomethingElseChecked ? 'Yes' : 'No',
 			comments: comments,
 		});
-		setOpen( false );
+
+		closeModal();
 	};
 
 	if ( ! isOpen ) {

--- a/src/payments-welcome/exit-survey-modal.tsx
+++ b/src/payments-welcome/exit-survey-modal.tsx
@@ -20,7 +20,9 @@ import wcpayTracks from './tracks';
  * Provides a modal requesting customer feedback.
  *
  */
-function ExitSurveyModal(): JSX.Element | null {
+function ExitSurveyModal({ setExitSurveyModalOpen }: {
+	setExitSurveyModalOpen: Function	
+}): JSX.Element | null {
 	const [ isOpen, setOpen ] = useState( true );
 	const [ isHappyChecked, setHappyChecked ] = useState(false);
 	const [ isInstallChecked, setInstallChecked ] = useState(false);
@@ -31,7 +33,10 @@ function ExitSurveyModal(): JSX.Element | null {
 	
 	const closeModal = () => {
 		setOpen( false );
+		setExitSurveyModalOpen( false );
+	}
 
+	const removeWCPayMenu = () => {
 		apiFetch({
 			path: 'wc-admin/options',
 			method: 'POST',
@@ -41,6 +46,8 @@ function ExitSurveyModal(): JSX.Element | null {
 		}).then( () => {
 			window.location.href = 'admin.php?page=wc-admin';
 		});
+
+		setOpen( false );
 	}
 
 	const sendFeedback = () => {
@@ -53,7 +60,7 @@ function ExitSurveyModal(): JSX.Element | null {
 			comments: comments,
 		});
 
-		closeModal();
+		removeWCPayMenu();
 	};
 
 	if ( ! isOpen ) {
@@ -109,7 +116,7 @@ function ExitSurveyModal(): JSX.Element | null {
 			</div>
 
 			<div className="wc-calypso-bridge-payments-welcome-survey__buttons">
-				<Button isTertiary isDestructive onClick={ closeModal } name="cancel">
+				<Button isTertiary isDestructive onClick={ removeWCPayMenu } name="cancel">
 					{ strings.surveyCancelButton }
 				</Button>
 				<Button isSecondary onClick={ sendFeedback } name="send">

--- a/src/payments-welcome/index.tsx
+++ b/src/payments-welcome/index.tsx
@@ -126,6 +126,8 @@ const ConnectPageOnboarding = ({
 		}		
 	}
 
+	const [ isExitSurveyModalOpen, setExitSurveyModalOpen ] = useState( false );
+
 	const handleSetup = async () => {
 		setSubmitted(true);
 		wcpayTracks.recordEvent(wcpayTracks.events.CONNECT_ACCOUNT_CLICKED, {

--- a/src/payments-welcome/index.tsx
+++ b/src/payments-welcome/index.tsx
@@ -126,8 +126,6 @@ const ConnectPageOnboarding = ({
 		}		
 	}
 
-	const [ isExitSurveyModalOpen, setExitSurveyModalOpen ] = useState( false );
-
 	const handleSetup = async () => {
 		setSubmitted(true);
 		wcpayTracks.recordEvent(wcpayTracks.events.CONNECT_ACCOUNT_CLICKED, {
@@ -178,15 +176,15 @@ const ConnectPageOnboarding = ({
 					{strings.button}
 				</Button>
 				<Button
-					isBusy={isNoThanksClicked}
-					disabled={isNoThanksClicked}
+					isBusy={isNoThanksClicked && isExitSurveyModalOpen}
+					disabled={isNoThanksClicked && isExitSurveyModalOpen}
 					onClick={handleNoThanks}
 					className="btn-nothanks"
 				>
 					{strings.nothanks}
 				</Button>
 				{ isExitSurveyModalOpen && (
-					<ExitSurveyModal />
+					<ExitSurveyModal setExitSurveyModalOpen = {setExitSurveyModalOpen}/>
 				) }
 			</p>
 		</>


### PR DESCRIPTION
Fixes #691 

This PR updates `wc_calypso_bridge_payments_dismissed` to `yes` and redirect the user to WC Home when the user closes the exit survey modal.

### Testing instructions

1. Navigate to the welcome page.
2. Click [ No Thanks ] button
3. Click either [ Just remove WooCommerce Payments ] or [ Remove and send feedback ] button.
4. You should be redirected to WooCommerce Home, `wc_calypso_bridge_payments_dismissed` value should be updated to `yes`, and the WC Payment menu should be removed as well.