### PR TITLE
Hide theme onboarding step

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,3 +24,8 @@ addFilter('woocommerce_admin_pages_list', 'wc-calypso-bridge', (pages) => {
 
 	return pages;
 });
+
+// Remove theme selection step from onboarding per https://wp.me/pNEWy-e9X#comment-53446
+addFilter( 'woocommerce_admin_profile_wizard_steps', 'woocommerce-admin', ( steps ) => {
+	return steps.filter( ( step ) => step.key !== 'theme' );
+} );


### PR DESCRIPTION
Hide the theme selection onboarding step.

Premium themes are being retired: pNEWy-e9X-p2#comment-53446

Testing:
- Visit the setup wizard in wc-admin: https://localhost/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard
- Theme step should be hidden with this PR applied

Before:
![Screenshot 2021-08-30 at 14-51-16 Setup Wizard ‹ WooCommerce ‹ test — WooCommerce](https://user-images.githubusercontent.com/811776/131286843-78e66746-8a80-4aad-8bb3-e66601a9a0a5.png)

After:
![Screenshot 2021-08-30 at 14-50-43 Setup Wizard ‹ WooCommerce ‹ test — WooCommerce](https://user-images.githubusercontent.com/811776/131286830-43cd6f52-3374-49f8-b0ad-c5343f079752.png)

Fixes https://github.com/Automattic/wp-calypso/issues/55406
