### PR TITLE
Fix tests, update tests/bootstrap.php to match woocommerce changes

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,7 +7,6 @@
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
 	verbose="true"
-	syntaxCheck="true"
 	>
 	<testsuites>
 		<testsuite name="WooCommerce Calypso Bridge Test Suite">

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,8 @@
 <?php
 /**
  * WooCommerce Calypso Bridge Unit Tests Bootstrap
+ *
+ * Loosely based on woocommerce/tests/legacy/bootstrap.php.
  */
 class WC_Calypso_Bridge_Unit_Tests_Bootstrap {
 
@@ -44,6 +46,10 @@ class WC_Calypso_Bridge_Unit_Tests_Bootstrap {
 		}
 		$this->wp_tests_dir = getenv( 'WP_TESTS_DIR' ) ? getenv( 'WP_TESTS_DIR' ) : '/tmp/wordpress-tests-lib';
 
+		$this->register_autoloader_for_testing_tools();
+
+		$this->initialize_code_hacker();
+
 		// load test function so tests_add_filter() is available
 		require_once $this->wp_tests_dir . '/includes/functions.php';
 
@@ -64,12 +70,17 @@ class WC_Calypso_Bridge_Unit_Tests_Bootstrap {
 
 		// load extra filters
 		require_once $this->plugin_dir . '/includes/class-wc-calypso-bridge-filters.php';
+
+		// re-initialize dependency injection, this needs to be the last operation after everything else is in place.
+		$this->initialize_dependency_injection();
 	}
 
 	/**
 	 * Load WooCommerce.
 	 */
 	public function load_wc() {
+		define( 'WC_TAX_ROUNDING_MODE', 'auto' );
+		define( 'WC_USE_TRANSACTIONS', false );
 		require_once $this->wc_dir . '/woocommerce.php';
 	}
 
@@ -83,13 +94,18 @@ class WC_Calypso_Bridge_Unit_Tests_Bootstrap {
 
 	/**
 	 * Install WooCommerce after the test environment and WC have been loaded.
+	 *
+	 * wc-calypso-bridge: fix include uninstall dir.
 	 */
 	public function install_wc() {
-
 		// Clean existing install first.
 		define( 'WP_UNINSTALL_PLUGIN', true );
 		define( 'WC_REMOVE_ALL_DATA', true );
 		include $this->wc_dir . '/uninstall.php';
+
+		// Initialize the WC API extensions.
+		\Automattic\WooCommerce\Admin\Install::create_tables();
+		\Automattic\WooCommerce\Admin\Install::create_events();
 
 		WC_Install::install();
 
@@ -111,21 +127,22 @@ class WC_Calypso_Bridge_Unit_Tests_Bootstrap {
 	 * If needed, these can also be shipped with the dev plugin and a local copy can be called.
 	 */
 	public function includes() {
-		// framework
+		// framework.
 		require_once $this->wc_tests_dir . '/framework/class-wc-unit-test-factory.php';
 		require_once $this->wc_tests_dir . '/framework/class-wc-mock-session-handler.php';
 		require_once $this->wc_tests_dir . '/framework/class-wc-mock-wc-data.php';
 		require_once $this->wc_tests_dir . '/framework/class-wc-mock-wc-object-query.php';
+		require_once $this->wc_tests_dir . '/framework/class-wc-mock-payment-gateway.php';
 		require_once $this->wc_tests_dir . '/framework/class-wc-payment-token-stub.php';
 		require_once $this->wc_tests_dir . '/framework/vendor/class-wp-test-spy-rest-server.php';
 
-		// test cases
+		// test cases.
 		require_once $this->wc_tests_dir . '/includes/wp-http-testcase.php';
 		require_once $this->wc_tests_dir . '/framework/class-wc-unit-test-case.php';
 		require_once $this->wc_tests_dir . '/framework/class-wc-api-unit-test-case.php';
 		require_once $this->wc_tests_dir . '/framework/class-wc-rest-unit-test-case.php';
 
-		// Helpers
+		// Helpers.
 		require_once $this->wc_tests_dir . '/framework/helpers/class-wc-helper-product.php';
 		require_once $this->wc_tests_dir . '/framework/helpers/class-wc-helper-coupon.php';
 		require_once $this->wc_tests_dir . '/framework/helpers/class-wc-helper-fee.php';
@@ -135,10 +152,97 @@ class WC_Calypso_Bridge_Unit_Tests_Bootstrap {
 		require_once $this->wc_tests_dir . '/framework/helpers/class-wc-helper-shipping-zones.php';
 		require_once $this->wc_tests_dir . '/framework/helpers/class-wc-helper-payment-token.php';
 		require_once $this->wc_tests_dir . '/framework/helpers/class-wc-helper-settings.php';
+
+		// Traits.
+		require_once $this->wc_tests_dir . '/framework/traits/trait-wc-rest-api-complex-meta.php';
+	}
+
+
+	/**
+	 * Register autoloader for the files in the 'tests/tools' directory, for the root namespace 'Automattic\WooCommerce\Testing\Tools'.
+	 *
+	 * wc-calpso-bridge: fixed base_dir.
+	 */
+	protected static function register_autoloader_for_testing_tools() {
+		return spl_autoload_register(
+			function ( $class ) {
+				$prefix   = 'Automattic\\WooCommerce\\Testing\\Tools\\';
+				$base_dir = dirname( $this->plugin_dir ) . '/woocommerce/tests/Tools/';
+				$len      = strlen( $prefix );
+				if ( strncmp( $prefix, $class, $len ) !== 0 ) {
+					// no, move to the next registered autoloader.
+					return;
+				}
+				$relative_class = substr( $class, $len );
+				$file           = $base_dir . str_replace( '\\', '/', $relative_class ) . '.php';
+				if ( ! file_exists( $file ) ) {
+					throw new \Exception( 'Autoloader for unit tests: file not found: ' . $file );
+				}
+				require $file;
+			}
+		);
 	}
 
 	/**
-	 * Gets the single class instance.
+	 * Initialize the code hacker.
+	 *
+	 * @throws Exception Error when initializing one of the hacks.
+	 *
+	 * wc-calypso-bridge: fixed paths to point at $this->wc_tests_dir.
+	 */
+	private function initialize_code_hacker() {
+		CodeHacker::initialize( array( $this->wc_tests_dir . '/../../includes/' ) );
+
+		$replaceable_functions = include_once $this->wc_tests_dir . '/mockable-functions.php';
+		if ( ! empty( $replaceable_functions ) ) {
+			FunctionsMockerHack::initialize( $replaceable_functions );
+			CodeHacker::add_hack( FunctionsMockerHack::get_hack_instance() );
+		}
+
+		$mockable_static_classes = include_once $this->wc_tests_dir . '/classes-with-mockable-static-methods.php';
+		if ( ! empty( $mockable_static_classes ) ) {
+			StaticMockerHack::initialize( $mockable_static_classes );
+			CodeHacker::add_hack( StaticMockerHack::get_hack_instance() );
+		}
+
+		CodeHacker::add_hack( new BypassFinalsHack() );
+
+		CodeHacker::enable();
+	}
+
+	/**
+	 * Re-initialize the dependency injection engine.
+	 *
+	 * The dependency injection engine has been already initialized as part of the Woo initialization, but we need
+	 * to replace the registered read-only container with a fully configurable one for testing.
+	 * To this end we hack a bit and use reflection to grab the underlying container that the read-only one stores
+	 * in a private property.
+	 *
+	 * Additionally, we replace the legacy/function proxies with mockable versions to easily replace anything
+	 * in tests as appropriate.
+	 *
+	 * @throws \Exception The Container class doesn't have a 'container' property.
+	 */
+	private function initialize_dependency_injection() {
+		try {
+			$inner_container_property = new \ReflectionProperty( \Automattic\WooCommerce\Container::class, 'container' );
+		} catch ( ReflectionException $ex ) {
+			throw new \Exception( "Error when trying to get the private 'container' property from the " . \Automattic\WooCommerce\Container::class . ' class using reflection during unit testing bootstrap, has the property been removed or renamed?' );
+		}
+
+		$inner_container_property->setAccessible( true );
+		$inner_container = $inner_container_property->getValue( wc_get_container() );
+
+		$inner_container->replace( LegacyProxy::class, MockableLegacyProxy::class );
+		$inner_container->reset_all_resolved();
+
+		$GLOBALS['wc_container'] = $inner_container;
+	}
+
+	/**
+	 * Get the single class instance.
+	 *
+	 * @return WC_Calypso_Bridge_Unit_Tests_Bootstrap
 	 */
 	public static function instance() {
 		if ( is_null( self::$instance ) ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -173,11 +173,12 @@ class WC_Calypso_Bridge_Unit_Tests_Bootstrap {
 	 *
 	 * wc-calpso-bridge: fixed base_dir.
 	 */
-	protected static function register_autoloader_for_testing_tools() {
+	protected function register_autoloader_for_testing_tools() {
+		$plugin_dir = $this->plugin_dir;
 		return spl_autoload_register(
-			function ( $class ) {
+			function ( $class ) use ( $plugin_dir ) {
 				$prefix   = 'Automattic\\WooCommerce\\Testing\\Tools\\';
-				$base_dir = dirname( $this->plugin_dir ) . '/woocommerce/tests/Tools/';
+				$base_dir = dirname( $plugin_dir ) . '/woocommerce/tests/Tools/';
 				$len      = strlen( $prefix );
 				if ( strncmp( $prefix, $class, $len ) !== 0 ) {
 					// no, move to the next registered autoloader.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -171,7 +171,7 @@ class WC_Calypso_Bridge_Unit_Tests_Bootstrap {
 	/**
 	 * Register autoloader for the files in the 'tests/tools' directory, for the root namespace 'Automattic\WooCommerce\Testing\Tools'.
 	 *
-	 * wc-calpso-bridge: fixed base_dir.
+	 * wc-calypso-bridge: fixed base_dir.
 	 */
 	protected function register_autoloader_for_testing_tools() {
 		$plugin_dir = $this->plugin_dir;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,6 +4,17 @@
  *
  * Loosely based on woocommerce/tests/legacy/bootstrap.php.
  */
+
+use Automattic\WooCommerce\Proxies\LegacyProxy;
+use Automattic\WooCommerce\Testing\Tools\CodeHacking\CodeHacker;
+use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\StaticMockerHack;
+use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\FunctionsMockerHack;
+use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\BypassFinalsHack;
+use Automattic\WooCommerce\Testing\Tools\DependencyManagement\MockableLegacyProxy;
+
+/**
+ * Class WC_Calypso_Bridge_Unit_Tests_Bootstrap
+ */
 class WC_Calypso_Bridge_Unit_Tests_Bootstrap {
 
 	/** @var WC_Calypso_Bridge_Unit_Tests_Bootstrap instance */
@@ -156,7 +167,6 @@ class WC_Calypso_Bridge_Unit_Tests_Bootstrap {
 		// Traits.
 		require_once $this->wc_tests_dir . '/framework/traits/trait-wc-rest-api-complex-meta.php';
 	}
-
 
 	/**
 	 * Register autoloader for the files in the 'tests/tools' directory, for the root namespace 'Automattic\WooCommerce\Testing\Tools'.


### PR DESCRIPTION
This PR updates the calypso-bridge bootstrap with new loading logic from [woocommerce](https://github.com/woocommerce/woocommerce/blob/trunk/tests/legacy/bootstrap.php).

Let me know if this isn't the right approach but it looks like this is where we got the original bootstrapping logic from (modified to include our own tests once upstream test framework is loaded.

Tests are currently failing due to changes to woocommerce and movement of legacy code. 

e.g. https://travis-ci.org/github/Automattic/wc-calypso-bridge/builds/774724440

#### Before:
![before](https://user-images.githubusercontent.com/811776/131074670-a67b0285-c817-48ca-a3fa-2a718599959e.png)

#### After:
![after](https://user-images.githubusercontent.com/811776/131074676-799a074b-19fa-483c-a402-7a42584b47bc.png)

#### Testing instructions:

You need mysql running locally. Personally I'm using [mysql from ganon](https://github.com/Automattic/ganon/blob/ac81af0e363807f2ac87fd628bc4983933e0bbbb/docker-compose.yml#L9) but any mysql instance on localhost should work for this setup.

```
# Cleanup previous install attempts
rm -rf /tmp/wordpress-tests-lib /tmp/wordpress
mysql -h127.0.0.1 -P3306 -uroot -proot -e"drop database wordpress_tests"

# Run the setup install process, installs into /tmp and a database named wordpress_tests accessed through the loopback
./bin/install-wp-tests.sh wordpress_tests root root 127.0.0.1:3306
```

On my system, in order to get the woocommerce `npm install` command to successfully execute in install-wp-tests.sh I needed this patch:

```diff
diff --git a/bin/install-wp-tests.sh b/bin/install-wp-tests.sh
index 70c150b..892db6b 100755
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -181,6 +181,8 @@ install_deps() {
 
        # Bring in WooCommerce Core dependencies
        cd "woocommerce"
+       source /usr/share/nvm/nvm.sh
+       nvm use "lts/*"
        npm install
        composer install --no-dev
```

If you have the right version of node installed you probably won't need this (12 and 14 seem to work, 16 fails). I'm aware this is less than ideal but you only need to run the install script successfully one time (if you're /tmp doesn't get cleared on reboot!) and fixing this will require a fair bit of refactoring of the install script to allow more diverse setups. I also think it's worth dockerizing this but taking a look into that yesterday I decided this isn't the PR for that.

To run the tests
```
./vendor/bin/phpunit
```