### PR TITLE
Fix WCPay in core texts and promo slug

### DIFF
--- a/includes/notes/class-wc-calypso-bridge-payments-remind-me-later-note.php
+++ b/includes/notes/class-wc-calypso-bridge-payments-remind-me-later-note.php
@@ -64,7 +64,7 @@ class WC_Calypso_Bridge_Payments_Remind_Me_Later_Note {
 			return;
 		}
 
-		$content = __( 'Save up to 50% in fees by managing transactions in WooCommerce Payments. With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies.', 'wc-calypso-bridge' );
+		$content = __( 'Save up to $800 in fees by managing transactions with WooCommerce Payments. With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies.', 'wc-calypso-bridge' );
 
 		$note = new Note();
 		$note->set_title( __( 'Save big with WooCommerce Payments', 'wc-calypso-bridge' ) );

--- a/includes/payments/class-wc-payments-controller.php
+++ b/includes/payments/class-wc-payments-controller.php
@@ -79,7 +79,7 @@ class WC_Payments_Controller extends WC_REST_Controller {
 	 * Set action to promo note to give the user discount eligibility.
 	 */
 	public function activate_promo_note() {
-		$promo_name       = 'wcpay-promo-2021-6-incentive-1';
+		$promo_name       = 'wcpay-promo-2022-3-incentive-100-off';
 		$data_store       = WC_Data_Store::load( 'admin-note' );
 		$add_where_clause = function( $where_clause ) use ( $promo_name ) {
 			return $where_clause . " AND name = '$promo_name'";

--- a/src/payments-welcome/strings.tsx
+++ b/src/payments-welcome/strings.tsx
@@ -16,7 +16,7 @@ export default {
 		'wc-calypso-bridge'
 	),
 	bannerCopy: __(
-		'50% transaction fee discount for up to $125,000 in payments or six months',
+		'No transaction fees for up to 3 months (or $25,000 in payments)',
 		'wc-calypso-bridge'
 	),
 	discountCopy: __(
@@ -27,7 +27,7 @@ export default {
 
 	onboarding: {
 		description: __(
-			"Save 50% on transaction fees by managing transactions with WooCommerce Payments. With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies. Track cash flow and manage recurring revenue directly from your store's dashboard - with no setup costs or monthly fees.",
+			"Save up to $800 in fees by managing transactions with WooCommerce Payments. With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies. Track cash flow and manage recurring revenue directly from your store's dashboard - with no setup costs or monthly fees.",
 			'wc-calypso-bridge'
 		),
 	},

--- a/src/payments-welcome/strings.tsx
+++ b/src/payments-welcome/strings.tsx
@@ -16,7 +16,7 @@ export default {
 		'wc-calypso-bridge'
 	),
 	bannerCopy: __(
-		'No transaction fees for up to 3 months (or $25,000 in payments)',
+		'No card transaction fees for up to 3 months (or $25,000 in payments)',
 		'wc-calypso-bridge'
 	),
 	discountCopy: __(


### PR DESCRIPTION
This PR fixes promo texts to reflect the actual WCPay promo applied in backend (100% discount instead of 50%).

### Screenshots

<img width="811" alt="image" src="https://user-images.githubusercontent.com/3747241/153559942-03bf9fc3-9531-430c-a1fa-43d7dd765448.png">

### Detailed test instructions:

#### Testing the changed texts
- Go to payments welcome page and observe the correct texts in banner and header card

#### Testing promo note action
- In payments welcome screen, click on "Install"
- Browse your database in `wp_wc_admin_notes` table, make sure a note with the name `wcpay-promo-2022-3-incentive-100-off` is created and its status is `actioned`
