### PR TITLE
Auto-skip the profile setup-wizard on wc-admin navigation

### DIFF
--- a/includes/woop/hide-onboarding.php
+++ b/includes/woop/hide-onboarding.php
@@ -13,3 +13,15 @@ add_filter( 'pre_option_woocommerce_task_list_hidden', 'wc_calypso_bridge_return
 
 // Disable the setup wizard redirect on plugin activation.
 add_filter( 'woocommerce_enable_setup_wizard', '__return_false' );
+
+/**
+ * Skip the onboarding profile setup wizard when navigating to wc-admin for the first time.
+ *
+ * Preset the onboarding profile data to skipped. This is the same as clicking "Skip" in the first step of the setup-wizard.
+ *
+ * @return array
+ */
+function wc_calypso_bridge_skip_onboarding() {
+	return array( 'skipped' => 1 );
+}
+add_filter( 'pre_option_woocommerce_onboarding_profile', 'wc_calypso_bridge_skip_onboarding' );


### PR DESCRIPTION
Follow up on #738.

Auto-skips the profile setup-wizard redirect that happens when navigating to most wc-admin screens before completing the setup wizard.

### Testing Instructions

- Starting with a new install of WordPress
- Ensure WooCommerce is active
- Ensure bridge is loaded (via wpcomsh being active)
- Ensure woop features are [flagged on](https://github.com/Automattic/wc-calypso-bridge/blob/4728e9212d38642094171bcafbd2484aef6f2650/includes/woop.php#L18) in your wp-config.php
- If you've already completed the profile step, delete the wp_option: `woocommerce_onboarding_profile`
- Navigate to the WooCommerce dashboard, you should be redirected to the setup-wizard.
- Go back to a non wc-admin screen, e.g. wp-admin works fine.
- Delete the wp_option again.
- Apply the PR
- Navigate to the WooCommerce dashboard, you should no longer be redirected to the setup-wizard.

### Before

https://user-images.githubusercontent.com/811776/131632943-bd01ea23-f646-4a1d-9c63-d7e52bc8c3dd.mp4

### After

https://user-images.githubusercontent.com/811776/131632973-8c3da646-8973-425e-8d3f-5920bdda59db.mp4

Relates to: https://github.com/Automattic/wp-calypso/issues/55422