### PR TITLE
Apply the WC Pay menu icon in CSS for the plugin

### DIFF
--- a/assets/css/wc-payments.css
+++ b/assets/css/wc-payments.css
@@ -13,7 +13,11 @@
 #toplevel_page_wc-admin-path--payments-welcome div.wp-menu-image::before,
 #toplevel_page_admin-page-wc-admin-path--payments-welcome div.wp-menu-image::before,
 #toplevel_page_wc-admin-path--wc-pay-welcome-page div.wp-menu-image::before,
-#toplevel_page_admin-page-wc-admin-path--wc-pay-welcome-page div.wp-menu-image::before {
+#toplevel_page_admin-page-wc-admin-path--wc-pay-welcome-page div.wp-menu-image::before,
+#toplevel_page_wc-admin-path--payments-connect div.wp-menu-image::before,
+#toplevel_page_admin_page-wc-admin-path--payments-connect div.wp-mene-image::before,
+#toplevel_page_wc-admin-path--payments-overview div.wp-menu-image::before,
+#toplevel_page_admin_page-wc-admin-path--payments-overview div.wp-menu-image::before {
 	font-family: 'WCPay' !important;
 	content: '\e900';
 	width: 24px;


### PR DESCRIPTION
Fixes #776 

This PR uses CSS to render the WC Pay menu icon for the WC Pay plugin on wp.com sites.

This PR must be deployed before releasing https://github.com/Automattic/woocommerce-payments/pull/3722 PR.

### Testing instructions.

1. Sign up for a business site on wp.com
2. Install WooCommerce
3. Confirm the WC Pay menu icon is dashicon on My Home page.
4. Convert the site into a dev blog via WoA Developer Blog Manager.
5. SSH into the site.
6. cd to `wp-content/mu-plugins/wpcomsh/vendor/automattic/wc-calypso-bridge/assets/css`
7. Open `wc-payments.css` file and apply changes in this PR.
8. cd to `wp-content/plugins/woocommerce-payments/includes/admin`
9. Open `class-wc-payments-admin.php` and apply changes in https://github.com/Automattic/woocommerce-payments/pull/3722/files
10. Navigate to My Home page. 
11. Confirm the menu icon is rendered correctly.
12. Click other non-calpyosified pages and confirm the menu icon is rendered correctly.



 