### PR TITLE
Add host param to WC Tracker params

### DIFF
--- a/includes/class-wc-calypso-bridge-tracks.php
+++ b/includes/class-wc-calypso-bridge-tracks.php
@@ -52,8 +52,20 @@ class WC_Calypso_Bridge_Tracks {
 		// Always opt-in to Tracks, WPCOM user tracks preferences take priority.
 		add_filter( 'woocommerce_apply_tracking', '__return_true' );
 		add_filter( 'woocommerce_apply_user_tracking', '__return_true' );
-
 		$this->enable_tracking();
+
+		add_filter( 'woocommerce_tracker_data', array( $this, 'add_host_to_wctracker_param' ) );
+	}
+
+	/**
+	 * Add `host` key to woocommerce_tracker_data filter data
+	 *
+	 * @param array $data WC Tracker data from WC_Tracker class.
+	 * @return array
+	 */
+	public function add_host_to_wctracker_param( $data ) {
+		$data['host'] = self::$tracks_host_value;
+		return $data;
 	}
 
 	/**
@@ -66,7 +78,6 @@ class WC_Calypso_Bridge_Tracks {
 			update_option( 'woocommerce_allow_tracking', 'yes', true );
 		}
 	}
-
 
 	/**
 	 * Set's the value for the tracks host property.


### PR DESCRIPTION
Closes #799 

This PR adds `host` param to WC Tracker param.

`host` param value is either `bizplan-wp-admin` or `ecomplan` depending on the user's wp.com plan.

`woocommerce_tracker_data` is used [here](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/class-wc-tracker.php#L181)

### Testing Instructions

