### PR TITLE
Run travis against merges into woop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ script:
 branches:
   only:
     - master
-  
+    - woop


### PR DESCRIPTION
Ensure CI runs against PR's wanting to merge into the woop branch.

The Woo on Plans pod is working out of the "woop" feature branch. We'll periodically merge this branch into master for deploys. https://github.com/Automattic/wp-calypso/issues/55820

In the meantime I want to ensure phpcs and unittests are run on PR's before they get merged into woop so problems are picked up early.