### PR TITLE
Adjust the header width when the sidebar is collpased

### DIFF
--- a/store-on-wpcom/assets/css/admin/nav-unification.css
+++ b/store-on-wpcom/assets/css/admin/nav-unification.css
@@ -3,4 +3,8 @@
 	.jetpack-connected.is-nav-unification .woocommerce-layout__header {
 		width: calc( 100% - 272px );
 	}
+
+	body.jetpack-connected.folded .woocommerce-layout__header {
+		width: calc( 100% - 36px );
+	}
 }


### PR DESCRIPTION
This is a follow-up fix for https://github.com/Automattic/wp-calypso/issues/65522#issuecomment-1186177631

After fixing the initial issue, we found out that collapsing the sidebar causes the same issue.

This PR adds a new CSS rule for the folded sidebar.

### Screenshots

![Screen Shot 2022-07-16 at 7 11 10 AM](https://user-images.githubusercontent.com/4723145/179358397-9f924a33-e014-434a-938f-6999038a133a.jpg)

### Test instructions

Let's first reproduce the issue.

1. Sign up a new site on WP.COM and install and activate WooCommerce
2. Go to Plugins and click `Settings` on Jetpack.
3. Enable SSO
4. Go to WooCommerce -> Home
5. Collapse the sidebar.
6. You should see a blank div on the right.

Open browser inspector and find `.woocommerce-layout__header ` and apply the change in this PR manually.


When the sidebar is collapsed, the body element gets `folded` class. This PR targets `folded` class to adjust the header width. 36px is the width of the collapsed sidebar.


**Dev Note**: We should take some time to overview how the header works and see if there is a way to fix the root cause without using dynamic width in CSS.