### PR TITLE
WCPay in core experiment: expand new countries

### DIFF
--- a/includes/class-wc-calypso-bridge-payments.php
+++ b/includes/class-wc-calypso-bridge-payments.php
@@ -96,8 +96,9 @@ class WC_Calypso_Bridge_Payments {
 			return;
 		}
 
-		// Store country must be the US.
-		if ( 'US' !== WC()->countries->get_base_country() ) {
+		// Store country must be in defined array.
+		$supported_countries = array( 'US', 'UK', 'AU', 'NZ', 'CA', 'IE', 'ES', 'FR', 'IT', 'DE' );
+		if ( ! in_array( WC()->countries->get_base_country(), $supported_countries ) ) {
 			return;
 		}
 

--- a/includes/class-wc-calypso-bridge-payments.php
+++ b/includes/class-wc-calypso-bridge-payments.php
@@ -97,7 +97,7 @@ class WC_Calypso_Bridge_Payments {
 		}
 
 		// Store country must be in defined array.
-		$supported_countries = array( 'US', 'UK', 'AU', 'NZ', 'CA', 'IE', 'ES', 'FR', 'IT', 'DE' );
+		$supported_countries = array( 'US', 'GB', 'AU', 'NZ', 'CA', 'IE', 'ES', 'FR', 'IT', 'DE' );
 		if ( ! in_array( WC()->countries->get_base_country(), $supported_countries ) ) {
 			return;
 		}

--- a/src/payments-welcome/banner.tsx
+++ b/src/payments-welcome/banner.tsx
@@ -13,10 +13,13 @@ const Banner = () => {
 		<Card size="large" className="account-page woocommerce-payments-banner">
 			<CardBody>
 				<div className="limited-time-offer">
-					{strings.limitedTimeOffer}
+					<h1 className="offer-copy">
+						<i className="flag"></i>
+						{strings.limitedTimeOffer}: {strings.bannerCopy}
+					</h1>
+					<p className="discount-copy">{strings.discountCopy}</p>
 				</div>
-				<h1>{strings.bannerHeading}</h1>
-				<p>{strings.bannerCopy}</p>
+				{/* <h1>{strings.bannerHeading}</h1> */}
 			</CardBody>
 		</Card>
 	);

--- a/src/payments-welcome/faq.tsx
+++ b/src/payments-welcome/faq.tsx
@@ -2,6 +2,7 @@
  * External dependencies.
  */
 import { Icon, help } from '@wordpress/icons';
+import { Panel, PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies.
@@ -9,52 +10,81 @@ import { Icon, help } from '@wordpress/icons';
 import strings from './strings';
 
 const FrequentlyAskedQuestions = () => {
+	// const [panelOpen, setPanelOpen] = useState(false);
 	return (
-		<>
-			<h2>{strings.faq.faqHeader}</h2>
-			<h3>{strings.faq.question1}</h3>
-			<p>{strings.faq.question1Answer1}</p>
-			<p>{strings.faq.question1Answer2}</p>
+		<div className="faq__card">
+			<h3>{strings.faq.faqHeader}</h3>
+			<Panel>
+				<PanelBody title={strings.faq.question1}>
+					<p>{strings.faq.question1Answer1}</p>
+					<p>{strings.faq.question1Answer2}</p>
+				</PanelBody>
 
-			<h3>{strings.faq.question2}</h3>
-			<p>{strings.faq.question2Answer1}</p>
-			<h4>{strings.faq.question2Answer2}</h4>
-			<ul>
-				<li>
-					{strings.faq.question2Answer3}
+				<PanelBody title={strings.faq.question2}>
+					<p>{strings.faq.question2Answer1}</p>
+				</PanelBody>
+
+				<PanelBody title={strings.faq.question3}>
 					<ul>
-						<li>{strings.faq.question2Answer4}</li>
-						<li>{strings.faq.question2Answer5}</li>
+						<li>{strings.faq.question3Answer1}</li>
+						<li>{strings.faq.question3Answer2}</li>
+						<li>{strings.faq.question3Answer3}</li>
+						<li>{strings.faq.question3Answer4}</li>
 					</ul>
-				</li>
-				<li>{strings.faq.question2Answer6}</li>
-				<li>{strings.faq.question2Answer7}</li>
-			</ul>
-			{strings.faq.question2Answer8}
-			<h3>{strings.faq.question3}</h3>
-			<p>{strings.faq.question3Answer1}</p>
-			<p>{strings.faq.question3Answer2}</p>
-			<p>{strings.faq.question3Answer3}</p>
-			<p>{strings.faq.question3Answer4}</p>
-			<p>{strings.faq.question3Answer5}</p>
-			<h3>{strings.faq.question4}</h3>
-			{strings.faq.question4Answer1}
-			<ul>
-				<li>{strings.faq.question4Answer2}</li>
-				<li>{strings.faq.question4Answer3}</li>
-				<li>{strings.faq.question4Answer4}</li>
-				<li>{strings.faq.question4Answer5}</li>
-				<li>{strings.faq.question4Answer6}</li>
-				<li>{strings.faq.question4Answer7}</li>
-				<li>{strings.faq.question4Answer8}</li>
-				<li>{strings.faq.question4Answer9}</li>
-				<li>{strings.faq.question4Answer10}</li>
-			</ul>
-			<p>{strings.faq.question4Answer11}</p>
-			<p>{strings.faq.question4Answer12}</p>
-			<p>{strings.faq.question4Answer13}</p>
-			<h3>{strings.faq.question5}</h3>
-			<p>{strings.faq.question5Answer1}</p>
+				</PanelBody>
+
+				<PanelBody title={strings.faq.question4}>
+					<p>{strings.faq.question4Answer1}</p>
+					<p>{strings.faq.question4Answer2}</p>
+				</PanelBody>
+
+				<PanelBody title={strings.faq.question5}>
+					<p>{strings.faq.question5Answer1}</p>
+					<p>{strings.faq.question5Answer2}</p>
+					<p>{strings.faq.question5Answer3}</p>
+				</PanelBody>
+
+				<PanelBody title={strings.faq.question6}>
+					<p>{strings.faq.question6Answer1}</p>
+					<p>{strings.faq.question6Answer2}</p>
+					<p>{strings.faq.question6Answer3}</p>
+					<p>{strings.faq.question6Answer4}</p>
+					<p>{strings.faq.question6Answer5}</p>
+				</PanelBody>
+
+				<PanelBody title={strings.faq.question7}>
+					<p>{strings.faq.question7Answer1}</p>
+					<ul>
+						<li>{strings.faq.question7Answer2}</li>
+						<li>{strings.faq.question7Answer3}</li>
+						<li>{strings.faq.question7Answer4}</li>
+						<li>{strings.faq.question7Answer5}</li>
+						<li>{strings.faq.question7Answer6}</li>
+						<li>{strings.faq.question7Answer7}</li>
+						<li>{strings.faq.question7Answer8}</li>
+						<li>{strings.faq.question7Answer9}</li>
+						<li>{strings.faq.question7Answer10}</li>
+					</ul>
+					<p>{strings.faq.question7Answer11}</p>
+					<p>{strings.faq.question7Answer12}</p>
+					<p>{strings.faq.question7Answer13}</p>
+				</PanelBody>
+
+				<PanelBody title={strings.faq.question8}>
+					<p>{strings.faq.question8Answer1}</p>
+					<p>{strings.faq.question8Answer2}</p>
+					<ul>
+						<li>{strings.faq.question8Answer3}</li>
+						<li>{strings.faq.question8Answer4}</li>
+						<li>{strings.faq.question8Answer5}</li>
+						<li>{strings.faq.question8Answer6}</li>
+						<li>{strings.faq.question8Answer7}</li>
+						<li>{strings.faq.question8Answer8}</li>
+						<li>{strings.faq.question8Answer9}</li>
+					</ul>
+					<p>{strings.faq.question8Answer10}</p>
+				</PanelBody>
+			</Panel>
 			<div className="help-section">
 				<Icon icon={help} />
 				<span>{strings.faq.haveMoreQuestions}</span>
@@ -65,7 +95,7 @@ const FrequentlyAskedQuestions = () => {
 					{strings.faq.getInTouch}
 				</a>
 			</div>
-		</>
+		</div>
 	);
 };
 

--- a/src/payments-welcome/faq.tsx
+++ b/src/payments-welcome/faq.tsx
@@ -2,14 +2,20 @@
  * External dependencies.
  */
 import { Icon, help } from '@wordpress/icons';
-import { Panel, PanelBody } from '@wordpress/components';
+import { Panel, PanelBody as PanelBodyBase } from '@wordpress/components';
 
 /**
  * Internal dependencies.
  */
 import strings from './strings';
 
-const FrequentlyAskedQuestions = () => {
+const PanelBody: React.FC< PanelBodyBase.Props > = ( props ) => {
+	return (
+		<PanelBodyBase initialOpen={false} {...props}/>
+	)
+}
+
+const FrequentlyAskedQuestions: React.FC = () => {
 	// const [panelOpen, setPanelOpen] = useState(false);
 	return (
 		<div className="faq__card">

--- a/src/payments-welcome/faq.tsx
+++ b/src/payments-welcome/faq.tsx
@@ -47,7 +47,6 @@ const FrequentlyAskedQuestions: React.FC = () => {
 				<PanelBody title={strings.faq.question5}>
 					<p>{strings.faq.question5Answer1}</p>
 					<p>{strings.faq.question5Answer2}</p>
-					<p>{strings.faq.question5Answer3}</p>
 				</PanelBody>
 
 				<PanelBody title={strings.faq.question6}>

--- a/src/payments-welcome/index.tsx
+++ b/src/payments-welcome/index.tsx
@@ -1,9 +1,7 @@
 /**
  * External dependencies
  */
-// @ts-ignore
-import { Card, CardBody, CardHeader } from '@wordpress/components';
-import { Button, Modal, Notice } from '@wordpress/components';
+import { Card, CardBody, CardHeader, Button, Notice } from '@wordpress/components';
 // @ts-ignore
 import { useState, useEffect } from 'wordpress-element';
 import apiFetch from '@wordpress/api-fetch';
@@ -155,7 +153,7 @@ const ConnectPageOnboarding = ({
 		<Card className="connect-account__card">
 			<CardHeader>
 				<div>
-					<h1>{strings.bannerHeading}</h1>
+					<h1 className="banner-heading-copy">{strings.bannerHeading}</h1>
 					<TermsOfService />
 				</div>
 				<div className="connect-account__action">
@@ -187,10 +185,14 @@ const ConnectPageOnboarding = ({
 			<CardBody>
 				<div className="content">
 					<p className="onboarding-description">
-						{strings.onboarding.description} <LearnMore />
+						{strings.onboarding.description}
+						<br />
+						<LearnMore />
 					</p>
 
-					<h3>{strings.paymentMethodsHeading}</h3>
+					<h3 className="accepted-payment-methods">
+						{strings.paymentMethodsHeading}
+					</h3>
 
 					<PaymentMethods />
 				</div>
@@ -223,13 +225,7 @@ const ConnectAccountPage = () => {
 				<ConnectPageError errorMessage={errorMessage} />
 				<ConnectPageOnboarding {...onboardingProps} />
 				<Banner />
-				<Card className="faq__card">
-					<CardBody>
-						<div className="content">
-							<FrequentlyAskedQuestions />
-						</div>
-					</CardBody>
-				</Card>
+				<FrequentlyAskedQuestions />
 			</div>
 		</div>
 	);

--- a/src/payments-welcome/index.tsx
+++ b/src/payments-welcome/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 // @ts-ignore
-import { Card, CardBody } from '@wordpress/components';
+import { Card, CardBody, CardHeader } from '@wordpress/components';
 import { Button, Modal, Notice } from '@wordpress/components';
 // @ts-ignore
 import { useState, useEffect } from 'wordpress-element';
@@ -29,10 +29,10 @@ import wcpayTracks from './tracks';
 import ExitSurveyModal from './exit-survey-modal';
 
 declare global {
-	interface Window { 
-		wp: any,
-		wcCalypsoBridge: any,
-		location: Location
+	interface Window {
+		wp: any;
+		wcCalypsoBridge: any;
+		location: Location;
 	}
 }
 
@@ -73,9 +73,7 @@ const TermsOfService = () => (
 	</span>
 );
 
-const ConnectPageError = ({ errorMessage }: {
-	errorMessage: string
-}) => {
+const ConnectPageError = ({ errorMessage }: { errorMessage: string }) => {
 	if (!errorMessage) {
 		return null;
 	}
@@ -96,35 +94,35 @@ const ConnectPageOnboarding = ({
 	setErrorMessage,
 	connectUrl,
 }: {
-	isJetpackConnected: string,
-	installAndActivatePlugins: Function,
-	setErrorMessage: Function,
-	connectUrl: string
+	isJetpackConnected: string;
+	installAndActivatePlugins: Function;
+	setErrorMessage: Function;
+	connectUrl: string;
 }) => {
 	const [isSubmitted, setSubmitted] = useState(false);
 	const [isNoThanksClicked, setNoThanksClicked] = useState(false);
-	
-	const [ isExitSurveyModalOpen, setExitSurveyModalOpen ] = useState( false );
+
+	const [isExitSurveyModalOpen, setExitSurveyModalOpen] = useState(false);
 
 	const renderErrorMessage = (message: string) => {
 		setErrorMessage(message);
 		setSubmitted(false);
-	}
+	};
 
 	const activatePromo = async () => {
 		try {
-			const activatePromoResponse = await apiFetch({
+			const activatePromoResponse = (await apiFetch({
 				path: '/wc-calypso-bridge/v1/payments/activate-promo',
-				method: 'POST'
-			}) as any;
+				method: 'POST',
+			})) as any;
 
 			if (activatePromoResponse?.success) {
 				window.location.href = connectUrl;
 			}
 		} catch (e: any) {
 			renderErrorMessage(e.message);
-		}		
-	}
+		}
+	};
 
 	const handleSetup = async () => {
 		setSubmitted(true);
@@ -142,7 +140,7 @@ const ConnectPageOnboarding = ({
 				activatePromo();
 			} else {
 				renderErrorMessage(installAndActivateResponse.message);
-			}			
+			}
 		} catch (e: any) {
 			renderErrorMessage(e.message);
 		}
@@ -150,44 +148,54 @@ const ConnectPageOnboarding = ({
 
 	const handleNoThanks = () => {
 		setNoThanksClicked(true);
-		setExitSurveyModalOpen( true );
+		setExitSurveyModalOpen(true);
 	};
 
 	return (
-		<>
-			<p className="onboarding-description">
-				{strings.onboarding.description} <LearnMore />
-			</p>
+		<Card className="connect-account__card">
+			<CardHeader>
+				<div>
+					<h1>{strings.bannerHeading}</h1>
+					<TermsOfService />
+				</div>
+				<div className="connect-account__action">
+					<Button
+						isSecondary
+						isBusy={isNoThanksClicked && isExitSurveyModalOpen}
+						disabled={isNoThanksClicked && isExitSurveyModalOpen}
+						onClick={handleNoThanks}
+						className="btn-nothanks"
+					>
+						{strings.nothanks}
+					</Button>
+					<Button
+						isPrimary
+						isBusy={isSubmitted}
+						disabled={isSubmitted}
+						onClick={handleSetup}
+						className="btn-install"
+					>
+						{strings.button}
+					</Button>
+					{isExitSurveyModalOpen && (
+						<ExitSurveyModal
+							setExitSurveyModalOpen={setExitSurveyModalOpen}
+						/>
+					)}
+				</div>
+			</CardHeader>
+			<CardBody>
+				<div className="content">
+					<p className="onboarding-description">
+						{strings.onboarding.description} <LearnMore />
+					</p>
 
-			<h3>{strings.paymentMethodsHeading}</h3>
+					<h3>{strings.paymentMethodsHeading}</h3>
 
-			<PaymentMethods />
-
-			<hr className="full-width" />
-
-			<p className="connect-account__action">
-				<TermsOfService />
-				<Button
-					isPrimary
-					isBusy={isSubmitted}
-					disabled={isSubmitted}
-					onClick={handleSetup}
-				>
-					{strings.button}
-				</Button>
-				<Button
-					isBusy={isNoThanksClicked && isExitSurveyModalOpen}
-					disabled={isNoThanksClicked && isExitSurveyModalOpen}
-					onClick={handleNoThanks}
-					className="btn-nothanks"
-				>
-					{strings.nothanks}
-				</Button>
-				{ isExitSurveyModalOpen && (
-					<ExitSurveyModal setExitSurveyModalOpen = {setExitSurveyModalOpen}/>
-				) }
-			</p>
-		</>
+					<PaymentMethods />
+				</div>
+			</CardBody>
+		</Card>
 	);
 };
 
@@ -203,7 +211,8 @@ const ConnectAccountPage = () => {
 			.select('wc/admin/plugins')
 			.isJetpackConnected(),
 		installAndActivatePlugins:
-			window.wp.data.dispatch('wc/admin/plugins').installAndActivatePlugins,
+			window.wp.data.dispatch('wc/admin/plugins')
+				.installAndActivatePlugins,
 		setErrorMessage,
 		connectUrl: window.wcCalypsoBridge.wcpayConnectUrl,
 	};
@@ -212,14 +221,8 @@ const ConnectAccountPage = () => {
 		<div className="connect-account-page">
 			<div className="woocommerce-payments-page is-narrow connect-account">
 				<ConnectPageError errorMessage={errorMessage} />
-				<Card className="connect-account__card">
+				<ConnectPageOnboarding {...onboardingProps} />
 				<Banner />
-				<CardBody>
-					<div className="content">
-						<ConnectPageOnboarding {...onboardingProps} />
-					</div>
-				</CardBody>
-				</Card>
 				<Card className="faq__card">
 					<CardBody>
 						<div className="content">

--- a/src/payments-welcome/strings.tsx
+++ b/src/payments-welcome/strings.tsx
@@ -27,7 +27,7 @@ export default {
 
 	onboarding: {
 		description: __(
-			"Save up to $800 in fees by managing transactions with WooCommerce Payments. With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies. Track cash flow and manage recurring revenue directly from your store's dashboard - with no setup costs or monthly fees.",
+			"Save 50% on transaction fees by managing transactions with WooCommerce Payments. With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies. Track cash flow and manage recurring revenue directly from your store's dashboard - with no setup costs or monthly fees.",
 			'wc-calypso-bridge'
 		),
 	},
@@ -173,13 +173,11 @@ export default {
 		),
 
 		question5Answer1: __(
-			'WooCommerce Payments uses a pay-as-you-go pricing model. You pay only for activity on the account. No setup fee or monthly fee. Fees differ based on the country of your account and country of your customer’s card. The full list of fees for available countries is listed below.',
+			'WooCommerce Payments uses a pay-as-you-go pricing model. You pay only for activity on the account. No setup fee or monthly fee. Fees differ based on the country of your account and country of your customer’s card.',
 			'wc-calypso-bridge'
 		),
 
-		question5Answer2: __('[Countries TBD]', 'wc-calypso-bridge'),
-
-		question5Answer3: createInterpolateElement(
+		question5Answer2: createInterpolateElement(
 			__('<a>View all fees</a>', 'wc-calypso-bridge'),
 			{
 				a: (

--- a/src/payments-welcome/strings.tsx
+++ b/src/payments-welcome/strings.tsx
@@ -343,7 +343,7 @@ export default {
 		),
 
 		question8: __(
-			'What products are not permitted on my store when accepting payments with WooCommerce Payments?',
+			'Can WooCommerce Payments support Subscriptions and recurring payment options?',
 			'wc-calypso-bridge'
 		),
 

--- a/src/payments-welcome/strings.tsx
+++ b/src/payments-welcome/strings.tsx
@@ -87,7 +87,7 @@ export default {
 
 	terms: createInterpolateElement(
 		__(
-			'By clicking "Install", you agree to the <a>Terms of Service</a>.',
+			'By clicking "Install", you agree to the <a>Terms of Service</a>',
 			'wc-calypso-bridge'
 		),
 		{

--- a/src/payments-welcome/strings.tsx
+++ b/src/payments-welcome/strings.tsx
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 import { __experimentalCreateInterpolateElement as createInterpolateElement } from 'wordpress-element';
 
 export default {
-	button: __('Get started', 'wc-calypso-bridge'),
+	button: __('Install', 'wc-calypso-bridge'),
 	nothanks: __('No thanks', 'wc-calypso-bridge'),
 	limitedTimeOffer: __('Limited time offer', 'wc-calypso-bridge'),
 	heading: __('WooCommerce Payments', 'wc-calypso-bridge'),
@@ -17,6 +17,10 @@ export default {
 	),
 	bannerCopy: __(
 		'50% transaction fee discount for up to $125,000 in payments or six months',
+		'wc-calypso-bridge'
+	),
+	discountCopy: __(
+		'Discount will be applied upon install and completed setup of WooCommerce Payments',
 		'wc-calypso-bridge'
 	),
 	learnMore: __('Learn more', 'wc-calypso-bridge'),
@@ -83,7 +87,7 @@ export default {
 
 	terms: createInterpolateElement(
 		__(
-			'Upon clicking "Get started", you agree to the <a>Terms of Service</a>. Next we\'ll ask you to share a few details about your business to create your account.',
+			'By clicking "Install", you agree to the <a>Terms of Service</a>.',
 			'wc-calypso-bridge'
 		),
 		{

--- a/src/payments-welcome/strings.tsx
+++ b/src/payments-welcome/strings.tsx
@@ -27,7 +27,7 @@ export default {
 
 	onboarding: {
 		description: __(
-			"With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies. Manage transactions directly from your store's dashboard -- with no setup costs or monthly fees.",
+			"Save up to $800 in fees by managing transactions with WooCommerce Payments. With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies. Track cash flow and manage recurring revenue directly from your store's dashboard - with no setup costs or monthly fees.",
 			'wc-calypso-bridge'
 		),
 	},
@@ -105,53 +105,87 @@ export default {
 	faq: {
 		faqHeader: __('Frequently asked questions', 'wc-calypso-bridge'),
 
-		question1: __(
-			'How will I save money using WooCommerce Payments?',
-			'wc-calypso-bridge'
-		),
+		question1: __('What is WooCommerce Payments?', 'wc-calypso-bridge'),
 
 		question1Answer1: __(
-			'Stores accepted into the promotional program will receive a 50% discount on transaction fees for the first $125,000 in payments, or 6 months, whichever comes first. Simply install the extension and if eligible you’ll be entered into the promotional offer.',
+			'WooCommerce Payments is an integrated payment solution, built by WooCommerce, for WooCommerce. Use WooCommerce Payments to manage your payments, track cash flow, and manage revenue from your dashboard.',
 			'wc-calypso-bridge'
 		),
 
 		question1Answer2: __(
-			'To be eligible for this promotional offer, your store must: (1) meet the WooCommerce Payments usage requirements; (2) be a U.S.-based business; (3) not have processed payments through WooCommerce Payments before; and (4) be accepted into the promotional program.',
+			'You can securely accept credit and debit card payments, Apple Pay, bank transfers, recurring revenue, accelerated checkout, and more - in over 100+ currencies with WooCommerce Payments.',
 			'wc-calypso-bridge'
 		),
 
 		question2: __(
-			'What are the fees for WooCommerce Payments?',
+			'Can I use WooCommerce Payments alongside other payment gateways?',
 			'wc-calypso-bridge'
 		),
 
 		question2Answer1: __(
+			'Yes. WooCommerce Payments works alongside other payment service providers, including Stripe, PayPal, and all others. We’ve built it with this flexibility in mind so that you can ensure your store is working to meet your business needs.',
+			'wc-calypso-bridge'
+		),
+
+		question3: __(
+			'Why should I choose WCPay over other payment gateways?',
+			'wc-calypso-bridge'
+		),
+
+		question3Answer1: __(
+			"Native dashboard: track cash flow from the same  WordPress dashboard you're already using to manage product catalogue, inventory, orders, fulfilment, and otherwise run your online storefront.",
+			'wc-calypso-bridge'
+		),
+
+		question3Answer2: __(
+			'In-person payments: the only payment method that helps you sell online and offline with the official WooCommerce mobile app instead of a paid POS solution.',
+			'wc-calypso-bridge'
+		),
+
+		question3Answer3: __(
+			'Subscription functionality: offer customers a recurring option for your inventory without purchasing an additional extension.',
+			'wc-calypso-bridge'
+		),
+
+		question3Answer4: __(
+			'Native multi-currency: increase sales by making it easier for customers outside your country to purchase from your store, without an extension.',
+			'wc-calypso-bridge'
+		),
+
+		question4: __(
+			'How will I save money using WooCommerce Payments?',
+			'wc-calypso-bridge'
+		),
+
+		question4Answer1: __(
+			'Stores accepted into the promotional program will receive a 100% discount on transaction fees (excluding currency conversion fees) for the first $25,000 in payments, or 3 months, whichever comes first. Simply install the extension and if eligible you’ll be entered into the promotional offer.',
+			'wc-calypso-bridge'
+		),
+
+		question4Answer2: __(
+			'To be eligible for this promotional offer, your store must: (1) meet the WooCommerce Payments usage requirements; (2) be a U.S.-based business; (3) not have processed payments through WooCommerce Payments before; and (4) be accepted into the promotional program.',
+			'wc-calypso-bridge'
+		),
+
+		question5: __(
+			'What are the fees for WooCommerce Payments?',
+			'wc-calypso-bridge'
+		),
+
+		question5Answer1: __(
 			'WooCommerce Payments uses a pay-as-you-go pricing model. You pay only for activity on the account. No setup fee or monthly fee. Fees differ based on the country of your account and country of your customer’s card. The full list of fees for available countries is listed below.',
 			'wc-calypso-bridge'
 		),
 
-		question2Answer2: __('United States', 'wc-calypso-bridge'),
+		question5Answer2: __('[Countries TBD]', 'wc-calypso-bridge'),
 
-		question2Answer3: __(
-			'2.9% + $0.30 USD per transaction for U.S. issued credit or debit card',
-			'wc-calypso-bridge'
-		),
-
-		question2Answer4: __(
-			'+1% for transactions paid using a card issued outside the US',
-			'wc-calypso-bridge'
-		),
-
-		question2Answer5: createInterpolateElement(
-			__(
-				'<a>+1% for conversion of currencies other than USD</a>',
-				'wc-calypso-bridge'
-			),
+		question5Answer3: createInterpolateElement(
+			__('<a>View all fees</a>', 'wc-calypso-bridge'),
 			{
 				a: (
 					// eslint-disable-next-line jsx-a11y/anchor-has-content
 					<a
-						href="https://docs.woocommerce.com/document/payments/faq/fees/currency-conversion/"
+						href="https://docs.woocommerce.com/document/payments/faq/fees/"
 						target="_blank"
 						rel="noopener noreferrer"
 					/>
@@ -159,12 +193,7 @@ export default {
 			}
 		),
 
-		question2Answer6: __(
-			'$15 USD fee per dispute (refunded if you win the dispute)',
-			'wc-calypso-bridge'
-		),
-
-		question2Answer7: createInterpolateElement(
+		question5Answer7: createInterpolateElement(
 			__(
 				'1.5% fee on the payout amount for <a>instant deposits</a>',
 				'wc-calypso-bridge'
@@ -181,7 +210,7 @@ export default {
 			}
 		),
 
-		question2Answer8: createInterpolateElement(
+		question5Answer8: createInterpolateElement(
 			__('<a>View all fees</a>', 'wc-calypso-bridge'),
 			{
 				a: (
@@ -195,32 +224,44 @@ export default {
 			}
 		),
 
-		question3: __(
+		question6: __(
 			'When will I receive deposits for my WooCommerce Payments account balance?',
 			'wc-calypso-bridge'
 		),
 
-		question3Answer1: __(
-			'For most accounts, WooCommerce Payments automatically pays out your available account balance into your nominated account daily after a standard pending period.',
-			'wc-calypso-bridge'
+		question6Answer1: createInterpolateElement(
+			__(
+				'For most accounts, <a>WooCommerce Payments</a> automatically pays out your available account balance into your nominated account daily after a standard pending period.',
+				'wc-calypso-bridge'
+			),
+			{
+				a: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a
+						href="https://woocommerce.com/payments/"
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			}
 		),
 
-		question3Answer2: __(
+		question6Answer2: __(
 			'Payments received each day become part of the pending balance. That pending balance will become available after a pending period. On the day it becomes available, it will be automatically paid out to your bank account. The pending period is based on the country of the account.',
 			'wc-calypso-bridge'
 		),
 
-		question3Answer3: __(
+		question6Answer3: __(
 			'For example, a business based in New Zealand has a pending period of 4 business days. Payments made to this account on Wednesday will be paid out on the next Tuesday.',
 			'wc-calypso-bridge'
 		),
 
-		question3Answer4: __(
+		question6Answer4: __(
 			'Most banks will reflect the deposit in your account as soon as they receive the transfer from WooCommerce Payments. Some may take a few extra days to make the balance available to you.',
 			'wc-calypso-bridge'
 		),
 
-		question3Answer5: createInterpolateElement(
+		question6Answer5: createInterpolateElement(
 			__('<a>All deposits details</a>', 'wc-calypso-bridge'),
 			{
 				a: (
@@ -234,47 +275,47 @@ export default {
 			}
 		),
 
-		question4: __(
+		question7: __(
 			'What products are not permitted on my store when accepting payments with WooCommerce Payments?',
 			'wc-calypso-bridge'
 		),
 
-		question4Answer1: __(
+		question7Answer1: __(
 			'Due to restrictions from card networks, our payment service providers, and their financial service providers, some businesses and product types that are not allowed to transact using WooCommerce Payments, including but not limited to:',
 			'wc-calypso-bridge'
 		),
 
-		question4Answer2: __(
+		question7Answer2: __(
 			'Virtual currency, including video game or virtual world credits',
 			'wc-calypso-bridge'
 		),
 
-		question4Answer3: __('Counterfeit goods', 'wc-calypso-bridge'),
+		question7Answer3: __('Counterfeit goods', 'wc-calypso-bridge'),
 
-		question4Answer4: __('Adult content and services', 'wc-calypso-bridge'),
+		question7Answer4: __('Adult content and services', 'wc-calypso-bridge'),
 
-		question4Answer5: __(
+		question7Answer5: __(
 			'Drug paraphernalia (including e-cigarette, vapes and nutraceuticals)',
 			'wc-calypso-bridge'
 		),
 
-		question4Answer6: __('Multi-level marketing', 'wc-calypso-bridge'),
+		question7Answer6: __('Multi-level marketing', 'wc-calypso-bridge'),
 
-		question4Answer7: __('Pseudo pharmaceuticals', 'wc-calypso-bridge'),
+		question7Answer7: __('Pseudo pharmaceuticals', 'wc-calypso-bridge'),
 
-		question4Answer8: __(
+		question7Answer8: __(
 			'Social media activity, like Twitter followers, Facebook likes, YouTube views',
 			'wc-calypso-bridge'
 		),
 
-		question4Answer9: __(
+		question7Answer9: __(
 			'Substances designed to mimic illegal drugs',
 			'wc-calypso-bridge'
 		),
 
-		question4Answer10: __('Firearms, ammunition', 'wc-calypso-bridge'),
+		question7Answer10: __('Firearms, ammunition', 'wc-calypso-bridge'),
 
-		question4Answer11: createInterpolateElement(
+		question7Answer11: createInterpolateElement(
 			__(
 				'The full list of these businesses can be found in <a>Stripe’s Restricted Businesses list</a>.',
 				'wc-calypso-bridge'
@@ -291,24 +332,75 @@ export default {
 			}
 		),
 
-		question4Answer12: __(
+		question7Answer12: __(
 			'By signing up to use WooCommerce Payments, you agree not to accept payments in connection with these restricted activities, practices or products. We also work to ensure that no prohibited activity is conducted on WooCommerce Payments.',
 			'wc-calypso-bridge'
 		),
 
-		question4Answer13: __(
+		question7Answer13: __(
 			'If we become aware of prohibited activity, we may restrict or shutdown the account responsible.',
 			'wc-calypso-bridge'
 		),
 
-		question5: __(
-			'Can I use WooCommerce Payments alongside other payment gateways?',
+		question8: __(
+			'What products are not permitted on my store when accepting payments with WooCommerce Payments?',
 			'wc-calypso-bridge'
 		),
 
-		question5Answer1: __(
-			'Yes! WooCommerce Payments works alongside other payment service providers, including Stripe, PayPal, and all others. We’ve built it with this flexibility in mind so that you can ensure your store is working to meet your business needs.',
+		question8Answer1: createInterpolateElement(
+			__(
+				'WooCommerce Payments supports charging automatic recurring payments via the <a>WooCommerce Subscriptions</a> plugin.',
+				'wc-calypso-bridge'
+			),
+			{
+				a: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a
+						href="https://woocommerce.com/products/woocommerce-subscriptions/"
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			}
+		),
+
+		question8Answer2: __(
+			'WooCommerce Payments offers full compatibility with WooCommerce Subscriptions’ features, including:',
 			'wc-calypso-bridge'
+		),
+
+		question8Answer3: __('Subscription suspension', 'wc-calypso-bridge'),
+
+		question8Answer4: __('Subscription cancellation', 'wc-calypso-bridge'),
+
+		question8Answer5: __('Subscription reactivation', 'wc-calypso-bridge'),
+
+		question8Answer6: __('Multiple subscriptions', 'wc-calypso-bridge'),
+
+		question8Answer7: __('Recurring total changes', 'wc-calypso-bridge'),
+
+		question8Answer8: __('Payment date changes', 'wc-calypso-bridge'),
+
+		question8Answer9: __(
+			'Customer & Store Manager payment method changes',
+			'wc-calypso-bridge'
+		),
+
+		question8Answer10: createInterpolateElement(
+			__(
+				'For more details on the subscription features that WooCommerce Payments offers, refer to the <a>subscription section of the WooCommerce Payments start up guide</a>.',
+				'wc-calypso-bridge'
+			),
+			{
+				a: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a
+						href="https://docs.woocommerce.com/document/payments/#subscriptions"
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			}
 		),
 
 		haveMoreQuestions: __('Have more questions?', 'wc-calypso-bridge'),

--- a/src/payments-welcome/style.scss
+++ b/src/payments-welcome/style.scss
@@ -29,8 +29,8 @@
 		}
 
 		h3 {
-			font-size: 1.3em;
-			line-height: 1.4em;
+			font-size: 16px;
+			line-height: 24px;
 			padding-top: 15px;
 		}
 
@@ -49,7 +49,7 @@
 
 			h3 {
 				padding: 0 24px;
-				font-weight: 500;
+				font-weight: normal;
 			}
 
 			.components-panel__body {
@@ -64,7 +64,6 @@
 
 			.components-panel__body-toggle.components-button {
 				padding-left: 24px;
-				font-weight: 600;
 				line-height: 20px;
 			}
 

--- a/src/payments-welcome/style.scss
+++ b/src/payments-welcome/style.scss
@@ -49,12 +49,12 @@
 
 			h3 {
 				padding: 0 24px;
-				font-weight: bold;
+				font-weight: 500;
 			}
 
 			.components-panel__body {
 				&.is-opened {
-					padding: 24px;
+					padding: 24px 24px 8px 24px;
 					> .components-panel__body-title {
 						margin: -24px;
 						margin-bottom: 13px;
@@ -64,6 +64,8 @@
 
 			.components-panel__body-toggle.components-button {
 				padding-left: 24px;
+				font-weight: 600;
+				line-height: 20px;
 			}
 
 			.components-panel {

--- a/src/payments-welcome/style.scss
+++ b/src/payments-welcome/style.scss
@@ -35,9 +35,10 @@
 		}
 
 		.connect-account__card,
+		.woocommerce-payments-banner,
 		.faq__card {
 			box-shadow: none;
-			border: 1px solid #E2E4E7;
+			border: 1px solid #e2e4e7;
 			border-radius: 2px;
 			margin-top: 24px;
 		}
@@ -85,6 +86,21 @@
 		}
 
 		.connect-account__card {
+			> .components-card__header {
+				align-items: baseline;
+			}
+
+			// Phone-ish sizes.
+			@media (max-width: 680px) {
+				> .components-card__header {
+					flex-direction: column;
+				}
+
+				.connect-account__action {
+					margin-top: 15px;
+				}
+			}
+
 			// Applies for non-gutenberg
 			> .components-card__body {
 				padding: 0;
@@ -104,26 +120,27 @@
 					margin-top: 0.5em;
 				}
 				.connect-account__action {
-					margin-bottom: 0.5em;
+					// margin-bottom: 0.5em;
 				}
 			}
 
 			hr.full-width {
 				position: relative;
 				left: -24px;
-				width: calc( 100% + 48px );
+				width: calc(100% + 48px);
 				background-color: #e3e3e5;
 			}
 		}
 
 		.connect-account__action {
-			margin-top: 16px;
-			margin-bottom: 0;
+			margin: 0;
+			white-space: nowrap;
 			button.btn-nothanks {
-				margin-left: 5px !important;
+				margin-left: 0;
+				margin-right: 10px !important;
 			}
-			button.is-primary {
-				padding: 0 25px 0 25px;
+			button.btn-install {
+				padding: 0 35px 0 35px;
 				border-radius: 3px;
 			}
 		}
@@ -131,39 +148,40 @@
 }
 
 .woocommerce-payments-banner {
-
 	&.account-page {
-		background: #f7edf7;
 		border: none;
-		border-bottom: 1px solid #E2E4E7;
+		border-bottom: 1px solid #e2e4e7;
 		border-radius: 0;
 		box-shadow: none;
 		.components-card__body {
-			padding: 24px 24px 3px 24px;
+			padding: 24px;
+		}
+	}
+	.limited-time-offer {
+		i.flag {
+			display: inline-block;
+			background: url('../../assets/images/icon-flag.svg') no-repeat left;
+			width: 14px;
+			height: 14px;
+			margin-right: 8px;
 		}
 	}
 
-	h1 {
-		font-size: 24px;
-		width: 360px;
+	.offer-copy {
+		font-size: 16px;
+		line-height: 22px;
+		width: 380px;
 		font-weight: normal;
 	}
 
-	p {
-		font-size: 16px;
-		width: 360px;
+	.discount-copy {
+		font-size: 12px;
+		width: 380px;
 		margin-top: 5px;
 	}
 
-	.limited-time-offer {
-		background: url('../../assets/images/icon-flag.svg') no-repeat left;
-		font-weight:bold;
-		font-size: 12px;
-		padding-left: 16px;
-	}
-
 	.components-card__body {
-		background: url( '../../assets/images/wcpay-banner.svg' ) no-repeat right;
+		background: url('../../assets/images/wcpay-banner.svg') no-repeat right;
 	}
 }
 
@@ -173,14 +191,13 @@
 	}
 }
 
-.wc-calypso-bridge-payments-welcome-survey__intro{
+.wc-calypso-bridge-payments-welcome-survey__intro {
 	max-width: 500px;
 }
 
-.wc-calypso-bridge-payments-welcome-survey__question{
+.wc-calypso-bridge-payments-welcome-survey__question {
 	font-weight: bold;
 }
-
 
 .wc-calypso-bridge-payments-welcome-survey__selection {
 	margin: 1em 0;
@@ -204,4 +221,3 @@
 		}
 	}
 }
-

--- a/src/payments-welcome/style.scss
+++ b/src/payments-welcome/style.scss
@@ -45,9 +45,16 @@
 
 		.faq__card {
 			margin-bottom: var(--large-gap);
+			background-color: #fff;
 
-			.woocommerce-card__body {
-				padding: 7px 25px;
+			h3 {
+				padding: 0 24px;
+			}
+
+			.components-panel {
+				border-left: 0;
+				border-right: 0;
+				// padding: 7px 25px;
 			}
 
 			p {
@@ -124,11 +131,13 @@
 				}
 			}
 
-			hr.full-width {
-				position: relative;
-				left: -24px;
-				width: calc(100% + 48px);
-				background-color: #e3e3e5;
+			.onboarding-description {
+				font-size: 16px;
+				color: #555;
+			}
+
+			.accepted-payment-methods {
+				font-size: 12px;
 			}
 		}
 
@@ -145,6 +154,11 @@
 			}
 		}
 	}
+
+	.banner-heading-copy {
+		font-size: 26px;
+    line-height: 34px;
+	}
 }
 
 .woocommerce-payments-banner {
@@ -157,6 +171,7 @@
 			padding: 24px;
 		}
 	}
+
 	.limited-time-offer {
 		i.flag {
 			display: inline-block;
@@ -169,15 +184,14 @@
 
 	.offer-copy {
 		font-size: 16px;
-		line-height: 22px;
+		line-height: 24px;
 		width: 380px;
 		font-weight: normal;
 	}
 
 	.discount-copy {
-		font-size: 12px;
 		width: 380px;
-		margin-top: 5px;
+		margin-top: 6px;
 	}
 
 	.components-card__body {

--- a/src/payments-welcome/style.scss
+++ b/src/payments-welcome/style.scss
@@ -49,22 +49,40 @@
 
 			h3 {
 				padding: 0 24px;
+				font-weight: bold;
+			}
+
+			.components-panel__body {
+				&.is-opened {
+					padding: 24px;
+					> .components-panel__body-title {
+						margin: -24px;
+						margin-bottom: 13px;
+					}
+				}
+			}
+
+			.components-panel__body-toggle.components-button {
+				padding-left: 24px;
 			}
 
 			.components-panel {
 				border-left: 0;
 				border-right: 0;
-				// padding: 7px 25px;
 			}
 
 			p {
-				line-height: 24px;
+				font-size: 14px;
+				line-height: 20px;
 			}
+
 			ul {
-				margin-left: 44px;
+				margin-left: 34px;
 				li {
 					list-style: disc;
-					margin: 0;
+					line-height: 20px;
+					font-size: 14px;
+					margin: 5px 0 0 0;
 					ul li {
 						list-style: circle;
 					}
@@ -73,9 +91,8 @@
 
 			.help-section {
 				font-size: 16px;
-				margin-bottom: 15px;
 				background: #f7edf7;
-				padding: 15px;
+				padding: 16px 24px;
 				color: #533582;
 				svg path {
 					fill: #533582;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wc-calypso-bridge/issues/744.

This PR is making changes to WooCommerce in Core experiment. It:
- Adds support for countries `UK, AU, NZ, CA, IE, ES, FR, IT, DE`
- Moves actions to the right side of the header card
- Moves incentive into its own card between the main card and FAQ
- Adds accordion to FAQ using `@wordpress/components`'s `Panel` component
- Modifies FAQ to use copy from [this document](https://docs.google.com/document/d/1txfcYxA_1ha8QhOTRdXtZ7QLhq5enIAvxPlNGI1v_X8/edit#heading=h.8uljvatrhcew)
- Prettified JS and CSS

### Testing Instructions

**Before starting, make sure of the following:**
1. Deactivate WooCommerce Payments plugin
2. `wc_calypso_bridge_payments_dismissed` option is deleted or set to `No`
2. Remove the option `jetpack_options` if WCPay was already connected
1. Open your browser developer console, make sure debug tracks is enabled with `localStorage.setItem( 'debug', 'wc-admin:tracks*' );`

**Test for excluded countries**
1. Change your store country to **NOT** in any of `US, UK, AU, NZ, CA, IE, ES, FR, IT, DE`.
3. Make sure payment menu does not appear

**Test for included countries**
1. Change your store country to any of `US, UK, AU, NZ, CA, IE, ES, FR, IT, DE`.
3. Make sure payment menu is observed

**Test for UI and content changes**
1. Go to payments menu
2. Observe the following:
    - Actions are on the right side of the header card
    - Incentive card is in between of header and FAQ card
    - FAQ is using accordion component, it toggles contents of each question's answer accordioningly *(ba dum tss)*
    - Check all texts are accurate (FAQ [document](https://docs.google.com/document/d/1txfcYxA_1ha8QhOTRdXtZ7QLhq5enIAvxPlNGI1v_X8/edit#))

**Test for installation**
1. Go to payments menu
2. Click on "Install"
3. Your developer console should log `wcadmin_wcpay_connect_account_clicked` track
4. Wait and you should be redirected to connect page.
3. Make sure WooCommerce Payments is installed & activated

**Test for opting out**
1. Deactivate WooCommerce Payments plugin
1. Go to payments menu, click on "No thanks" button, select any checkbox, and click on "Remove and send feedback"
3. Your developer console should log `wcadmin_wcpay_connect_account_clicked` track `wcadmin_wcpay_exit_survey` with the value of your selected checkbox set to true
2. Make sure you're redirected to WooCommerce home and the payments menu disappeared