### PR TITLE
Disable setup-wizard redirect on plugin activation

### DIFF
--- a/includes/woop/hide-onboarding.php
+++ b/includes/woop/hide-onboarding.php
@@ -10,3 +10,9 @@ defined( 'ABSPATH' ) || exit;
 
 // Hide the 'WooCommerce Setup' card from wp-admin.
 add_filter( 'pre_option_woocommerce_task_list_hidden', 'wc_calypso_bridge_return_yes' );
+
+// Disable the setup wizard
+add_filter( 'woocommerce_enable_setup_wizard', '__return_false' );
+
+// Disable the setup wizard redirect on plugin activation
+add_filter( 'woocommerce_prevent_automatic_wizard_redirect', '__return_true' );

--- a/includes/woop/hide-onboarding.php
+++ b/includes/woop/hide-onboarding.php
@@ -11,5 +11,5 @@ defined( 'ABSPATH' ) || exit;
 // Hide the 'WooCommerce Setup' card from wp-admin.
 add_filter( 'pre_option_woocommerce_task_list_hidden', 'wc_calypso_bridge_return_yes' );
 
-// Disable the setup wizard redirect on plugin activation
+// Disable the setup wizard redirect on plugin activation.
 add_filter( 'woocommerce_enable_setup_wizard', '__return_false' );

--- a/includes/woop/hide-onboarding.php
+++ b/includes/woop/hide-onboarding.php
@@ -11,8 +11,5 @@ defined( 'ABSPATH' ) || exit;
 // Hide the 'WooCommerce Setup' card from wp-admin.
 add_filter( 'pre_option_woocommerce_task_list_hidden', 'wc_calypso_bridge_return_yes' );
 
-// Disable the setup wizard
-add_filter( 'woocommerce_enable_setup_wizard', '__return_false' );
-
 // Disable the setup wizard redirect on plugin activation
-add_filter( 'woocommerce_prevent_automatic_wizard_redirect', '__return_true' );
+add_filter( 'woocommerce_enable_setup_wizard', '__return_false' );


### PR DESCRIPTION
Disables the redirect to site-wizard that takes place on plugin activation in [wc-admin](https://github.com/woocommerce/woocommerce-admin/blob/8c3b4a0ca95af306f5fecf92b2b99c6f252a6f8e/src/Features/Onboarding.php#L145).

### Testing instructions:

- Start with a fresh wp install for each test, this redirect only gets applied on the first activation after WooCommerce installs its database tables and sets up basic options.
- `ganon down; docker volume rm ganon_mysql; ganon up -d` (db reset)
- Ensure bridge is loaded (via wpcomsh being active)
- Ensure woop features are [flagged on](https://github.com/Automattic/wc-calypso-bridge/blob/4728e9212d38642094171bcafbd2484aef6f2650/includes/woop.php#L18) in your wp-config.php
- Activate WooCommerce observe redirect or not to the setup wizard.

### Before:

https://user-images.githubusercontent.com/811776/131629591-42a03dbe-7d84-428a-85cc-a8998aa372d9.mp4

### After:

https://user-images.githubusercontent.com/811776/131629095-9865352f-f7db-4f55-96b7-05f9441c4ee1.mp4

Relates to: https://github.com/Automattic/wp-calypso/issues/55422

