### PR TITLE
Only apply the rule when nav unification is rendered

### DIFF
--- a/store-on-wpcom/assets/css/admin/nav-unification.css
+++ b/store-on-wpcom/assets/css/admin/nav-unification.css
@@ -1,6 +1,6 @@
 /* Fix header overflow https://github.com/woocommerce/woocommerce-admin/issues/7035 */
 @media ( min-width: 961px ) {
-	.is-nav-unification .woocommerce-layout__header {
+	.jetpack-connected.is-nav-unification .woocommerce-layout__header {
 		width: calc( 100% - 272px );
 	}
 }

--- a/store-on-wpcom/assets/css/admin/nav-unification.css
+++ b/store-on-wpcom/assets/css/admin/nav-unification.css
@@ -1,6 +1,6 @@
 /* Fix header overflow https://github.com/woocommerce/woocommerce-admin/issues/7035 */
 @media ( min-width: 961px ) {
 	.jetpack-connected .woocommerce-layout__header {
-		width: calc( 100% - 272px );
+		width: calc( 100% - 160px );
 	}
 }

--- a/store-on-wpcom/assets/css/admin/nav-unification.css
+++ b/store-on-wpcom/assets/css/admin/nav-unification.css
@@ -1,6 +1,6 @@
 /* Fix header overflow https://github.com/woocommerce/woocommerce-admin/issues/7035 */
 @media ( min-width: 961px ) {
-	.jetpack-connected .woocommerce-layout__header {
-		width: calc( 100% - 160px );
+	.is-nav-unification .woocommerce-layout__header {
+		width: calc( 100% - 272px );
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/65522

This PR only applies the CSS when there is nav-unification (272px width menu).

