### PR TITLE
Don't render WC Pay Menu if WCA has it already

### DIFF
--- a/assets/css/wc-payments.css
+++ b/assets/css/wc-payments.css
@@ -11,7 +11,9 @@
 
 /* stylelint-disable selector-id-pattern */
 #toplevel_page_wc-admin-path--payments-welcome div.wp-menu-image::before,
-#toplevel_page_admin-page-wc-admin-path--payments-welcome div.wp-menu-image::before {
+#toplevel_page_admin-page-wc-admin-path--payments-welcome div.wp-menu-image::before,
+#toplevel_page_wc-admin-path--wc-pay-welcome-page div.wp-menu-image::before,
+#toplevel_page_admin-page-wc-admin-path--wc-pay-welcome-page div.wp-menu-image::before {
 	font-family: 'WCPay' !important;
 	content: '\e900';
 	width: 24px;

--- a/includes/class-wc-calypso-bridge-payments.php
+++ b/includes/class-wc-calypso-bridge-payments.php
@@ -48,6 +48,9 @@ class WC_Calypso_Bridge_Payments {
 			add_action( 'rest_api_init', array( $this, 'register_routes' ), 20 );
 			add_action( 'admin_menu', array( $this, 'register_payments_welcome_page' ) );
 			add_action( 'current_screen', array( $this, 'enqueue_scripts_and_styles' ) );
+		} else {
+			// load wc-payments.css so that the font can be used in WCA on WPCOM
+			add_action( 'admin_enqueue_scripts', array( $this, 'add_wc_payments_style' ) );
 		}
 	}
 

--- a/includes/class-wc-calypso-bridge-payments.php
+++ b/includes/class-wc-calypso-bridge-payments.php
@@ -7,6 +7,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\Features\Features;
+
 /**
  * WC_Calypso_Bridge_Payments Class.
  */
@@ -42,7 +44,7 @@ class WC_Calypso_Bridge_Payments {
 	 * Include notes and initialize note hooks.
 	 */
 	public function init() {
-		if ( $this->is_woocommerce_valid() ) {
+		if ( $this->is_woocommerce_valid() && ! Features::is_enabled( 'wc-pay-welcome-page' ) ) {
 			add_action( 'rest_api_init', array( $this, 'register_routes' ), 20 );
 			add_action( 'admin_menu', array( $this, 'register_payments_welcome_page' ) );
 			add_action( 'current_screen', array( $this, 'enqueue_scripts_and_styles' ) );


### PR DESCRIPTION
This PR makes the following changes

- adds a check to avoid rendering WC Pay Menu from `wc-calypso-bridge` if WCA has it already.
- adds the following CSS to set the menu icon for WC Pay Menu rendered from WCA.

```
#toplevel_page_wc-admin-path--wc-pay-welcome-page div.wp-menu-image::before,
#toplevel_page_admin-page-wc-admin-path--wc-pay-welcome-page div.wp-menu-image::before
```

**Why do we need this extra CSS in `wc-calypso-brdige`?**

I still don't know exactly what's going on, but here's what I found so far.

When we add a new menu by calling `wc_admin_register_page` function, we're actually calling `PageController::register_page()` function.

In the `register_page` function, it [modifies](https://github.com/woocommerce/woocommerce-admin/blob/main/src/PageController.php#L430) `path` value to include `wc-admin`. For some reason, WPCOM sites do not render the menu icon correctly when this happens 🤷 Local and individual sites work just fine. 


#### Testing Instructions

Preparing wc-calypso-bridge changes 

1. Sign up for a business/ecom plan on WPCOM
2. Convert the site into dev blog to access SSH.
3. SSH into the server.
4. cd to `~/wp-content/mu-plugins/wpcomsh/vendor/automattic/wc-calypso-bridge/assets/css` and open `wc-payments.css`. 
5. Add changes in this PR to the file.
6. Open `~/wp-content/mu-plugins/wpcomsh/vendor/automattic/wc-calypso-bridge/includes/class-wc-calypso-bridge-payments.php`   and add changes in this PR to the file.
7. Install WooCommerce.
8. Confirm URL of WC Pay Menu. It should be `admin.php?page=wc-admin&path=%2Fpayments-welcome` without WCA installed.

Preparing WCA

7. Checkout `add/8064-add-wc-pay-welcome-screen` branch from WooCommerce Admin.
8. Open `src/Features/WcPayWelcomePage.php` and add `return true` at the first line of `should_add_the_menu` function so that we don't have to assign ourselves to the experiment.
9. Build a test zip file by running `npm run test:zip`
10. Upload the zip file.
11. Confirm URL of WC Pay Menu. It should be `admin.php?page=wc-admin&path=%2Fwc-pay-welcome-page`