### PR TITLE
Hide onboarding checklist in wp-admin

### DIFF
--- a/includes/woop.php
+++ b/includes/woop.php
@@ -30,7 +30,7 @@ function wc_calypso_bridge_woop_init() {
 	}
 
 	if ( is_admin() ) {
-		// require_once dirname( __FILE__ ) . '/woop/some-admin-feature.php';.
+		require_once dirname( __FILE__ ) . '/woop/hide-onboarding.php';
 	} else {
 		// require_once dirname( __FILE__ ) . '/woop/some-feature.php';.
 	}

--- a/includes/woop/hide-onboarding.php
+++ b/includes/woop/hide-onboarding.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Hide onboarding flows.
+ *
+ * @since 1.8.1
+ * @package WC_Calypso_Bridge
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+// Hide the 'WooCommerce Setup' card from wp-admin.
+add_filter( 'pre_option_woocommerce_task_list_hidden', 'wc_calypso_bridge_return_yes' );


### PR DESCRIPTION
Hides the onboarding setup checklist from wp-admin.

Testing Setup checklist:
- Enable woop with a define in your wp-config.php `define( 'WPCOM_ENABLE_WOOP', true );`
- Load https://localhost/wp-admin/index.php with and without the define set. When set, the onboarding checklist should not be shown.

Before:
![Screenshot 2021-08-24 at 16-21-27 Dashboard ‹ Test — WordPress](https://user-images.githubusercontent.com/811776/130566407-976a55c6-1e71-4f61-8ead-f1a2341ecab4.png)


After:
![Screenshot 2021-08-24 at 16-20-53 Dashboard ‹ Test — WordPress](https://user-images.githubusercontent.com/811776/130566374-d41ecb6c-b4d4-40f9-8ef2-4e6894169749.png)

Related: https://github.com/Automattic/wp-calypso/issues/55422