### PR TITLE
Remove calls to old navigation note

### DIFF
--- a/includes/class-wc-calypso-bridge-notes.php
+++ b/includes/class-wc-calypso-bridge-notes.php
@@ -41,11 +41,6 @@ class WC_Calypso_Bridge_Notes {
 	 * Include notes and initialize note hooks.
 	 */
 	public function init() {
-		if ( wc_calypso_bridge_is_ecommerce_plan() ) {
-			include_once dirname( __FILE__ ) . '/notes/class-wc-calypso-bridge-navigation-learn-more-note.php';
-			new WC_Calypso_Bridge_Navigation_Learn_More_Note();
-		}
-
 		include_once dirname( __FILE__ ) . '/notes/class-wc-calypso-bridge-payments-remind-me-later-note.php';
 		new WC_Calypso_Bridge_Payments_Remind_Me_Later_Note();
 	}
@@ -54,10 +49,6 @@ class WC_Calypso_Bridge_Notes {
 	 * Add qualifying notes.
 	 */
 	public function add_notes() {
-		if ( wc_calypso_bridge_is_ecommerce_plan() ) {
-			WC_Calypso_Bridge_Navigation_Learn_More_Note::possibly_add_note();
-		}
-
 		WC_Calypso_Bridge_Payments_Remind_Me_Later_Note::possibly_add_note();
 	}
 


### PR DESCRIPTION
This PR removes the old navigation note since it has never been shown before and will start showing when cron events are fixed in WPCOM, which will cause confusion for users.

### Testing Instructions

1. Install [Crontrol](https://wordpress.org/plugins/wp-crontrol/) plugin
2. Make sure the note named `wc-admin-navigation-learn-more` does not exist in notes table in database
2. Go to Tools > Cron Events, manually run `wc_calypso_bridge_daily`
3. Go to WooCommerce > Home, make sure the note with content `Introducing a streamlined, commerce-first navigation experience,` does not appear
