### PR TITLE
Add css fix for CardBody bug

### DIFF
--- a/assets/css/ecommerce.css
+++ b/assets/css/ecommerce.css
@@ -20,3 +20,7 @@
 	.components-tab-panel__tabs {
 	display: none;
 }
+
+.woocommerce-layout__main .components-scrollable {
+	overflow: unset;
+}

--- a/store-on-wpcom/assets/css/admin/store-on-wpcom.css
+++ b/store-on-wpcom/assets/css/admin/store-on-wpcom.css
@@ -1,0 +1,3 @@
+.woocommerce-layout__main .components-scrollable {
+    overflow: unset;
+}

--- a/store-on-wpcom/class-wc-calypso-bridge.php
+++ b/store-on-wpcom/class-wc-calypso-bridge.php
@@ -41,6 +41,8 @@ class WC_Calypso_Bridge {
 	public function init() {
 		if ( $this->is_woocommerce_valid() ) {
 			$this->includes();
+			add_action( 'admin_enqueue_scripts', array($this, 'add_scripts') );
+
 			// Ensure wc-api-dev has already registered routes.
 			add_action( 'rest_api_init', array( $this, 'register_routes' ), 20 );
 		}
@@ -113,6 +115,14 @@ class WC_Calypso_Bridge {
 			$controller_instance = new $controller();
 			$controller_instance->register_routes();
 		}
+	}
+
+	/**
+	 * Add common scripts.
+	 */
+	public function add_scripts() {
+		$asset_path = WC_Calypso_Bridge::$plugin_asset_path ? WC_Calypso_Bridge::$plugin_asset_path : WC_Calypso_Bridge::MU_PLUGIN_ASSET_PATH;
+		wp_enqueue_style( 'wp-calypso-bridge-store-on-wpcom-css', $asset_path . 'assets/css/admin/store-on-wpcom.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
 	}
 
 	/**

--- a/store-on-wpcom/class-wc-calypso-bridge.php
+++ b/store-on-wpcom/class-wc-calypso-bridge.php
@@ -41,7 +41,7 @@ class WC_Calypso_Bridge {
 	public function init() {
 		if ( $this->is_woocommerce_valid() ) {
 			$this->includes();
-			add_action( 'admin_enqueue_scripts', array($this, 'add_scripts') );
+			add_action( 'admin_enqueue_scripts', array( $this, 'add_scripts' ) );
 
 			// Ensure wc-api-dev has already registered routes.
 			add_action( 'rest_api_init', array( $this, 'register_routes' ), 20 );
@@ -121,7 +121,7 @@ class WC_Calypso_Bridge {
 	 * Add common scripts.
 	 */
 	public function add_scripts() {
-		$asset_path = WC_Calypso_Bridge::$plugin_asset_path ? WC_Calypso_Bridge::$plugin_asset_path : WC_Calypso_Bridge::MU_PLUGIN_ASSET_PATH;
+		$asset_path = self::$plugin_asset_path ? self::$plugin_asset_path : self::MU_PLUGIN_ASSET_PATH;
 		wp_enqueue_style( 'wp-calypso-bridge-store-on-wpcom-css', $asset_path . 'assets/css/admin/store-on-wpcom.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
 	}
 


### PR DESCRIPTION
Fixes p1626286300278800-slack-C9K5T0XSP

Please refer to the slack thread for more details.

A little background: 

1. Gutenberg updated `Card` component with a new [isSCrollable](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/card/card-body/hook.js#L26) props. The prop's default value is `true`. This causes a visual glitch with `CardBody` component. 

![Screen Shot 2021-07-14 at 4 33 01 PM](https://user-images.githubusercontent.com/4723145/125705762-bdbf21de-57d0-4253-8cdf-ff1d274832b2.jpg)

2. We can either fix this issue in Gutenberg or WC Admin, but both require a code push and users have to update one of the plugins.

This PR fixes the problem for wordpress.com users while we're working on a fix in WC Admin.