### PR TITLE
Add new pageview track to WCPay welcome page

### DIFF
--- a/src/payments-welcome/index.tsx
+++ b/src/payments-welcome/index.tsx
@@ -5,7 +5,7 @@
 import { Card } from '@woocommerce/components';
 import { Button, Modal, Notice } from '@wordpress/components';
 // @ts-ignore
-import { useState } from 'wordpress-element';
+import { useState, useEffect } from 'wordpress-element';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
@@ -192,6 +192,11 @@ const ConnectPageOnboarding = ({
 };
 
 const ConnectAccountPage = () => {
+	useEffect(() => {
+		wcpayTracks.recordEvent(wcpayTracks.events.CONNECT_ACCOUNT_VIEW, {
+			path: 'payments_connect_dotcom_test',
+		});
+	}, []);
 	const [errorMessage, setErrorMessage] = useState('');
 	const onboardingProps = {
 		isJetpackConnected: window.wp.data

--- a/src/payments-welcome/tracks.ts
+++ b/src/payments-welcome/tracks.ts
@@ -38,6 +38,7 @@ function recordEvent(eventName: string, eventProperties?: object) {
 const events = {
 	CONNECT_ACCOUNT_CLICKED: 'wcpay_connect_account_clicked',
 	CONNECT_ACCOUNT_LEARN_MORE: 'wcpay_welcome_learn_more',
+	CONNECT_ACCOUNT_VIEW: 'page_view',
 	SURVEY_FEEDBACK: 'wcpay_exit_survey'
 };
 


### PR DESCRIPTION
This PR is a follow-up to https://github.com/Automattic/wc-calypso-bridge/pull/700. It adds a pageview track with a path `payments_connect_dotcom_test`.

### Testing Instructions

1. Open your browser console.
2. If you haven't enabled tracks debug, type in `localStorage.setItem( 'debug', 'wc-admin:tracks*' );` to enable it.
1. Navigate to the WCPay welcome page.
2. Note the track `wcadmin_page_view` is recorded with the prop `{path: "payments_connect_dotcom_test"} `