### PR TITLE
Update promo incentive and all relevant copies

### DIFF
--- a/includes/payments/class-wc-payments-controller.php
+++ b/includes/payments/class-wc-payments-controller.php
@@ -64,7 +64,7 @@ class WC_Payments_Controller extends WC_REST_Controller {
 	 *
 	 */
 	public function activate_promo_note() {
-		$promo_name = 'wcpay-promo-2021-6-incentive-2';
+		$promo_name = 'wcpay-promo-2021-6-incentive-1';
 		$data_store = WC_Data_Store::load( 'admin-note' );
 		$add_where_clause = function( $where_clause ) use ( $promo_name ) {
 			return $where_clause . " AND name = '$promo_name'";

--- a/src/payments-welcome/faq.tsx
+++ b/src/payments-welcome/faq.tsx
@@ -14,7 +14,7 @@ const FrequentlyAskedQuestions = () => {
 			<h2>Frequently asked questions</h2>
 			<h3>How will I save money using WooCommerce Payments?</h3>
 			<p>
-			Stores accepted into the promotional program will receive a 100% discount on transaction fees (excluding currency conversion fees) for the first $25,000 in payments, or 3 months, whichever comes first. Simply install the extension and if eligible you’ll be entered into the promotional offer. 
+			Stores accepted into the promotional program will receive a 50% discount on transaction fees for the first $125,000 in payments, or 6 months, whichever comes first. Simply install the extension and if eligible you’ll be entered into the promotional offer.
 			</p>
 			<p>
 			To be eligible for this promotional offer, your store must: (1) meet the WooCommerce Payments usage requirements; (2) be a U.S.-based business; (3) not have processed payments through WooCommerce Payments before; and (4) be accepted into the promotional program.

--- a/src/payments-welcome/strings.tsx
+++ b/src/payments-welcome/strings.tsx
@@ -16,7 +16,7 @@ export default {
 		'wc-calypso-bridge'
 	),
 	bannerCopy: __(
-		'No transaction fees for up to 3 months (or $25,000 in payments)',
+		'50% transaction fee discount for up to $125,000 in payments or six months',
 		'wc-calypso-bridge'
 	),
 	learnMore: __('Learn more', 'wc-calypso-bridge'),

--- a/src/payments-welcome/style.scss
+++ b/src/payments-welcome/style.scss
@@ -30,6 +30,7 @@
 
 		h3 {
 			font-size: 1.3em;
+			line-height: 1.4em;
 			padding-top: 15px;
 		}
 


### PR DESCRIPTION
This PR updates from free incentive to 50% paJDYF-1Yz-p2#comment-7136. It also changes all relevant copies. Please cross check with the T&C [here](https://woocommerce.com/terms-conditions/woocommerce-payments-half-off-six-promotion/?utm_medium=notification&utm_source=product&utm_campaign=wcpay_exp222). 

### Testing Instructions
1. Review all copies in WCPay welcome page and make sure all incentive benefits are accurate.
4. Click "Get started" button. You should be redirected.
5. Open `wp_wc_admin_notes` table and confirm that the `wcpay-promo-2021-6-incentive-1` status is now actioned