### PR TITLE
Make sure WC is active

### DIFF
--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -17,7 +17,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	return;
 }
 
-if ( ! file_exists( WP_PLUGIN_DIR . '/woocommerce/woocommerce.php' ) ) {
+if ( ! function_exists( 'is_plugin_active' ) ) {
+    require_once ABSPATH . 'wp-admin/includes/plugin.php';
+}
+
+$wc_plugin_path = 'woocommerce/woocommerce.php';
+
+if ( ! file_exists( WP_PLUGIN_DIR . '/' . $wc_plugin_path ) || ! is_plugin_active( $wc_plugin_path ) ) {
 	// No WooCommerce installed, we don't need this.
 	return;
 }


### PR DESCRIPTION
Fixes #787 

This PR adds a check to make sure WC is active to prevent any undesired errors by accessing WC classes. 

### Test Instructions

1. Clone `trunk` branch
2. Active both `WooCommerce` and `wc-calpyso-brdige`
3. Deactivate `WooCommerce`
4. Install [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/)
5. Navigate to `Tools -> Cron Events`  and run `wc_calypso_bridge_daily` event
6. Notice a fatal PHP error.
7. Clone this branch
8. Repeat the same steps. The fatal error should not show up again.

If you can test it on a dev blog, that would be nice (not required)