### PR TITLE
Fix missing WCPay icon on ecom plan users

### DIFF
--- a/assets/css/wc-payments.css
+++ b/assets/css/wc-payments.css
@@ -10,8 +10,8 @@
 }
 
 /* stylelint-disable selector-id-pattern */
-#toplevel_page_wc-admin-path--payments-welcome
-div.wp-menu-image::before {
+#toplevel_page_wc-admin-path--payments-welcome div.wp-menu-image::before,
+#toplevel_page_admin-page-wc-admin-path--payments-welcome div.wp-menu-image::before {
 	font-family: 'WCPay' !important;
 	content: '\e900';
 	width: 24px;

--- a/includes/class-wc-calypso-bridge-payments.php
+++ b/includes/class-wc-calypso-bridge-payments.php
@@ -85,17 +85,21 @@ class WC_Calypso_Bridge_Payments {
 			return;
 		}
 
+		// Temporary until we have translations ready.
+		if ( get_locale() !== 'en_US' ) {
+			return;
+		}
+
 		if ( 'yes' === get_option( 'wc_calypso_bridge_payments_dismissed', 'no' ) ) {
 			return;
 		}
 
 		$menu_icon = 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjxzdmcKICAgdmVyc2lvbj0iMS4xIgogICBpZD0ic3ZnNjciCiAgIHNvZGlwb2RpOmRvY25hbWU9IndjcGF5X21lbnVfaWNvbi5zdmciCiAgIHdpZHRoPSI4NTIiCiAgIGhlaWdodD0iNjg0IgogICBpbmtzY2FwZTp2ZXJzaW9uPSIxLjEgKGM0ZThmOWUsIDIwMjEtMDUtMjQpIgogICB4bWxuczppbmtzY2FwZT0iaHR0cDovL3d3dy5pbmtzY2FwZS5vcmcvbmFtZXNwYWNlcy9pbmtzY2FwZSIKICAgeG1sbnM6c29kaXBvZGk9Imh0dHA6Ly9zb2RpcG9kaS5zb3VyY2Vmb3JnZS5uZXQvRFREL3NvZGlwb2RpLTAuZHRkIgogICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogIDxkZWZzCiAgICAgaWQ9ImRlZnM3MSIgLz4KICA8c29kaXBvZGk6bmFtZWR2aWV3CiAgICAgaWQ9Im5hbWVkdmlldzY5IgogICAgIHBhZ2Vjb2xvcj0iI2ZmZmZmZiIKICAgICBib3JkZXJjb2xvcj0iIzY2NjY2NiIKICAgICBib3JkZXJvcGFjaXR5PSIxLjAiCiAgICAgaW5rc2NhcGU6cGFnZXNoYWRvdz0iMiIKICAgICBpbmtzY2FwZTpwYWdlb3BhY2l0eT0iMC4wIgogICAgIGlua3NjYXBlOnBhZ2VjaGVja2VyYm9hcmQ9IjAiCiAgICAgc2hvd2dyaWQ9ImZhbHNlIgogICAgIGZpdC1tYXJnaW4tdG9wPSIwIgogICAgIGZpdC1tYXJnaW4tbGVmdD0iMCIKICAgICBmaXQtbWFyZ2luLXJpZ2h0PSIwIgogICAgIGZpdC1tYXJnaW4tYm90dG9tPSIwIgogICAgIGlua3NjYXBlOnpvb209IjI1NiIKICAgICBpbmtzY2FwZTpjeD0iLTg0Ljg1NzQyMiIKICAgICBpbmtzY2FwZTpjeT0iLTgzLjI5NDkyMiIKICAgICBpbmtzY2FwZTp3aW5kb3ctd2lkdGg9IjEzMTIiCiAgICAgaW5rc2NhcGU6d2luZG93LWhlaWdodD0iMTA4MSIKICAgICBpbmtzY2FwZTp3aW5kb3cteD0iMTE2IgogICAgIGlua3NjYXBlOndpbmRvdy15PSIyMDIiCiAgICAgaW5rc2NhcGU6d2luZG93LW1heGltaXplZD0iMCIKICAgICBpbmtzY2FwZTpjdXJyZW50LWxheWVyPSJzdmc2NyIgLz4KICA8cGF0aAogICAgIHRyYW5zZm9ybT0ic2NhbGUoLTEsIDEpIHRyYW5zbGF0ZSgtODUwLCAwKSIKICAgICBkPSJNIDc2OCw4NiBWIDU5OCBIIDg0IFYgODYgWiBtIDAsNTk4IGMgNDgsMCA4NCwtMzggODQsLTg2IFYgODYgQyA4NTIsMzggODE2LDAgNzY4LDAgSCA4NCBDIDM2LDAgMCwzOCAwLDg2IHYgNTEyIGMgMCw0OCAzNiw4NiA4NCw4NiB6IE0gMzg0LDEyOCB2IDQ0IGggLTg2IHYgODQgaCAxNzAgdiA0NCBIIDM0MCBjIC0yNCwwIC00MiwxOCAtNDIsNDIgdiAxMjggYyAwLDI0IDE4LDQyIDQyLDQyIGggNDQgdiA0NCBoIDg0IHYgLTQ0IGggODYgViA0MjggSCAzODQgdiAtNDQgaCAxMjggYyAyNCwwIDQyLC0xOCA0MiwtNDIgViAyMTQgYyAwLC0yNCAtMTgsLTQyIC00MiwtNDIgaCAtNDQgdiAtNDQgeiIKICAgICBmaWxsPSIjYTJhYWIyIgogICAgIGlkPSJwYXRoNjUiIC8+Cjwvc3ZnPgo=';
 
-		wc_admin_register_page( array(
+		$menu_data =  array(
 			'id'       => 'wc-calypso-bridge-payments-welcome-page',
 			'title'    => __( 'Payments', 'wc-calypso-bridge' ),
 			'path'     => '/payments-welcome',
-			'icon' => $menu_icon,
 			'position' => '55.7',
 			'nav_args'   => [
 				'title'        => __( 'WooCommerce Payments', 'wc-calypso-bridge' ),
@@ -103,22 +107,37 @@ class WC_Calypso_Bridge_Payments {
 				'menuId'       => 'plugins',
 				'is_top_level' => true,
 			],
-		) );
+		);
+
+		$is_calypso_menu_request = 0 === strpos( $_SERVER['REQUEST_URI'], '/?rest_route=%2Fwpcom%2Fv2%2Fadmin-menu' );
+
+		if ( $is_calypso_menu_request ) {
+			$menu_data[ 'icon' ] = $menu_icon;
+		}
+
+		wc_admin_register_page( $menu_data );
 
 		// Registering a top level menu via wc_admin_register_page doesn't work when the new
 		// nav is enabled. The new nav disabled everything, except the 'WooCommerce' menu.
 		// We need to register this menu via add_menu_page so that it doesn't become a child of
 		// WooCommerce menu.
-		if ( 'yes' === get_option('woocommerce_navigation_enabled', 'no') ) {
-			add_menu_page(
+		if ( 'yes' === get_option( 'woocommerce_navigation_enabled', 'no' ) ) {
+			$menu_with_nav_data = array(
 				__( 'Payments', 'wc-calypso-bridge' ),
 				__( 'Payments', 'wc-calypso-bridge' ),
 				'view_woocommerce_reports',
 				'admin.php?page=wc-admin&path=/payments-welcome',
 				null,
-				$menu_icon,
-				'55.7' // After WooCommerce & Product menu items.
 			);
+
+			if ( $is_calypso_menu_request ) {
+				array_push( $menu_with_nav_data, $menu_icon );
+			} else {
+				array_push( $menu_with_nav_data, null );
+			}
+
+			array_push( $menu_with_nav_data, 55.7 );
+			call_user_func_array( 'add_menu_page', $menu_with_nav_data );
 		}
 
 		// Add badge


### PR DESCRIPTION
It was discovered that ecom plan users users would have a different classname appended to menu. As such, the WCPay icon in `wc-payments.css` did not get applied and resulted in the following:

<img src="https://user-images.githubusercontent.com/3747241/127144979-565d1fe4-909f-4179-a9d1-a7b536676d71.png" width="400">

This PR would fix this problem by adding another full class path.

### Testing Instructions

1. Set up a new ecommerce plan site in WordPress.com
2. After setting up, revert the site (you can obtain the revert link in wpcom-dev-blogs)
2. Follow the guide in p90Yrv-2j7-p2 to transfer the site to atomic, obtain sftp credentials, and upload bridge to the site
3. Observe the payments icon displayed properly in wp-admin (if it's showing WooCommerce navigation, click on "Back to WordPress Dashboard")