### PR TITLE
Launch WCPay experiment in new countries and bump version to 1.8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v1.8.1",
+  "version": "v1.8.2",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/includes/class-wc-calypso-bridge-payments.php
+++ b/includes/class-wc-calypso-bridge-payments.php
@@ -97,13 +97,8 @@ class WC_Calypso_Bridge_Payments {
 		}
 
 		// Store country must be in defined array.
-		$supported_countries = array( 'US' );
+		$supported_countries = array( 'US', 'GB', 'AU', 'NZ', 'CA', 'IE', 'ES', 'FR', 'IT', 'DE' );
 		if ( ! in_array( WC()->countries->get_base_country(), $supported_countries ) ) {
-			return;
-		}
-
-		// Temporary until we have translations ready.
-		if ( get_locale() !== 'en_US' ) {
 			return;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 1.8.1
+Stable tag: 1.8.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,11 @@ This section describes how to install the plugin and get it working.
 1. Activate the plugin through the 'Plugins' screen in WordPress
 
 == Changelog ==
+
+= 1.8.2 =
+
+* Launch WCPay experiment in new countries #760
+* Set woocommerce_navigation_enabled to yes on eCom plans #749
 
 = 1.8.1 =
 

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 1.8.1
+ * Version: 1.8.2
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -31,7 +31,7 @@ if ( file_exists( WP_PLUGIN_DIR . '/wc-calypso-bridge/wc-calypso-bridge.php' ) )
 }
 
 define( 'WC_CALYSPO_BRIDGE_PLUGIN_FILE', __FILE__ );
-define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.8.1' );
+define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.8.2' );
 define( 'WC_MIN_VERSION', '3.0.0' );
 
 if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_plan' ) ) {


### PR DESCRIPTION
This PR launches WCPay experiment in new countries by:

- Removes locale check so users in other languages can access it
- Add back the countries `'GB', 'AU', 'NZ', 'CA', 'IE', 'ES', 'FR', 'IT', 'DE'` into allowed list

It also bumps version to 1.8.2 to prepare for a deployment

### Testing Instructions

1. Make sure WooCommerce payments is not activated 
2. Make sure `wc_calypso_bridge_payments_dismissed` option is deleted or set to `No`
1. In Settings > General, change locale to anything other than English
2. Observe the Payments menu is accessible
3. In WooCommerce > Settings, change the store country to any of `'GB', 'AU', 'NZ', 'CA', 'IE', 'ES', 'FR', 'IT', 'DE'` 
4. Observe the Payments menu is still accessible
5. Change the store country to any other countries than listed above or US
6. Observe the Payments menu is no longer accessible

Also, please check the version changes for the version bump and changelog.