### PR TITLE
Add condition to disable WCPay menu when store is not US english

### DIFF
--- a/includes/class-wc-calypso-bridge-payments.php
+++ b/includes/class-wc-calypso-bridge-payments.php
@@ -85,6 +85,11 @@ class WC_Calypso_Bridge_Payments {
 			return;
 		}
 
+		// Temporary until we have translations ready.
+		if ( get_locale() !== 'en_US' ) {
+			return;
+		}
+
 		if ( 'yes' === get_option( 'wc_calypso_bridge_payments_dismissed', 'no' ) ) {
 			return;
 		}


### PR DESCRIPTION
This PR adds another condition to display WCPay menu, which is the store's WordPress instance language needs to be in US English. This change should be temporary and removed when we have translations ready.

### Testing Instructions

2. Go to Settings > General.
3. Set site language to anything other than `English (United States)`
3. Observe that the WCPay menu disappears.
4. Optionally, set it back to English (United States) and see it appears again.