### PR TITLE
Remove CSS fix for the Gutenberg CardBody component

### DIFF
--- a/assets/css/ecommerce.css
+++ b/assets/css/ecommerce.css
@@ -20,7 +20,3 @@
 	.components-tab-panel__tabs {
 	display: none;
 }
-
-.woocommerce-layout__main .components-scrollable {
-	overflow: unset;
-}

--- a/store-on-wpcom/assets/css/admin/store-on-wpcom.css
+++ b/store-on-wpcom/assets/css/admin/store-on-wpcom.css
@@ -1,3 +1,0 @@
-.woocommerce-layout__main .components-scrollable {
-    overflow: unset;
-}

--- a/store-on-wpcom/class-wc-calypso-bridge.php
+++ b/store-on-wpcom/class-wc-calypso-bridge.php
@@ -41,7 +41,6 @@ class WC_Calypso_Bridge {
 	public function init() {
 		if ( $this->is_woocommerce_valid() ) {
 			$this->includes();
-			add_action( 'admin_enqueue_scripts', array( $this, 'add_scripts' ) );
 
 			// Ensure wc-api-dev has already registered routes.
 			add_action( 'rest_api_init', array( $this, 'register_routes' ), 20 );
@@ -114,14 +113,6 @@ class WC_Calypso_Bridge {
 			$controller_instance = new $controller();
 			$controller_instance->register_routes();
 		}
-	}
-
-	/**
-	 * Add common scripts.
-	 */
-	public function add_scripts() {
-		$asset_path = self::$plugin_asset_path ? self::$plugin_asset_path : self::MU_PLUGIN_ASSET_PATH;
-		wp_enqueue_style( 'wp-calypso-bridge-store-on-wpcom-css', $asset_path . 'assets/css/admin/store-on-wpcom.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #726 

This PR removes CSS fix for the Gutenberg CardBody component as a permanent [fix](https://github.com/Automattic/wc-calypso-bridge/pull/710) was deployed in the latest Gutenberg (11.2)