### PR TITLE
Prep for 1.8.5 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v1.8.4",
+  "version": "v1.8.5",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,10 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 1.8.5 =
+
+* Don't render WC Pay menu if WCA has it already #773
+
 = 1.8.4 =
 
 * Use plugins_loaded to register callback to register cron event #764

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 1.8.4
+Stable tag: 1.8.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 1.8.4
+ * Version: 1.8.5
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -31,7 +31,7 @@ if ( file_exists( WP_PLUGIN_DIR . '/wc-calypso-bridge/wc-calypso-bridge.php' ) )
 }
 
 define( 'WC_CALYSPO_BRIDGE_PLUGIN_FILE', __FILE__ );
-define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.8.4' );
+define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.8.5' );
 define( 'WC_MIN_VERSION', '3.0.0' );
 
 if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_plan' ) ) {


### PR DESCRIPTION
Version bump and changelog for releasing 1.8.4

### Test instructions
Make sure [version bump directions](https://github.com/Automattic/wc-calypso-bridge#deployment) were followed.