### PR TITLE
Add payments remind me later note

### DIFF
--- a/class-wc-calypso-bridge-shared.php
+++ b/class-wc-calypso-bridge-shared.php
@@ -88,9 +88,9 @@ class WC_Calypso_Bridge_Shared {
 			'wc-calypso-bridge',
 			'window.wcCalypsoBridge = ' . wp_json_encode(
 				array(
-					'isWooPage'       => $is_woo_page,
-					'homeUrl'         => get_home_url(),
-					'wcpayConnectUrl' => 'admin.php?page=wc-admin&path=%2Fpayments%2Fconnect&wcpay-connect=1&_wpnonce=' . wp_create_nonce( 'wcpay-connect' ),
+					'isWooPage'         => $is_woo_page,
+					'homeUrl'           => get_home_url(),
+					'wcpayConnectUrl'   => 'admin.php?page=wc-admin&path=%2Fpayments%2Fconnect&wcpay-connect=1&_wpnonce=' . wp_create_nonce( 'wcpay-connect' ),
 					'hasViewedPayments' => get_option( 'wc_calypso_bridge_payments_view_welcome_timestamp', false ) !== false,
 				)
 			),

--- a/class-wc-calypso-bridge-shared.php
+++ b/class-wc-calypso-bridge-shared.php
@@ -91,7 +91,7 @@ class WC_Calypso_Bridge_Shared {
 					'isWooPage'       => $is_woo_page,
 					'homeUrl'         => get_home_url(),
 					'wcpayConnectUrl' => 'admin.php?page=wc-admin&path=%2Fpayments%2Fconnect&wcpay-connect=1&_wpnonce=' . wp_create_nonce( 'wcpay-connect' ),
-					'hasViewedPayments' => get_option( 'wc_calypso_bridge_payments_viewed_welcome' ) === 'yes',
+					'hasViewedPayments' => get_option( 'wc_calypso_bridge_payments_view_welcome_timestamp', false ) !== false,
 				)
 			),
 			'before'

--- a/class-wc-calypso-bridge-shared.php
+++ b/class-wc-calypso-bridge-shared.php
@@ -91,6 +91,7 @@ class WC_Calypso_Bridge_Shared {
 					'isWooPage'       => $is_woo_page,
 					'homeUrl'         => get_home_url(),
 					'wcpayConnectUrl' => 'admin.php?page=wc-admin&path=%2Fpayments%2Fconnect&wcpay-connect=1&_wpnonce=' . wp_create_nonce( 'wcpay-connect' ),
+					'hasViewedPayments' => get_option( 'wc_calypso_bridge_payments_viewed_welcome' ) === 'yes',
 				)
 			),
 			'before'

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -115,7 +115,6 @@ class WC_Calypso_Bridge {
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-addons-screen.php';
 		include_once dirname( __FILE__ ) . '/includes/gutenberg.php';
 		require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-woocommerce-admin.php';
-		require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-notes.php';
 
 		// Shared with store-on-wpcom.
 		include_once dirname( __FILE__ ) . '/store-on-wpcom/inc/wc-calypso-bridge-mailchimp-no-redirect.php';

--- a/includes/class-wc-calypso-bridge-events.php
+++ b/includes/class-wc-calypso-bridge-events.php
@@ -68,9 +68,8 @@ class WC_Calypso_Bridge_Events {
 	 * Daily events to run.
 	 */
 	public function do_wc_calypso_bridge_daily() {
-		if ( class_exists( 'WC_Calypso_Bridge_Notes' ) ) {
-			WC_Calypso_Bridge_Notes::get_instance()->add_notes();
-		}
+		require_once dirname( __FILE__ ) . '/class-wc-calypso-bridge-notes.php';
+		WC_Calypso_Bridge_Notes::get_instance()->add_notes();
 	}
 }
 

--- a/includes/class-wc-calypso-bridge-events.php
+++ b/includes/class-wc-calypso-bridge-events.php
@@ -70,6 +70,7 @@ class WC_Calypso_Bridge_Events {
 	public function do_wc_calypso_bridge_daily() {
 		require_once dirname( __FILE__ ) . '/class-wc-calypso-bridge-notes.php';
 		WC_Calypso_Bridge_Notes::get_instance()->add_notes();
+		WC_Calypso_Bridge_Notes::get_instance()->delete_notes();
 	}
 }
 

--- a/includes/class-wc-calypso-bridge-notes.php
+++ b/includes/class-wc-calypso-bridge-notes.php
@@ -60,6 +60,13 @@ class WC_Calypso_Bridge_Notes {
 
 		WC_Calypso_Bridge_Payments_Remind_Me_Later_Note::possibly_add_note();
 	}
+
+	/**
+	 * Delete qualifying notes.
+	 */
+	public function delete_notes() {
+		WC_Calypso_Bridge_Payments_Remind_Me_Later_Note::possibly_clear_note();
+	}
 }
 
 WC_Calypso_Bridge_Notes::get_instance();

--- a/includes/class-wc-calypso-bridge-notes.php
+++ b/includes/class-wc-calypso-bridge-notes.php
@@ -41,16 +41,24 @@ class WC_Calypso_Bridge_Notes {
 	 * Include notes and initialize note hooks.
 	 */
 	public function init() {
-		include_once dirname( __FILE__ ) . '/notes/class-wc-calypso-bridge-navigation-learn-more-note.php';
+		if ( wc_calypso_bridge_is_ecommerce_plan() ) {
+			include_once dirname( __FILE__ ) . '/notes/class-wc-calypso-bridge-navigation-learn-more-note.php';
+			new WC_Calypso_Bridge_Navigation_Learn_More_Note();
+		}
 
-		$navigation_learn_more_note = new WC_Calypso_Bridge_Navigation_Learn_More_Note();
+		include_once dirname( __FILE__ ) . '/notes/class-wc-calypso-bridge-payments-remind-me-later-note.php';
+		new WC_Calypso_Bridge_Payments_Remind_Me_Later_Note();
 	}
 
 	/**
 	 * Add qualifying notes.
 	 */
 	public function add_notes() {
-		WC_Calypso_Bridge_Navigation_Learn_More_Note::possibly_add_note();
+		if ( wc_calypso_bridge_is_ecommerce_plan() ) {
+			WC_Calypso_Bridge_Navigation_Learn_More_Note::possibly_add_note();
+		}
+
+		WC_Calypso_Bridge_Payments_Remind_Me_Later_Note::possibly_add_note();
 	}
 }
 

--- a/includes/notes/class-wc-calypso-bridge-payments-remind-me-later-note.php
+++ b/includes/notes/class-wc-calypso-bridge-payments-remind-me-later-note.php
@@ -33,7 +33,7 @@ class WC_Calypso_Bridge_Payments_Remind_Me_Later_Note {
 	 */
 	public static function get_note() {
 		// Installed WCPay.
-		$installed_plugins = PluginsHelper::get_active_plugin_slugs();
+		$installed_plugins = PluginsHelper::get_installed_plugin_slugs();
 		if ( in_array( 'woocommerce-payments', $installed_plugins ) ) {
 			return;
 		}

--- a/includes/notes/class-wc-calypso-bridge-payments-remind-me-later-note.php
+++ b/includes/notes/class-wc-calypso-bridge-payments-remind-me-later-note.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * WooCommerce Calypso Bridge Payments Remind Me Later Note
+ *
+ * @package WC_Calypso_Bridge/Notes
+ */
+
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+use Automattic\WooCommerce\Admin\Loader;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Calypso_Bridge_Payments_Remind_Me_Later_Note
+ */
+class WC_Calypso_Bridge_Payments_Remind_Me_Later_Note {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-calypso-bridge-payments-remind-me-later';
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note
+	 */
+	public static function get_note() {
+		// TODO: Determine what conditions this should bail.
+		if ( true ) {
+			return;
+		}
+
+		$content = __( 'Save up to 50% in fees by managing transactions in WooCommerce Payments. With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies.', 'wc-calypso-bridge' );
+
+		$note = new Note();
+		$note->set_title( __( 'Save big with WooCommerce Payments', 'wc-calypso-bridge' ) );
+		$note->set_content( $content );
+		$note->set_content_data( (object) array() );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'wc-calypso-bridge' );
+		$note->add_action( 'learn-more', __( 'Learn more', 'wc-calypso-bridge' ), admin_url( 'admin.php?page=wc-admin&path=/payments-welcome' ) );
+		return $note;
+	}
+}

--- a/includes/notes/class-wc-calypso-bridge-payments-remind-me-later-note.php
+++ b/includes/notes/class-wc-calypso-bridge-payments-remind-me-later-note.php
@@ -8,6 +8,7 @@
 use Automattic\WooCommerce\Admin\Notes\Note;
 use Automattic\WooCommerce\Admin\Notes\NoteTraits;
 use Automattic\WooCommerce\Admin\Loader;
+use Automattic\WooCommerce\Admin\PluginsHelper;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -31,8 +32,22 @@ class WC_Calypso_Bridge_Payments_Remind_Me_Later_Note {
 	 * @return Note
 	 */
 	public static function get_note() {
-		// TODO: Determine what conditions this should bail.
-		if ( true ) {
+		// Installed WCPay.
+		$installed_plugins = PluginsHelper::get_active_plugin_slugs();
+		if ( in_array( 'woocommerce-payments', $installed_plugins ) ) {
+			return;
+		}
+
+		// Dismissed WCPay welcome page.
+		if ( 'yes' === get_option( 'wc_calypso_bridge_payments_dismissed', 'no' ) ) {
+			return;
+		}
+
+		// Less than 3 days since viewing welcome page.
+		$view_timestamp = get_option( 'wc_calypso_bridge_payments_view_welcome_timestamp', false );
+		if ( ! $view_timestamp ||
+			( time() - $view_timestamp < 3 * DAY_IN_SECONDS )
+		) {
 			return;
 		}
 

--- a/includes/payments/class-wc-payments-controller.php
+++ b/includes/payments/class-wc-payments-controller.php
@@ -48,6 +48,14 @@ class WC_Payments_Controller extends WC_REST_Controller {
 			),
 			'schema' => array( $this, 'get_public_item_schema' ),
 		) );
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/view-welcome', array(
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'store_view_welcome_time' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+			),
+			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
 	}
 
 	/**
@@ -86,6 +94,23 @@ class WC_Payments_Controller extends WC_REST_Controller {
 			$note->set_name( $promo_name );
 			$note->set_status( Note::E_WC_ADMIN_NOTE_ACTIONED );
 			$data_store->create( $note );
+		}
+
+		return rest_ensure_response(
+			array(
+				'success' => true
+			)
+		);
+	}
+
+	/**
+	 * Save the time of viewing welcome to option in order to activate a remind me
+	 * note after 3 days.
+	 *
+	 */
+	public function store_view_welcome_time() {
+		if ( ! get_option( 'wc_calypso_bridge_payments_view_welcome_timestamp', false ) ) {
+			update_option( 'wc_calypso_bridge_payments_view_welcome_timestamp', time() );
 		}
 
 		return rest_ensure_response(

--- a/includes/payments/class-wc-payments-controller.php
+++ b/includes/payments/class-wc-payments-controller.php
@@ -40,22 +40,30 @@ class WC_Payments_Controller extends WC_REST_Controller {
 	 * Register routes.
 	 */
 	public function register_routes() {
-		register_rest_route( $this->namespace, '/' . $this->rest_base . '/activate-promo', array(
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/activate-promo',
 			array(
-				'methods'             => 'POST',
-				'callback'            => array( $this, 'activate_promo_note' ),
-				'permission_callback' => array( $this, 'check_permission' ),
-			),
-			'schema' => array( $this, 'get_public_item_schema' ),
-		) );
-		register_rest_route( $this->namespace, '/' . $this->rest_base . '/view-welcome', array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'activate_promo_note' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/view-welcome',
 			array(
-				'methods'             => 'POST',
-				'callback'            => array( $this, 'store_view_welcome_time' ),
-				'permission_callback' => array( $this, 'check_permission' ),
-			),
-			'schema' => array( $this, 'get_public_item_schema' ),
-		) );
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'store_view_welcome_time' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
 	}
 
 	/**
@@ -69,11 +77,10 @@ class WC_Payments_Controller extends WC_REST_Controller {
 
 	/**
 	 * Set action to promo note to give the user discount eligibility.
-	 *
 	 */
 	public function activate_promo_note() {
-		$promo_name = 'wcpay-promo-2021-6-incentive-1';
-		$data_store = WC_Data_Store::load( 'admin-note' );
+		$promo_name       = 'wcpay-promo-2021-6-incentive-1';
+		$data_store       = WC_Data_Store::load( 'admin-note' );
 		$add_where_clause = function( $where_clause ) use ( $promo_name ) {
 			return $where_clause . " AND name = '$promo_name'";
 		};
@@ -82,7 +89,7 @@ class WC_Payments_Controller extends WC_REST_Controller {
 		$notes = $data_store->get_notes();
 		remove_filter( 'woocommerce_note_where_clauses', $add_where_clause );
 
-		if (! empty( $notes ) ) {
+		if ( ! empty( $notes ) ) {
 			$note = new Note( $notes[0] );
 			$note->set_status( Note::E_WC_ADMIN_NOTE_ACTIONED );
 			$data_store->update( $note );
@@ -98,7 +105,7 @@ class WC_Payments_Controller extends WC_REST_Controller {
 
 		return rest_ensure_response(
 			array(
-				'success' => true
+				'success' => true,
 			)
 		);
 	}
@@ -106,7 +113,6 @@ class WC_Payments_Controller extends WC_REST_Controller {
 	/**
 	 * Save the time of viewing welcome to option in order to activate a remind me
 	 * note after 3 days.
-	 *
 	 */
 	public function store_view_welcome_time() {
 		if ( ! get_option( 'wc_calypso_bridge_payments_view_welcome_timestamp', false ) ) {
@@ -115,7 +121,7 @@ class WC_Payments_Controller extends WC_REST_Controller {
 
 		return rest_ensure_response(
 			array(
-				'success' => true
+				'success' => true,
 			)
 		);
 	}

--- a/src/payments-welcome/index.tsx
+++ b/src/payments-welcome/index.tsx
@@ -201,11 +201,31 @@ const ConnectPageOnboarding = ({
 	);
 };
 
+/**
+ * Submits a request to store viewing welcome time.
+ */
+const storeViewWelcome = async () => {
+	const { hasViewedPayments } = window.wcCalypsoBridge;
+	if ( hasViewedPayments ) {
+		return;
+	}
+
+	try {
+		await apiFetch({
+			path: '/wc-calypso-bridge/v1/payments/view-welcome',
+			method: 'POST',
+		});
+	} catch (e: any) {
+	}
+};
+
 const ConnectAccountPage = () => {
 	useEffect(() => {
 		wcpayTracks.recordEvent(wcpayTracks.events.CONNECT_ACCOUNT_VIEW, {
 			path: 'payments_connect_dotcom_test',
 		});
+
+		storeViewWelcome();
 	}, []);
 	const [errorMessage, setErrorMessage] = useState('');
 	const onboardingProps = {
@@ -230,5 +250,4 @@ const ConnectAccountPage = () => {
 		</div>
 	);
 };
-
 export default ConnectAccountPage;


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/7670

This PR:
- Changes the way admin notes are handled in bridge. Now it'll run on all plans instead of just Ecom plan sites.
- Adds a mechanism to capture the timestamp of viewing WCPay welcome page into an option.
- Adds an admin note for reminding users if they viewed the welcome page and did not act on it after 3 days.

As I'm writing this PR description, I just thought should we handle the case of users clicking on "Learn more" note **after** they installed WCPay plugin and connected WCPay without going through our flow? Currently, our note will still linger around until user actioned on it. This would be an edge case and I'm unsure if it's worth handling. Users who do encounter this, however, may still expect a discount that they will not get.

### Testing Instructions

**Before starting, make sure of the following:**
1. Deactivate & uninstall WooCommerce Payments plugin
2. `wc_calypso_bridge_payments_dismissed` option is deleted or set to `No`
3. Install the plugin [Crontrol](https://wordpress.org/plugins/wp-crontrol/)

**Testing timestamp trigger**
1. Click on the payments menu
2. Check the option `wc_calypso_bridge_payments_view_welcome_timestamp`, it should contain a timestamp value
3. Open Tools > Cron Events
4. Look for `wc_calypso_bridge_daily`, and click on "Run now"
5. Wait for it to finish running and navigate to WooCommerce homescreen
6. "Save big with WooCommerce Payments" note should **NOT** be displayed
7. Manually set the value `1632611715` to `wc_calypso_bridge_payments_view_welcome_timestamp` to pass the 3 day check
8. Re-run `wc_calypso_bridge_daily` event in Tools > Cron Events
9. Check WooCommerce homescreen, the note should be displayed

**Testing WCPay plugin installed**
1. Go to WP's database and delete `wc-calypso-bridge-payments-remind-me-later` in the table `wp_wc_admin_notes`
2. Go to Payments screen and click on "No thanks" > "Just remove WooCommerce Payments" 
8. Re-run `wc_calypso_bridge_daily` event in Tools > Cron Events
9. Check WooCommerce homescreen, the note should **NOT** be displayed

**Testing WCPay dismissed**
1. Delete the option `wc_calypso_bridge_payments_dismissed`
1. Go to WP's database and delete `wc-calypso-bridge-payments-remind-me-later` in the table `wp_wc_admin_notes`
2. Install WCPay plugin
8. Re-run `wc_calypso_bridge_daily` event in Tools > Cron Events
9. Check WooCommerce homescreen, the note should **NOT** be displayed

**Testing note removal**
1. Get the note displayed (refer to steps above)
2. Either install WCPay plugin or dismiss the payments menu
8. Re-run `wc_calypso_bridge_daily` event in Tools > Cron Events
9. Check WooCommerce homescreen, the note should **NOT** be displayed