### PR TITLE
Add translated FAQs

### DIFF
--- a/src/payments-welcome/faq.tsx
+++ b/src/payments-welcome/faq.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { Icon, help } from '@wordpress/icons'
+import { Icon, help } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
@@ -11,80 +11,63 @@ import strings from './strings';
 const FrequentlyAskedQuestions = () => {
 	return (
 		<>
-			<h2>Frequently asked questions</h2>
-			<h3>How will I save money using WooCommerce Payments?</h3>
+			<h2>{strings.faq.faqHeader}</h2>
+			<h3>{strings.faq.question1}</h3>
+			<p>{strings.faq.question1Answer1}</p>
+			<p>{strings.faq.question1Answer2}</p>
+
+			<h3>{strings.faq.question2}</h3>
+			<p>{strings.faq.question2Answer1}</p>
 			<p>
-			Stores accepted into the promotional program will receive a 50% discount on transaction fees for the first $125,000 in payments, or 6 months, whichever comes first. Simply install the extension and if eligible you’ll be entered into the promotional offer.
-			</p>
-			<p>
-			To be eligible for this promotional offer, your store must: (1) meet the WooCommerce Payments usage requirements; (2) be a U.S.-based business; (3) not have processed payments through WooCommerce Payments before; and (4) be accepted into the promotional program.
-			</p>
-			<h3>What are the fees for WooCommerce Payments?</h3>
-			<p>
-				WooCommerce Payments uses a pay-as-you-go pricing model. You pay only for activity on the account. No setup fee or monthly fee. Fees differ based on the country of your account and country of your customer’s card. The full list of fees for available countries is listed below.
-			</p>
-			<p>
-				<h4>United States</h4>
+				<h4>{strings.faq.question2Answer2}</h4>
 				<ul>
-					<li>2.9% + $0.30 USD per transaction for U.S. issued credit or debit card
+					<li>
+						{strings.faq.question2Answer3}
 						<ul>
-							<li>+1% for transactions paid using a card issued outside the US</li>
-							<li><a href='https://docs.woocommerce.com/document/payments/faq/fees/currency-conversion/' target='_blank'>+1% for conversion of currencies other than USD</a></li>
+							<li>{strings.faq.question2Answer4}</li>
+							<li>{strings.faq.question2Answer5}</li>
 						</ul>
 					</li>
-					<li>$15 USD fee per dispute (refunded if you win the dispute)</li>
-					<li>1.5% fee on the payout amount for <a href='https://docs.woocommerce.com/document/payments/instant-deposits/' target='_blank'>instant deposits</a></li>
+					<li>{strings.faq.question2Answer6}</li>
+					<li>{strings.faq.question2Answer7}</li>
 				</ul>
-				<a href='https://href.li/?https://docs.woocommerce.com/document/payments/faq/fees/' target='_blank'>View all fees</a>
+				{strings.faq.question2Answer8}
 			</p>
-			<h3>When will I receive deposits for my WooCommerce Payments account balance?</h3>
+			<h3>{strings.faq.question3}</h3>
+			<p>{strings.faq.question3Answer1}</p>
+			<p>{strings.faq.question3Answer2}</p>
+			<p>{strings.faq.question3Answer3}</p>
+			<p>{strings.faq.question3Answer4}</p>
+			<p>{strings.faq.question3Answer5}</p>
+			<h3>{strings.faq.question4}</h3>
 			<p>
-			For most accounts, WooCommerce Payments automatically pays out your available account balance into your nominated account daily after a standard pending period.
-			</p>
-			<p>
-				Payments received each day become part of the pending balance. That pending balance will become available after a pending period. On the day it becomes available, it will be automatically paid out to your bank account. The pending period is based on the country of the account.
-			</p>
-			<p>
-				For example, a business based in New Zealand has a pending period of 4 business days. Payments made to this account on Wednesday will be paid out on the next Tuesday.
-			</p>
-			<p>
-			Most banks will reflect the deposit in your account as soon as they receive the transfer from WooCommerce Payments. Some may take a few extra days to make the balance available to you.
-			</p>
-			<p>
-				<a href='https://href.li/?https://docs.woocommerce.com/document/payments/faq/deposit-schedule/' target='_blank'>All deposits details</a>
-			</p>
-			<h3>What products are not permitted on my store when accepting payments with WooCommerce Payments?</h3>
-			<p>
-				Due to restrictions from card networks, our payment service providers, and their financial service providers, some businesses and product types that are not allowed to transact using WooCommerce Payments, including but not limited to:
+				{strings.faq.question4Answer1}
 				<ul>
-					<li>Virtual currency, including video game or virtual world credits</li>
-					<li>Counterfeit goods</li>
-					<li>Adult content and services</li>
-					<li>Drug paraphernalia (including e-cigarette, vapes and nutraceuticals)</li>
-					<li>Multi-level marketing</li>
-					<li>Pseudo pharmaceuticals</li>
-					<li>Social media activity, like Twitter followers, Facebook likes, YouTube views</li>
-					<li>Substances designed to mimic illegal drugs</li>
-					<li>Firearms, ammunition</li>
+					<li>{strings.faq.question4Answer2}</li>
+					<li>{strings.faq.question4Answer3}</li>
+					<li>{strings.faq.question4Answer4}</li>
+					<li>{strings.faq.question4Answer5}</li>
+					<li>{strings.faq.question4Answer6}</li>
+					<li>{strings.faq.question4Answer7}</li>
+					<li>{strings.faq.question4Answer8}</li>
+					<li>{strings.faq.question4Answer9}</li>
+					<li>{strings.faq.question4Answer10}</li>
 				</ul>
 			</p>
-			<p>
-				The full list of these businesses can be found in <a href='https://stripe.com/restricted-businesses' target='_blank'>Stripe’s Restricted Businesses list</a>.
-			</p>
-			<p>
-				By signing up to use WooCommerce Payments, you agree not to accept payments in connection with these restricted activities, practices or products. We also work to ensure that no prohibited activity is conducted on WooCommerce Payments.
-			</p>
-			<p>
-				If we become aware of prohibited activity, we may restrict or shutdown the account responsible.
-			</p>
-			<h3>Can I use WooCommerce Payments alongside other payment gateways?</h3>
-			<p>
-				Yes! WooCommerce Payments works alongside other payment service providers, including Stripe, PayPal, and all others. We’ve built it with this flexibility in mind so that you can ensure your store is working to meet your business needs. 				
-			</p>
-			<div className='help-section'>
-				<Icon icon={ help } />
-				<span>{strings.haveMoreQuestions}</span>
-				<a href="https://www.woocommerce.com/my-account/tickets/" target="_blank">{strings.getInTouch}</a>
+			<p>{strings.faq.question4Answer11}</p>
+			<p>{strings.faq.question4Answer12}</p>
+			<p>{strings.faq.question4Answer13}</p>
+			<h3>{strings.faq.question5}</h3>
+			<p>{strings.faq.question5Answer1}</p>
+			<div className="help-section">
+				<Icon icon={help} />
+				<span>{strings.faq.haveMoreQuestions}</span>
+				<a
+					href="https://www.woocommerce.com/my-account/tickets/"
+					target="_blank"
+				>
+					{strings.faq.getInTouch}
+				</a>
 			</div>
 		</>
 	);

--- a/src/payments-welcome/strings.tsx
+++ b/src/payments-welcome/strings.tsx
@@ -183,7 +183,7 @@ export default {
 				a: (
 					// eslint-disable-next-line jsx-a11y/anchor-has-content
 					<a
-						href="https://href.li/?https://docs.woocommerce.com/document/payments/faq/fees/"
+						href="https://docs.woocommerce.com/document/payments/faq/fees/"
 						target="_blank"
 						rel="noopener noreferrer"
 					/>
@@ -222,7 +222,7 @@ export default {
 				a: (
 					// eslint-disable-next-line jsx-a11y/anchor-has-content
 					<a
-						href="https://href.li/?https://docs.woocommerce.com/document/payments/faq/deposit-schedule/"
+						href="https://docs.woocommerce.com/document/payments/faq/deposit-schedule/"
 						target="_blank"
 						rel="noopener noreferrer"
 					/>

--- a/src/payments-welcome/strings.tsx
+++ b/src/payments-welcome/strings.tsx
@@ -29,7 +29,7 @@ export default {
 	},
 
 	paymentMethodsHeading: __('Accepted payment methods', 'wc-calypso-bridge'),
-	surveyTitle: __( 'Remove WooCommerce Payments', 'wc-calypso-bridge' ) ,
+	surveyTitle: __('Remove WooCommerce Payments', 'wc-calypso-bridge'),
 
 	surveyIntro: createInterpolateElement(
 		// Note: \xa0 is used to create a non-breaking space.
@@ -38,32 +38,49 @@ export default {
 			'wc-calypso-bridge'
 		),
 		{
-			strong: (
-				<strong />
-			),
+			strong: <strong />,
 		}
 	),
 
-	surveyQuestion: __('What made you disable the new payments experience?', 'wc-calypso-bridge'),
+	surveyQuestion: __(
+		'What made you disable the new payments experience?',
+		'wc-calypso-bridge'
+	),
 
-	surveyHappyLabel: __('I’m already happy with my payments setup', 'wc-calypso-bridge'),
+	surveyHappyLabel: __(
+		'I’m already happy with my payments setup',
+		'wc-calypso-bridge'
+	),
 
-	surveyInstallLabel: __('I don’t want to install another plugin', 'wc-calypso-bridge'),
+	surveyInstallLabel: __(
+		'I don’t want to install another plugin',
+		'wc-calypso-bridge'
+	),
 
-	surveyMoreInfoLabel: __('I need more information about WooCommerce Payments', 'wc-calypso-bridge'),
+	surveyMoreInfoLabel: __(
+		'I need more information about WooCommerce Payments',
+		'wc-calypso-bridge'
+	),
 
-	surveyAnotherTimeLabel: __('I’m open to installing it another time', 'wc-calypso-bridge'),
+	surveyAnotherTimeLabel: __(
+		'I’m open to installing it another time',
+		'wc-calypso-bridge'
+	),
 
-	surveySomethingElseLabel: __('It’s something else (Please share below', 'wc-calypso-bridge'),
+	surveySomethingElseLabel: __(
+		'It’s something else (Please share below',
+		'wc-calypso-bridge'
+	),
 
 	surveyCommentsLabel: __('Comments (Optional)', 'wc-calypso-bridge'),
-	
-	surveyCancelButton: __('Just remove WooCommerce Payments', 'wc-calypso-bridge'),
-	
+
+	surveyCancelButton: __(
+		'Just remove WooCommerce Payments',
+		'wc-calypso-bridge'
+	),
+
 	surveySubmitButton: __('Remove and send feedback', 'wc-calypso-bridge'),
 
-	haveMoreQuestions: __('Have more questions?', 'wc-calypso-bridge'),
-	getInTouch: __('Get in touch', 'wc-calypso-bridge'),
 	terms: createInterpolateElement(
 		__(
 			'Upon clicking "Get started", you agree to the <a>Terms of Service</a>. Next we\'ll ask you to share a few details about your business to create your account.',
@@ -80,4 +97,218 @@ export default {
 			),
 		}
 	),
+
+	faq: {
+		faqHeader: __('Frequently asked questions', 'wc-calypso-bridge'),
+
+		question1: __(
+			'How will I save money using WooCommerce Payments?',
+			'wc-calypso-bridge'
+		),
+
+		question1Answer1: __(
+			'Stores accepted into the promotional program will receive a 50% discount on transaction fees for the first $125,000 in payments, or 6 months, whichever comes first. Simply install the extension and if eligible you’ll be entered into the promotional offer.',
+			'wc-calypso-bridge'
+		),
+
+		question1Answer2: __(
+			'To be eligible for this promotional offer, your store must: (1) meet the WooCommerce Payments usage requirements; (2) be a U.S.-based business; (3) not have processed payments through WooCommerce Payments before; and (4) be accepted into the promotional program.',
+			'wc-calypso-bridge'
+		),
+
+		question2: __(
+			'What are the fees for WooCommerce Payments?',
+			'wc-calypso-bridge'
+		),
+
+		question2Answer1: __(
+			'WooCommerce Payments uses a pay-as-you-go pricing model. You pay only for activity on the account. No setup fee or monthly fee. Fees differ based on the country of your account and country of your customer’s card. The full list of fees for available countries is listed below.',
+			'wc-calypso-bridge'
+		),
+
+		question2Answer2: __('United States', 'wc-calypso-bridge'),
+
+		question2Answer3: __(
+			'2.9% + $0.30 USD per transaction for U.S. issued credit or debit card',
+			'wc-calypso-bridge'
+		),
+
+		question2Answer4: __(
+			'+1% for transactions paid using a card issued outside the US',
+			'wc-calypso-bridge'
+		),
+
+		question2Answer5: createInterpolateElement(
+			__(
+				'<a>+1% for conversion of currencies other than USD</a>',
+				'wc-calypso-bridge'
+			),
+			{
+				a: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a
+						href="https://docs.woocommerce.com/document/payments/faq/fees/currency-conversion/"
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			}
+		),
+
+		question2Answer6: __(
+			'$15 USD fee per dispute (refunded if you win the dispute)',
+			'wc-calypso-bridge'
+		),
+
+		question2Answer7: createInterpolateElement(
+			__(
+				'1.5% fee on the payout amount for <a>instant deposits</a>',
+				'wc-calypso-bridge'
+			),
+			{
+				a: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a
+						href="https://docs.woocommerce.com/document/payments/instant-deposits/"
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			}
+		),
+
+		question2Answer8: createInterpolateElement(
+			__('<a>View all fees</a>', 'wc-calypso-bridge'),
+			{
+				a: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a
+						href="https://href.li/?https://docs.woocommerce.com/document/payments/faq/fees/"
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			}
+		),
+
+		question3: __(
+			'When will I receive deposits for my WooCommerce Payments account balance?',
+			'wc-calypso-bridge'
+		),
+
+		question3Answer1: __(
+			'For most accounts, WooCommerce Payments automatically pays out your available account balance into your nominated account daily after a standard pending period.',
+			'wc-calypso-bridge'
+		),
+
+		question3Answer2: __(
+			'Payments received each day become part of the pending balance. That pending balance will become available after a pending period. On the day it becomes available, it will be automatically paid out to your bank account. The pending period is based on the country of the account.',
+			'wc-calypso-bridge'
+		),
+
+		question3Answer3: __(
+			'For example, a business based in New Zealand has a pending period of 4 business days. Payments made to this account on Wednesday will be paid out on the next Tuesday.',
+			'wc-calypso-bridge'
+		),
+
+		question3Answer4: __(
+			'Most banks will reflect the deposit in your account as soon as they receive the transfer from WooCommerce Payments. Some may take a few extra days to make the balance available to you.',
+			'wc-calypso-bridge'
+		),
+
+		question3Answer5: createInterpolateElement(
+			__('<a>All deposits details</a>', 'wc-calypso-bridge'),
+			{
+				a: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a
+						href="https://href.li/?https://docs.woocommerce.com/document/payments/faq/deposit-schedule/"
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			}
+		),
+
+		question4: __(
+			'What products are not permitted on my store when accepting payments with WooCommerce Payments?',
+			'wc-calypso-bridge'
+		),
+
+		question4Answer1: __(
+			'Due to restrictions from card networks, our payment service providers, and their financial service providers, some businesses and product types that are not allowed to transact using WooCommerce Payments, including but not limited to:',
+			'wc-calypso-bridge'
+		),
+
+		question4Answer2: __(
+			'Virtual currency, including video game or virtual world credits',
+			'wc-calypso-bridge'
+		),
+
+		question4Answer3: __('Counterfeit goods', 'wc-calypso-bridge'),
+
+		question4Answer4: __('Adult content and services', 'wc-calypso-bridge'),
+
+		question4Answer5: __(
+			'Drug paraphernalia (including e-cigarette, vapes and nutraceuticals)',
+			'wc-calypso-bridge'
+		),
+
+		question4Answer6: __('Multi-level marketing', 'wc-calypso-bridge'),
+
+		question4Answer7: __('Pseudo pharmaceuticals', 'wc-calypso-bridge'),
+
+		question4Answer8: __(
+			'Social media activity, like Twitter followers, Facebook likes, YouTube views',
+			'wc-calypso-bridge'
+		),
+
+		question4Answer9: __(
+			'Substances designed to mimic illegal drugs',
+			'wc-calypso-bridge'
+		),
+
+		question4Answer10: __('Firearms, ammunition', 'wc-calypso-bridge'),
+
+		question4Answer11: createInterpolateElement(
+			__(
+				'The full list of these businesses can be found in <a>Stripe’s Restricted Businesses list</a>.',
+				'wc-calypso-bridge'
+			),
+			{
+				a: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a
+						href="https://stripe.com/restricted-businesses"
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			}
+		),
+
+		question4Answer12: __(
+			'By signing up to use WooCommerce Payments, you agree not to accept payments in connection with these restricted activities, practices or products. We also work to ensure that no prohibited activity is conducted on WooCommerce Payments.',
+			'wc-calypso-bridge'
+		),
+
+		question4Answer13: __(
+			'If we become aware of prohibited activity, we may restrict or shutdown the account responsible.',
+			'wc-calypso-bridge'
+		),
+
+		question5: __(
+			'Can I use WooCommerce Payments alongside other payment gateways?',
+			'wc-calypso-bridge'
+		),
+
+		question5Answer1: __(
+			'Yes! WooCommerce Payments works alongside other payment service providers, including Stripe, PayPal, and all others. We’ve built it with this flexibility in mind so that you can ensure your store is working to meet your business needs.',
+			'wc-calypso-bridge'
+		),
+
+		haveMoreQuestions: __('Have more questions?', 'wc-calypso-bridge'),
+
+		getInTouch: __('Get in touch', 'wc-calypso-bridge'),
+	},
 };


### PR DESCRIPTION
This PR uses i18n to translate all FAQ strings. It also lints formatting for modified files and removed `href.li` redirector since we don't need them.

Note that I did not put too much thought into the naming of the string variables, if you do have any better suggestions please let me know! The strings file also grew considerably, but I think we can address splitting strings in the future if required.

### Testing Instructions

1. Review all texts and links and make sure everything works as it was previously.

### Screenshots

![image](https://user-images.githubusercontent.com/3747241/126634380-fe3c9fb4-2f70-4ec6-8dd2-fd0ff5fa11ef.png)
