### PR TITLE
Add checks for WooCommerce in Payments class

### DIFF
--- a/includes/class-wc-calypso-bridge-payments.php
+++ b/includes/class-wc-calypso-bridge-payments.php
@@ -35,7 +35,7 @@ class WC_Calypso_Bridge_Payments {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->init();
+		add_action( 'woocommerce_init', array( $this, 'init' ), 20 );
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-payments.php
+++ b/includes/class-wc-calypso-bridge-payments.php
@@ -42,14 +42,30 @@ class WC_Calypso_Bridge_Payments {
 	 * Include notes and initialize note hooks.
 	 */
 	public function init() {
-		add_action( 'rest_api_init', array( $this, 'register_routes' ), 20 );
-		add_action( 'admin_menu', array( $this, 'register_payments_welcome_page' ) );
-		add_action( 'current_screen', array( $this, 'enqueue_scripts_and_styles' ) );
+		if ( $this->is_woocommerce_valid() ) {
+			add_action( 'rest_api_init', array( $this, 'register_routes' ), 20 );
+			add_action( 'admin_menu', array( $this, 'register_payments_welcome_page' ) );
+			add_action( 'current_screen', array( $this, 'enqueue_scripts_and_styles' ) );
+		}
 	}
 
 	public function enqueue_scripts_and_styles() {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_payments_welcome_page_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_wc_payments_style' ) );
+	}
+
+	/**
+	 * Makes sure WooCommerce is installed and up to date.
+	 */
+	public function is_woocommerce_valid() {
+		return (
+			class_exists( 'woocommerce' ) &&
+			version_compare(
+				get_option( 'woocommerce_db_version' ),
+				WC_MIN_VERSION,
+				'>='
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
This PR adds a check for WooCommerce availability and minimum version before initializing Payments class.

### Testing Instructions

1. If testing in local, `WooCommerce Calypso Bridge Helper` switch to Biz plan to be able to deactivate WooCommerce. 
1. Deactivate WooCommerce.
2. Go to Pages > New.
3. Observe no fatal error.