### PR TITLE
Always set woocommerce_allow_tracking to yes

### DIFF
--- a/includes/class-wc-calypso-bridge-tracks.php
+++ b/includes/class-wc-calypso-bridge-tracks.php
@@ -53,19 +53,19 @@ class WC_Calypso_Bridge_Tracks {
 		add_filter( 'woocommerce_apply_tracking', '__return_true' );
 		add_filter( 'woocommerce_apply_user_tracking', '__return_true' );
 
-        $this->enable_tracking();
+		$this->enable_tracking();
 	}
 
 	/**
-     * Set woocommerce_allow_tracking to yes.
-     *
+	 * Set woocommerce_allow_tracking to yes.
+	 *
 	 * @return void
 	 */
-    public function enable_tracking() {
+	public function enable_tracking() {
 		if ( 'no' === get_option( 'woocommerce_allow_tracking' ) ) {
-			update_option( 'woocommerce_allow_tracking', 'yes' , true );
+			update_option( 'woocommerce_allow_tracking', 'yes', true );
 		}
-    }
+	}
 
 
 	/**

--- a/includes/class-wc-calypso-bridge-tracks.php
+++ b/includes/class-wc-calypso-bridge-tracks.php
@@ -52,8 +52,21 @@ class WC_Calypso_Bridge_Tracks {
 		// Always opt-in to Tracks, WPCOM user tracks preferences take priority.
 		add_filter( 'woocommerce_apply_tracking', '__return_true' );
 		add_filter( 'woocommerce_apply_user_tracking', '__return_true' );
-		add_filter( 'pre_option_woocommerce_allow_tracking', array( $this, 'always_enable_tracking' ) );
+
+        $this->enable_tracking();
 	}
+
+	/**
+     * Set woocommerce_allow_tracking to yes.
+     *
+	 * @return void
+	 */
+    public function enable_tracking() {
+		if ( 'no' === get_option( 'woocommerce_allow_tracking' ) ) {
+			update_option( 'woocommerce_allow_tracking', 'yes' , true );
+		}
+    }
+
 
 	/**
 	 * Set's the value for the tracks host property.
@@ -87,13 +100,6 @@ class WC_Calypso_Bridge_Tracks {
 			}
 		</script>
 		<?php
-	}
-
-	/**
-	 * Always make the tracks setting be yes. Users can opt via WordPress.com privacy settings.
-	 */
-	public function always_enable_tracking() {
-		return 'yes';
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/wc-calypso-bridge/issues/797

This PR sets `woocommerce_allow_tracking` to `yes` in database instead of using `pre_option_woocommerce_allow_tracking` hook to fix the issue described in https://github.com/Automattic/wc-calypso-bridge/issues/797

### Testing instructions

1. Start with a fresh install. Do not start OBW and make sure `woocommerce_allow_tracking` is set to `no`
2. Checkout this branch and enable `wc-calypso-bridge` plugin.
3. Confirm `woocommerce_allow_tracking` is set to `yes` in `wp_options`
 