### PR TITLE
WCPay temporarily remove new countries

### DIFF
--- a/includes/class-wc-calypso-bridge-payments.php
+++ b/includes/class-wc-calypso-bridge-payments.php
@@ -97,7 +97,7 @@ class WC_Calypso_Bridge_Payments {
 		}
 
 		// Store country must be in defined array.
-		$supported_countries = array( 'US', 'GB', 'AU', 'NZ', 'CA', 'IE', 'ES', 'FR', 'IT', 'DE' );
+		$supported_countries = array( 'US' );
 		if ( ! in_array( WC()->countries->get_base_country(), $supported_countries ) ) {
 			return;
 		}


### PR DESCRIPTION
This PR removes new countries expansion.

### Testing Instructions
1. Set your store's country to any of `'GB', 'AU', 'NZ', 'CA', 'IE', 'ES', 'FR', 'IT', 'DE'`
2. Payment menu should not be displayed
