### PR TITLE
Add woop php base

### DIFF
--- a/includes/woop.php
+++ b/includes/woop.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Woo on Plans.
+ *
+ * @since 1.8.1
+ * @package WC_Calypso_Bridge
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Init woop.
+ *
+ * @return void
+ */
+function wc_calypso_bridge_woop_init() {
+	// Gate Woop behind feature flag
+	if ( ! defined( 'WPCOM_ENABLE_WOOP' ) ) {
+		return;
+	}
+
+	// Don't load mods in cronjobs.
+	if ( defined( 'DOING_CRON' ) ) {
+		return;
+	}
+
+	// Ensure a valid Woo install is installed.
+	if ( ! class_exists( 'woocommerce' ) || ! version_compare( get_option( 'woocommerce_db_version' ), WC_MIN_VERSION, '>=' ) ) {
+		return;
+	}
+
+	if ( is_admin() ) {
+		// require_once dirname( __FILE__ ) . '/woop/some-admin-feature.php';.
+	} else {
+		// require_once dirname( __FILE__ ) . '/woop/some-feature.php';.
+	}
+}
+add_action( 'plugins_loaded', 'wc_calypso_bridge_woop_init' );

--- a/includes/yesno.php
+++ b/includes/yesno.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Yes / No Functions for use in WC option filters.
+ *
+ * @since 1.8.1
+ * @package WC_Calypso_Bridge
+ */
+
+/**
+ * Always return 'yes'.
+ *
+ * @return string yes
+ */
+function wc_calypso_bridge_return_yes() {
+	return 'yes';
+}
+
+/**
+ * Always returns 'no'.
+ *
+ * @return string no
+ */
+function wc_calypso_bridge_return_no() {
+	return 'no';
+}

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -51,6 +51,9 @@ if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_plan' ) ) {
 	}
 }
 
+// Load yesno helper functions.
+require_once dirname( __FILE__ ) . '/includes/yesno.php';
+
 // Filters we want to add for ecommerce plan.
 require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-filters.php';
 add_action( 'init', array( 'WC_Calypso_Bridge_Filters', 'get_instance' ) );
@@ -68,9 +71,13 @@ require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-crowdsigna
 // Load shared stuff for both ecommerce and business plan.
 require_once dirname( __FILE__ ) . '/class-wc-calypso-bridge-shared.php';
 
-// Load WCPay in core experiment
+// Load WCPay in core experiment.
 require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-payments.php';
 
+// Load Woo on Plans.
+require_once dirname( __FILE__ ) . '/includes/woop.php';
+
+// Load the store-on-wpcom calypso-bridge for business plans.
 if ( ! wc_calypso_bridge_is_ecommerce_plan() ) {
 	include_once dirname( __FILE__ ) . '/store-on-wpcom/class-wc-calypso-bridge.php';
 	return;
@@ -78,7 +85,7 @@ if ( ! wc_calypso_bridge_is_ecommerce_plan() ) {
 
 if ( ! function_exists( 'wc_calypso_bridge_init' ) ) {
 	/**
-	 * Loads language files for the plugin
+	 * Loads language files for the plugin.
 	 */
 	function wc_calypso_bridge_init() {
 		$plugin_path = dirname( __FILE__ ) . '/languages';


### PR DESCRIPTION
Creates a space to organize Woo on Plans php code.

Some original review took place in https://github.com/Automattic/wc-calypso-bridge/pull/729 before we had the woop branch.