### PR TITLE
Use pre_option_ hook for woocommerce_allow_tracking

### DIFF
--- a/includes/class-wc-calypso-bridge-tracks.php
+++ b/includes/class-wc-calypso-bridge-tracks.php
@@ -52,21 +52,14 @@ class WC_Calypso_Bridge_Tracks {
 		// Always opt-in to Tracks, WPCOM user tracks preferences take priority.
 		add_filter( 'woocommerce_apply_tracking', '__return_true' );
 		add_filter( 'woocommerce_apply_user_tracking', '__return_true' );
-
-		$this->enable_tracking();
 	}
 
 	/**
-	 * Set woocommerce_allow_tracking to yes.
-	 *
-	 * @return void
+	 * Always make the tracks setting be yes. Users can opt via WordPress.com privacy settings.
 	 */
-	public function enable_tracking() {
-		if ( 'no' === get_option( 'woocommerce_allow_tracking' ) ) {
-			update_option( 'woocommerce_allow_tracking', 'yes', true );
-		}
+	public static function always_enable_tracking() {
+		return 'yes';
 	}
-
 
 	/**
 	 * Set's the value for the tracks host property.

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! function_exists( 'is_plugin_active' ) ) {
-    require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	require_once ABSPATH . 'wp-admin/includes/plugin.php';
 }
 
 $wc_plugin_path = 'woocommerce/woocommerce.php';
@@ -61,6 +61,7 @@ add_action( 'init', array( 'WC_Calypso_Bridge_Filters', 'get_instance' ) );
 
 // We want to adjust tracks settings for business, ecomm, in calypsoified and wp-admin views.
 require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-tracks.php';
+add_filter( 'pre_option_woocommerce_allow_tracking', array( 'WC_Calypso_Bridge_Tracks', 'always_enable_tracking' ) );
 add_action( 'init', array( 'WC_Calypso_Bridge_Tracks', 'get_instance' ) );
 
 // Load cron events.


### PR DESCRIPTION
Closes #801 

This PR moves `pre_option_woocommerce_allow_tracking` out of `init` hook and adds it right after the track class inclusion.

It's guaranteed to run before WooCommerce for being a MU plugin.

### Testing Instructions

Let's test it as a MU plugin to mimic Atomic env as close as possible.

1. Create `mu-plugins` in `wp-content` if it doesn't exist.
2. Move `wc-calypso-bridge` directory to the `mu-plugins` directory.
3. Create `wc-calypso-bridge-loader.php` in the `mu-plugins` with the following content.
```
<?php
/**
 * Plugin Name: WC Calypso Brdige Loader
 * Description: WordPress.com provided functionality & tools pre-installed and activated on all Atomic Sites
 *
 * @package wc-calypso-bridge
 */

require_once WPMU_PLUGIN_DIR . '/wc-calypso-bridge/wc-calypso-bridge.php';
```

4. Create a fresh site and start OBW.
5.  Click `Continue` on the first step and make sure the tracking confirmation modal doesn't show up. 
