### PR TITLE
Use plugins_loaded to register callback to register cron event

### DIFF
--- a/includes/class-wc-calypso-bridge-events.php
+++ b/includes/class-wc-calypso-bridge-events.php
@@ -5,8 +5,6 @@
  * @package WC_Calypso_Bridge/Classes
  */
 
-use Automattic\WooCommerce\Admin\Notes\Notes;
-
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -65,16 +63,6 @@ class WC_Calypso_Bridge_Events {
 		require_once dirname( __FILE__ ) . '/class-wc-calypso-bridge-notes.php';
 		WC_Calypso_Bridge_Notes::get_instance()->add_notes();
 		WC_Calypso_Bridge_Notes::get_instance()->delete_notes();
-
-		// Clear the hook if both notes have been added.
-		$data_store = Notes::load_data_store();
-
-		$learn_more_ids = $data_store->get_notes_with_name( WC_Calypso_Bridge_Navigation_Learn_More_Note::NOTE_NAME );
-		$remind_me_ids  = $data_store->get_notes_with_name(WC_Calypso_Bridge_Payments_Remind_Me_Later_Note::NOTE_NAME);
-
-		if ( count( $learn_more_ids ) && count( $remind_me_ids ) ) {
-			wp_clear_scheduled_hook( 'wc_calypso_bridge_daily' );
-		}
 	}
 }
 

--- a/includes/class-wc-calypso-bridge-events.php
+++ b/includes/class-wc-calypso-bridge-events.php
@@ -5,6 +5,8 @@
  * @package WC_Calypso_Bridge/Classes
  */
 
+use Automattic\WooCommerce\Admin\Notes\Notes;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -24,8 +26,7 @@ class WC_Calypso_Bridge_Events {
 	 * @return void
 	 */
 	protected function __construct() {
-		register_activation_hook( WC_CALYSPO_BRIDGE_PLUGIN_FILE, array( $this, 'on_plugin_activation' ) );
-		register_deactivation_hook( WC_CALYSPO_BRIDGE_PLUGIN_FILE, array( $this, 'on_plugin_deactivation' ) );
+		add_action( 'plugins_loaded', array( $this, 'on_plugin_loaded' ), 0 );
 		add_action( 'plugins_loaded', array( $this, 'init' ) );
 	}
 
@@ -51,17 +52,10 @@ class WC_Calypso_Bridge_Events {
 	/**
 	 * Registers the daily cron event.
 	 */
-	public function on_plugin_activation() {
+	public function on_plugin_loaded() {
 		if ( ! wp_next_scheduled( 'wc_calypso_bridge_daily' ) ) {
 			wp_schedule_event( time(), 'daily', 'wc_calypso_bridge_daily' );
 		}
-	}
-
-	/**
-	 * Clear scheduled cron events.
-	 */
-	public function on_plugin_deactivation() {
-		wp_clear_scheduled_hook( 'wc_calypso_bridge_daily' );
 	}
 
 	/**
@@ -71,6 +65,16 @@ class WC_Calypso_Bridge_Events {
 		require_once dirname( __FILE__ ) . '/class-wc-calypso-bridge-notes.php';
 		WC_Calypso_Bridge_Notes::get_instance()->add_notes();
 		WC_Calypso_Bridge_Notes::get_instance()->delete_notes();
+
+		// Clear the hook if both notes have been added.
+		$data_store = Notes::load_data_store();
+
+		$learn_more_ids = $data_store->get_notes_with_name( WC_Calypso_Bridge_Navigation_Learn_More_Note::NOTE_NAME );
+		$remind_me_ids  = $data_store->get_notes_with_name(WC_Calypso_Bridge_Payments_Remind_Me_Later_Note::NOTE_NAME);
+
+		if ( count( $learn_more_ids ) && count( $remind_me_ids ) ) {
+			wp_clear_scheduled_hook( 'wc_calypso_bridge_daily' );
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wc-calypso-bridge/pull/756

This PR:

1. Replaces `register_activation_hook` with `plugins_loaded` action to register `wc_calypso_bridge_daily` cron event. As `wc-calypso-bridge` is a part of MU plugin (wpcomsh) and MU plugins do not have activation/deactivation, `register_activation_hook` did not work as expected.
2. Clears the hook when both notes have been added successfully. 

### Testing Instructions

Please follow testing instructions in https://github.com/Automattic/wc-calypso-bridge/pull/756