### PR TITLE
 Add docker for running phpunit / phpcs locally

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,11 +9,14 @@ RUN apk -q --update --no-cache add tini shadow less git subversion nodejs npm \
     php7-phar php7-session php7-simplexml php7-tokenizer php7-pecl-xdebug php7-xml \
     php7-xmlwriter php7-zip php7-zlib
 
+# Woo requires pnpm
+RUN npm install -g pnpm
+
 # Install wp-cli
 RUN wget -q -O /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && \
     chmod +x /usr/local/bin/wp
 
-# Install WordPress
+# Install WordPress - must use /tmp for test env
 run mkdir -p /tmp && \
 	cd /tmp && \
 	wget -q https://wordpress.org/nightly-builds/wordpress-latest.zip && \
@@ -34,11 +37,13 @@ RUN sed -i "s/yourpasswordhere/wordpress_tests/" /tmp/wordpress-tests-lib/wp-tes
 RUN sed -i "s|localhost|mysql:3306|" /tmp/wordpress-tests-lib/wp-tests-config.php
 
 # Install WooCommerce
-RUN git clone --depth 1 https://github.com/woocommerce/woocommerce.git /tmp/wordpress/wp-content/plugins/woocommerce
+RUN git clone --depth 1 https://github.com/woocommerce/woocommerce.git /tmp/woocommerce
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ENV SKIP_UPDATE_TEXTDOMAINS=true
-RUN cd /tmp/wordpress/wp-content/plugins/woocommerce && npm install
-RUN cd /tmp/wordpress/wp-content/plugins/woocommerce && composer install --no-dev
+RUN cd /tmp/woocommerce && pnpm install
+RUN cd /tmp/woocommerce/plugins/woocommerce && pnpm install
+RUN cd /tmp/woocommerce/plugins/woocommerce && composer install --no-dev
+RUN cp -a /tmp/woocommerce/plugins/woocommerce /tmp/wordpress/wp-content/plugins/woocommerce
 
 WORKDIR /tmp/wordpress/wp-content/plugins/wc-calypso-bridge
 ENTRYPOINT ["tini", "--"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,45 @@
+FROM alpine:3.12
+
+# Install deps
+RUN apk -q --update --no-cache add tini shadow less git subversion nodejs npm \
+	composer ncurses mysql-client mariadb-connector-c curl python3 py3-pip g++ make \
+    php7 php7-pecl-apcu php7-bcmath php7-bz2 php7-ctype php7-curl php7-dom \
+    php7-ftp php7-gd php7-iconv php7-json php7-mbstring php7-mysqli \
+    php7-pecl-oauth php7-opcache php7-openssl php7-pcntl php7-pdo php7-pdo_mysql \
+    php7-phar php7-session php7-simplexml php7-tokenizer php7-pecl-xdebug php7-xml \
+    php7-xmlwriter php7-zip php7-zlib
+
+# Install wp-cli
+RUN wget -q -O /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && \
+    chmod +x /usr/local/bin/wp
+
+# Install WordPress
+run mkdir -p /tmp && \
+	cd /tmp && \
+	wget -q https://wordpress.org/nightly-builds/wordpress-latest.zip && \
+    unzip -q wordpress-latest.zip
+
+# Don't use mysql extension (copied from install-wp-tests.sh)
+RUN wget -q -O /tmp/wordpress/wp-content/db.php https://raw.github.com/markoheijnen/wp-mysqli/master/db.php
+
+# Install WP Tests lib and data
+RUN mkdir -p /tmp/wordpress-tests-lib
+RUN svn export https://develop.svn.wordpress.org/trunk/tests/phpunit/includes/ /tmp/wordpress-tests-lib/includes
+RUN svn export https://develop.svn.wordpress.org/trunk/tests/phpunit/data/ /tmp/wordpress-tests-lib/data
+RUN svn export https://develop.svn.wordpress.org/trunk/wp-tests-config-sample.php /tmp/wordpress-tests-lib/wp-tests-config.php
+RUN sed -i "s:dirname( __FILE__ ) . '/src/':'/tmp/wordpress/':" /tmp/wordpress-tests-lib/wp-tests-config.php
+RUN sed -i "s/youremptytestdbnamehere/wordpress_tests/" /tmp/wordpress-tests-lib/wp-tests-config.php
+RUN sed -i "s/yourusernamehere/wordpress_tests/" /tmp/wordpress-tests-lib/wp-tests-config.php
+RUN sed -i "s/yourpasswordhere/wordpress_tests/" /tmp/wordpress-tests-lib/wp-tests-config.php
+RUN sed -i "s|localhost|mysql:3306|" /tmp/wordpress-tests-lib/wp-tests-config.php
+
+# Install WooCommerce
+RUN git clone --depth 1 https://github.com/woocommerce/woocommerce.git /tmp/wordpress/wp-content/plugins/woocommerce
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV SKIP_UPDATE_TEXTDOMAINS=true
+RUN cd /tmp/wordpress/wp-content/plugins/woocommerce && npm install
+RUN cd /tmp/wordpress/wp-content/plugins/woocommerce && composer install --no-dev
+
+WORKDIR /tmp/wordpress/wp-content/plugins/wc-calypso-bridge
+ENTRYPOINT ["tini", "--"]
+CMD [ "sh" ]

--- a/docker/docker-compose
+++ b/docker/docker-compose
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+
+command docker-compose -f "$DIR"/docker-compose.yml "$@"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,24 @@
+# https://docs.docker.com/compose/compose-file/
+version: '3.8'
+
+volumes:
+    mysql:
+
+services:
+    mysql:
+        image: mariadb
+        volumes:
+            - mysql:/var/lib/mysql
+        environment:
+            MYSQL_DATABASE: wordpress_tests
+            MYSQL_USER: wordpress_tests
+            MYSQL_PASSWORD: wordpress_tests
+            MYSQL_ROOT_PASSWORD: root
+
+    wordpress:
+        build:
+            context: ./
+        volumes:
+            - ../:/tmp/wordpress/wp-content/plugins/wc-calypso-bridge:ro
+        depends_on:
+            - 'mysql'

--- a/docker/phpcs
+++ b/docker/phpcs
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+
+command docker-compose -f "$DIR"/docker-compose.yml run --rm wordpress \
+	/tmp/wordpress/wp-content/plugins/wc-calypso-bridge/vendor/bin/phpcs \
+	--standard=/tmp/wordpress/wp-content/plugins/wc-calypso-bridge/phpcs.xml.dist \
+	--encoding=utf-8 -n -p \
+	/tmp/wordpress/wp-content/plugins/wc-calypso-bridge "${@}"

--- a/docker/phpcs-changed
+++ b/docker/phpcs-changed
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+
+changed=$(cd "$DIR"/../ && git diff --name-only --diff-filter=ACMR master | grep '\.php$')
+
+if [ -z "$changed" ]; then
+	echo "No files changed."
+else
+	echo "Running phpcs on changed files:"
+	printf '%s\n' "$changed"
+	changed=$(echo "$changed" | awk '{print "/tmp/wordpress/wp-content/plugins/wc-calypso-bridge/"$0}' ORS=' ')
+	command docker-compose -f "$DIR"/docker-compose.yml run --rm wordpress \
+		/tmp/wordpress/wp-content/plugins/wc-calypso-bridge/vendor/bin/phpcs \
+		--standard=/tmp/wordpress/wp-content/plugins/wc-calypso-bridge/phpcs.xml.dist \
+		--encoding=utf-8 -n -p \
+		$changed "${@}"
+fi

--- a/docker/phpunit
+++ b/docker/phpunit
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+
+command docker-compose -f "$DIR"/docker-compose.yml run --rm wordpress \
+	/tmp/wordpress/wp-content/plugins/wc-calypso-bridge/vendor/bin/phpunit \
+	-c /tmp/wordpress/wp-content/plugins/wc-calypso-bridge/phpunit.xml \
+	"$@"

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -1,0 +1,33 @@
+# Running phpcs and phpunit with docker & docker-compose
+
+## phpunit
+
+To run the whole suite:
+
+```
+./docker/phpunit
+```
+
+Command arguments pass through:
+
+```
+./docker/phpunit --filter test_remove_paid_extension_upsells
+```
+
+## phpcs
+
+To lint the whole plugin:
+
+```
+./docker/phpcs
+```
+
+Only what's changed from master:
+
+```
+./docker/phpcs-changed
+```
+
+## Mac OSX & Windows
+
+On Docker Desktop for Mac & Windows you will need to add this plugin directory to your virtual machine directory shares.


### PR DESCRIPTION
Replaces #740.

This PR adds a `docker` directory and some helper scripts to run `phpunit` and `phpcs` locally during development.

- ~Made the implicit dependency on yoast phpunit polyfills explicit per https://core.trac.wordpress.org/changeset/51598.~ Done elsewhere since #740 
- Replicated most of `./bin/install-wp-test.sh` in the Dockerfile directly. This worked out because the all the required db bootstrapping is done by wp tests on startup and database creation is handled by the mysql image in its own entrypoint.
- Added `docker-compose.yml` to manage mysql / wordpress `depends_on` dependency for running tests.
- Added `phpunit`, `phpcs`, `phpcs-changed` scripts. There is also a `docker-compose` script but you shouldn't need it unless you want to run a `down` command to clear things. `phpcs-changed` was added due to there being a lot of pre-existing lint errors.
- Added readme.md to outline usage / note about getting things running in osx.

#### Testing:
```
./docker/docker-compose build
./docker/phpunit
./docker/phpcs
./docker/phpcs-changed
```

#### Usage:
![docker-after](https://user-images.githubusercontent.com/811776/132821842-4d58d516-37a6-4218-aac4-c414d1180023.png)
