### PR TITLE
Defualt the new navigation to on

### DIFF
--- a/includes/woop.php
+++ b/includes/woop.php
@@ -36,6 +36,7 @@ function wc_calypso_bridge_woop_init() {
 	if ( is_admin() ) {
 		require_once dirname( __FILE__ ) . '/woop/hide-onboarding.php';
 		require_once dirname( __FILE__ ) . '/woop/hide-extensions.php';
+		require_once dirname( __FILE__ ) . '/woop/default-new-navigation-on.php';
 	}
 
 	require_once dirname( __FILE__ ) . '/woop/limit-payment-gateways.php';

--- a/includes/woop.php
+++ b/includes/woop.php
@@ -35,6 +35,7 @@ function wc_calypso_bridge_woop_init() {
 
 	if ( is_admin() ) {
 		require_once dirname( __FILE__ ) . '/woop/hide-onboarding.php';
+		require_once dirname( __FILE__ ) . '/woop/hide-extensions.php';
 	}
 
 	require_once dirname( __FILE__ ) . '/woop/limit-payment-gateways.php';

--- a/includes/woop/default-new-navigation-on.php
+++ b/includes/woop/default-new-navigation-on.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Hide the extensions marketplace
+ *
+ * @since 1.8.1
+ * @package WC_Calypso_Bridge
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+function wc_calypso_bridge_enable_new_nav() {
+	return 'yes';
+}
+add_filter( 'default_option_woocommerce_navigation_enabled', 'wc_calypso_bridge_enable_new_nav' );

--- a/includes/woop/hide-extensions.php
+++ b/includes/woop/hide-extensions.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Hide the extensions marketplace
+ *
+ * @since 1.8.1
+ * @package WC_Calypso_Bridge
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_filter( 'woocommerce_show_addons_page', '__return_false' );


### PR DESCRIPTION
Defaults the new navigation to on for all plans.

Before
![Screenshot 2021-09-21 at 17-55-51 WooCommerce settings ‹ test — WordPress](https://user-images.githubusercontent.com/811776/134133446-57c54c3a-4e12-4fea-bfc6-e165bee7d13f.png)


After
![Screenshot 2021-09-21 at 17-55-34 WooCommerce settings ‹ test — WordPress](https://user-images.githubusercontent.com/811776/134133460-6998d1d3-9c78-4c8e-8808-8cd6b3835145.png)

