### PR TITLE
Move woop behind site sticker using Atomic persistent data

### DIFF
--- a/includes/woop.php
+++ b/includes/woop.php
@@ -14,13 +14,17 @@ defined( 'ABSPATH' ) || exit;
  * @return void
  */
 function wc_calypso_bridge_woop_init() {
-	// Gate Woop behind feature flag.
-	if ( ! defined( 'WPCOM_ENABLE_WOOP' ) ) {
+	// Don't load mods in cronjobs.
+	if ( defined( 'DOING_CRON' ) ) {
 		return;
 	}
 
-	// Don't load mods in cronjobs.
-	if ( defined( 'DOING_CRON' ) ) {
+	if ( ! class_exists( 'Atomic_Persistent_Data' ) ) {
+		return;
+	}
+
+	// Gate Woo on plans behind the site sticker "woop" feature flag.
+	if ( ! ( new Atomic_Persistent_Data() )->site_sticker_woop ?? false ) {
 		return;
 	}
 


### PR DESCRIPTION
This PR replaces the `WPCOM_ENABLE_WOOP` defined constant with a lookup against persistent data site stickers.

The woop site sticker is being added and synced to persistent data using ~D66393-code~ D66496-code. 

For testing locally you'll now need to replace the `WPCOM_ENABLE_WOOP` define in wp-config.php with a class stub:

```
class Atomic_Persistent_Data {
	public $site_sticker_woop = true;
	public function __get( $name ) {
		return null;
	}
}
```