### PR TITLE
Add docker for running phpunit / phpcs locally

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "wp-coding-standards/wpcs": "1.1.0",
     "woocommerce/woocommerce-sniffs": "*",
     "wimg/php-compatibility": "9.0.0",
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0"
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+    "yoast/phpunit-polyfills": "1.0.1"
   },
   "scripts": {
     "test": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b5120eddb9c75c0d4a5c4ede74933b6",
+    "content-hash": "bef2eea6fcbf17fdfda47fa435e0d55c",
     "packages": [
         {
             "name": "composer/installers",
@@ -2117,6 +2117,69 @@
                 "wiki": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki"
             },
             "time": "2018-09-10T17:04:05+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "f014fb21c2b0038fd329515d59025af42fb98715"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/f014fb21c2b0038fd329515d59025af42fb98715",
+                "reference": "f014fb21c2b0038fd329515d59025af42fb98715",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.3.0",
+                "yoast/yoastcs": "^2.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2021-08-09T16:28:08+00:00"
         }
     ],
     "aliases": [],
@@ -2126,5 +2189,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,45 @@
+FROM alpine:3.12
+
+# Install deps
+RUN apk -q --update --no-cache add tini shadow less git subversion nodejs npm \
+	composer ncurses bash mysql-client mariadb-connector-c curl python3 py3-pip g++ make \
+    php7 php7-pecl-apcu php7-bcmath php7-bz2 php7-ctype php7-curl php7-dom \
+    php7-ftp php7-gd php7-iconv php7-json php7-mbstring php7-mysqli \
+    php7-pecl-oauth php7-opcache php7-openssl php7-pcntl php7-pdo php7-pdo_mysql \
+    php7-phar php7-session php7-simplexml php7-tokenizer php7-pecl-xdebug php7-xml \
+    php7-xmlwriter php7-zip php7-zlib
+
+# Install wp-cli
+RUN wget -q -O /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && \
+    chmod +x /usr/local/bin/wp
+
+# Install WordPress
+run mkdir -p /tmp && \
+	cd /tmp && \
+	wget -q https://wordpress.org/nightly-builds/wordpress-latest.zip && \
+    unzip -q wordpress-latest.zip
+
+# Don't use mysql extension (copied from install-wp-tests.sh)
+RUN wget -q -O /tmp/wordpress/wp-content/db.php https://raw.github.com/markoheijnen/wp-mysqli/master/db.php
+
+# Install WP Tests lib and data
+RUN mkdir -p /tmp/wordpress-tests-lib
+RUN svn export https://develop.svn.wordpress.org/trunk/tests/phpunit/includes/ /tmp/wordpress-tests-lib/includes
+RUN svn export https://develop.svn.wordpress.org/trunk/tests/phpunit/data/ /tmp/wordpress-tests-lib/data
+RUN svn export https://develop.svn.wordpress.org/trunk/wp-tests-config-sample.php /tmp/wordpress-tests-lib/wp-tests-config.php
+RUN sed -i "s:dirname( __FILE__ ) . '/src/':'/tmp/wordpress/':" /tmp/wordpress-tests-lib/wp-tests-config.php
+RUN sed -i "s/youremptytestdbnamehere/wordpress_tests/" /tmp/wordpress-tests-lib/wp-tests-config.php
+RUN sed -i "s/yourusernamehere/wordpress_tests/" /tmp/wordpress-tests-lib/wp-tests-config.php
+RUN sed -i "s/yourpasswordhere/wordpress_tests/" /tmp/wordpress-tests-lib/wp-tests-config.php
+RUN sed -i "s|localhost|mysql:3306|" /tmp/wordpress-tests-lib/wp-tests-config.php
+
+# Install WooCommerce
+RUN git clone --depth 1 https://github.com/woocommerce/woocommerce.git /tmp/wordpress/wp-content/plugins/woocommerce
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV SKIP_UPDATE_TEXTDOMAINS=true
+RUN cd /tmp/wordpress/wp-content/plugins/woocommerce && npm install
+RUN cd /tmp/wordpress/wp-content/plugins/woocommerce && composer install --no-dev
+
+WORKDIR /wc-calypso-bridge
+ENTRYPOINT ["tini", "--"]
+CMD [ "bash" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.12
 
 # Install deps
 RUN apk -q --update --no-cache add tini shadow less git subversion nodejs npm \
-	composer ncurses bash mysql-client mariadb-connector-c curl python3 py3-pip g++ make \
+	composer ncurses mysql-client mariadb-connector-c curl python3 py3-pip g++ make \
     php7 php7-pecl-apcu php7-bcmath php7-bz2 php7-ctype php7-curl php7-dom \
     php7-ftp php7-gd php7-iconv php7-json php7-mbstring php7-mysqli \
     php7-pecl-oauth php7-opcache php7-openssl php7-pcntl php7-pdo php7-pdo_mysql \
@@ -40,6 +40,6 @@ ENV SKIP_UPDATE_TEXTDOMAINS=true
 RUN cd /tmp/wordpress/wp-content/plugins/woocommerce && npm install
 RUN cd /tmp/wordpress/wp-content/plugins/woocommerce && composer install --no-dev
 
-WORKDIR /wc-calypso-bridge
+WORKDIR /tmp/wordpress/wp-content/plugins/wc-calypso-bridge
 ENTRYPOINT ["tini", "--"]
-CMD [ "bash" ]
+CMD [ "sh" ]

--- a/docker/docker-compose
+++ b/docker/docker-compose
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+
+command docker-compose -f "$DIR"/docker-compose.yml "$@"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,24 @@
+# https://docs.docker.com/compose/compose-file/
+version: '3.8'
+
+volumes:
+    mysql:
+
+services:
+    mysql:
+        image: mariadb
+        volumes:
+            - mysql:/var/lib/mysql
+        environment:
+            MYSQL_DATABASE: wordpress_tests
+            MYSQL_USER: wordpress_tests
+            MYSQL_PASSWORD: wordpress_tests
+            MYSQL_ROOT_PASSWORD: root
+
+    wordpress:
+        build:
+            context: ./
+        volumes:
+            - ../:/tmp/wordpress/wp-content/plugins/wc-calypso-bridge:ro
+        depends_on:
+            - 'mysql'

--- a/docker/phpcs
+++ b/docker/phpcs
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+
+command docker-compose -f "$DIR"/docker-compose.yml run --rm wordpress \
+	/tmp/wordpress/wp-content/plugins/wc-calypso-bridge/vendor/bin/phpcs \
+	--standard=/tmp/wordpress/wp-content/plugins/wc-calypso-bridge/phpcs.xml.dist \
+	--encoding=utf-8 -n -p \
+	/tmp/wordpress/wp-content/plugins/wc-calypso-bridge "${@}"

--- a/docker/phpcs-changed
+++ b/docker/phpcs-changed
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+
+changed=$(cd "$DIR"/../ && git diff --name-only --diff-filter=ACMR master | grep '\.php$')
+
+if [ -z "$changed" ]; then
+	echo "No files changed."
+else
+	echo "Running phpcs on changed files:"
+	printf '%s\n' "$changed"
+	changed=$(echo "$changed" | awk '{print "/tmp/wordpress/wp-content/plugins/wc-calypso-bridge/"$0}' ORS=' ')
+	command docker-compose -f "$DIR"/docker-compose.yml run --rm wordpress \
+		/tmp/wordpress/wp-content/plugins/wc-calypso-bridge/vendor/bin/phpcs \
+		--standard=/tmp/wordpress/wp-content/plugins/wc-calypso-bridge/phpcs.xml.dist \
+		--encoding=utf-8 -n -p \
+		$changed "${@}"
+fi

--- a/docker/phpunit
+++ b/docker/phpunit
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+
+command docker-compose -f "$DIR"/docker-compose.yml run --rm wordpress \
+	/tmp/wordpress/wp-content/plugins/wc-calypso-bridge/vendor/bin/phpunit \
+	-c /tmp/wordpress/wp-content/plugins/wc-calypso-bridge/phpunit.xml \
+	"$@"

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -1,0 +1,33 @@
+# Running phpcs and phpunit with docker & docker-compose
+
+## phpunit
+
+To run the whole suite:
+
+```
+./docker/phpunit
+```
+
+Command arguments pass through:
+
+```
+./docker/phpunit --filter test_remove_paid_extension_upsells
+```
+
+## phpcs
+
+To lint the whole plugin:
+
+```
+./docker/phpcs
+```
+
+Only what's changed from master:
+
+```
+./docker/phpcs-changed
+```
+
+## Mac OSX & Windows
+
+On Docker Desktop for Mac & Windows you will need to add this plugin directory to your virtual machine directory shares.


### PR DESCRIPTION
This PR adds a `docker` directory and some helper scripts to run `phpunit` and `phpcs` locally during development.

- Made the implicit dependency on yoast phpunit polyfills explicit per https://core.trac.wordpress.org/changeset/51598.
- Replicated most of `./bin/install-wp-test.sh` in the Dockerfile directly. This worked out because the all the required db bootstrapping is done by wp tests on startup and database creation is handled by the mysql image in its own entrypoint.
- Added `docker-compose.yml` to manage mysql / wordpress `depends_on` dependency for running tests.
- Added `phpunit`, `phpcs`, `phpcs-changed` scripts. There is also a `docker-compose` script but you shouldn't need it unless you want to run a `down` command to clear things. `phpcs-changed` was added due to there being a lot of pre-existing lint errors.
- Added readme.md to outline usage / note about getting things running in osx.

#### Testing:
```
./docker/docker-compose build
./docker/phpunit
./docker/phpcs
./docker/phpcs-changed
```

#### Usage:
![docker-after](https://user-images.githubusercontent.com/811776/132821842-4d58d516-37a6-4218-aac4-c414d1180023.png)
