### PR TITLE
Replace deprecated card component

### DIFF
--- a/src/payments-welcome/index.tsx
+++ b/src/payments-welcome/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 // @ts-ignore
-import { Card } from '@woocommerce/components';
+import { Card, CardBody } from '@wordpress/components';
 import { Button, Modal, Notice } from '@wordpress/components';
 // @ts-ignore
 import { useState, useEffect } from 'wordpress-element';
@@ -213,15 +213,19 @@ const ConnectAccountPage = () => {
 			<div className="woocommerce-payments-page is-narrow connect-account">
 				<ConnectPageError errorMessage={errorMessage} />
 				<Card className="connect-account__card">
-					<Banner />
-					<div className="content">
-						<ConnectPageOnboarding {...onboardingProps} />
-					</div>
+					<CardBody>
+						<Banner />
+						<div className="content">
+							<ConnectPageOnboarding {...onboardingProps} />
+						</div>
+					</CardBody>
 				</Card>
 				<Card className="faq__card">
-					<div className="content">
-						<FrequentlyAskedQuestions />
-					</div>
+					<CardBody>
+						<div className="content">
+							<FrequentlyAskedQuestions />
+						</div>
+					</CardBody>
 				</Card>
 			</div>
 		</div>

--- a/src/payments-welcome/style.scss
+++ b/src/payments-welcome/style.scss
@@ -37,11 +37,12 @@
 		.faq__card {
 			box-shadow: none;
 			border: 1px solid #E2E4E7;
-			border-radius: 2px;			
+			border-radius: 2px;
+			margin-top: 24px;
 		}
 
 		.connect-account__card {
-			.woocommerce-card__body {
+			> .components-card__body {
 				padding: 0;
 
 				.content {


### PR DESCRIPTION
This PR replaces usage of deprecated `Card` component in `@woocommerce/components` to one provided by `@wordpress/components`.

I referred to the fix in https://github.com/Automattic/woocommerce-payments/pull/2315/files#diff-30293a9b506863170131c9147d3be1e5b027dd176ae41e7e448d96489892daf8.

### Screenshots

![image](https://user-images.githubusercontent.com/3747241/125730114-bbae9b43-4366-4f59-8303-700ea001c7f0.png)

### Testing Instructions
1. Run build
2. Go to the welcome page, observe no difference in UI