### PR TITLE
Cleanup Facebook for WooCommerce welcome notices

### DIFF
--- a/includes/class-wc-calypso-bridge-hide-alerts.php
+++ b/includes/class-wc-calypso-bridge-hide-alerts.php
@@ -98,7 +98,10 @@ class WC_Calypso_Bridge_Hide_Alerts {
 		WC_Calypso_Bridge_Helper_Functions::remove_class_action( 'in_admin_header', 'WC_Klarna_Banners_KP', 'klarna_banner', 10 );
 
 		// List of extensions that do not use class level functions for admin notices.
-		$other_admin_notices = array( 'woocommerce_gateway_paypal_express_upgrade_notice', 'woocommerce_gateway_klarna_welcome_notice' );
+		$other_admin_notices = array(
+			'woocommerce_gateway_paypal_express_upgrade_notice',
+			'woocommerce_gateway_klarna_welcome_notice',
+		);
 		foreach ( $other_admin_notices as $function_to_suppress ) {
 			remove_action( 'admin_notices', $function_to_suppress );
 		}

--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 1.9.4
+ * @version 1.9.5
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -43,6 +43,7 @@ class WC_Calypso_Bridge_Plugins {
 		add_filter( 'woocommerce_admin_onboarding_industries', array( $this, 'maybe_create_wc_pages' ), 10, 2 );
 		add_action( 'load-index.php', array( $this, 'maybe_remove_somewherewarm_maintenance_notices' ) );
 		add_action( 'load-plugins.php', array( $this, 'maybe_remove_somewherewarm_maintenance_notices' ) );
+		add_action( 'admin_head', array( $this, 'maybe_remove_wc_facebook_welcome_notices' ) );
 	}
 
 	/**
@@ -159,7 +160,7 @@ class WC_Calypso_Bridge_Plugins {
 	 * It's specifically hooked on `load-index.php` and `load-plugins.php`
 	 * as both PB and GC display notices only on these pages.
 	 *
-	 * @since 1.9.14
+	 * @since 1.9.4
 	 * @return void
 	 */
 	public function maybe_remove_somewherewarm_maintenance_notices() {
@@ -176,6 +177,41 @@ class WC_Calypso_Bridge_Plugins {
 				return 'welcome' !== $element;
 			} );
 		}
+	}
+
+	/**
+	 * Disable Facebook for WooCommerce welcome notices.
+	 * There is no hook to remove them, so the safest choice is to dismiss them per user
+	 * if they haven't been dismissed already.
+	 *
+	 * @since 1.9.5
+	 * @return void
+	 */
+	public function maybe_remove_wc_facebook_welcome_notices() {
+
+		// Defensive coding - bail out early if the class and the needed methods don't exist.
+		// In case any of the following is renamed, we don't want all sites to break with a WSOD.
+		if (
+			! function_exists( 'facebook_for_woocommerce' )
+			|| ! method_exists( facebook_for_woocommerce(), 'get_admin_notice_handler' )
+			|| ! method_exists( facebook_for_woocommerce()->get_admin_notice_handler(), 'is_notice_dismissed' )
+			|| ! method_exists( facebook_for_woocommerce()->get_admin_notice_handler(), 'dismiss_notice' )
+		) {
+			return;
+		}
+
+		$handler  = facebook_for_woocommerce()->get_admin_notice_handler();
+		$messages = array(
+			'facebook_for_woocommerce_get_started',
+			'settings_moved_to_marketing',
+		);
+
+		foreach ( $messages as $message_id ) {
+			if ( ! $handler->is_notice_dismissed( $message_id ) ) {
+				$handler->dismiss_notice( $message_id );
+			}
+		}
+
 	}
 
 }

--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -43,7 +43,7 @@ class WC_Calypso_Bridge_Plugins {
 		add_filter( 'woocommerce_admin_onboarding_industries', array( $this, 'maybe_create_wc_pages' ), 10, 2 );
 		add_action( 'load-index.php', array( $this, 'maybe_remove_somewherewarm_maintenance_notices' ) );
 		add_action( 'load-plugins.php', array( $this, 'maybe_remove_somewherewarm_maintenance_notices' ) );
-		add_action( 'admin_head', array( $this, 'maybe_remove_wc_facebook_welcome_notices' ) );
+
 	}
 
 	/**
@@ -177,41 +177,6 @@ class WC_Calypso_Bridge_Plugins {
 				return 'welcome' !== $element;
 			} );
 		}
-	}
-
-	/**
-	 * Disable Facebook for WooCommerce welcome notices.
-	 * There is no hook to remove them, so the safest choice is to dismiss them per user
-	 * if they haven't been dismissed already.
-	 *
-	 * @since 1.9.5
-	 * @return void
-	 */
-	public function maybe_remove_wc_facebook_welcome_notices() {
-
-		// Defensive coding - bail out early if the class and the needed methods don't exist.
-		// In case any of the following is renamed, we don't want all sites to break with a WSOD.
-		if (
-			! function_exists( 'facebook_for_woocommerce' )
-			|| ! method_exists( facebook_for_woocommerce(), 'get_admin_notice_handler' )
-			|| ! method_exists( facebook_for_woocommerce()->get_admin_notice_handler(), 'is_notice_dismissed' )
-			|| ! method_exists( facebook_for_woocommerce()->get_admin_notice_handler(), 'dismiss_notice' )
-		) {
-			return;
-		}
-
-		$handler  = facebook_for_woocommerce()->get_admin_notice_handler();
-		$messages = array(
-			'facebook_for_woocommerce_get_started',
-			'settings_moved_to_marketing',
-		);
-
-		foreach ( $messages as $message_id ) {
-			if ( ! $handler->is_notice_dismissed( $message_id ) ) {
-				$handler->dismiss_notice( $message_id );
-			}
-		}
-
 	}
 
 }

--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 1.9.5
+ * @version 1.9.4
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -41,9 +41,6 @@ class WC_Calypso_Bridge_Plugins {
 		add_action( 'current_screen', array( $this, 'prevent_woocommerce_deactivation_route' ), 10, 2 );
 		add_action( 'admin_notices', array( $this, 'prevent_woocommerce_deactivation_notice' ), 10, 2 );
 		add_filter( 'woocommerce_admin_onboarding_industries', array( $this, 'maybe_create_wc_pages' ), 10, 2 );
-		add_action( 'load-index.php', array( $this, 'maybe_remove_somewherewarm_maintenance_notices' ) );
-		add_action( 'load-plugins.php', array( $this, 'maybe_remove_somewherewarm_maintenance_notices' ) );
-
 	}
 
 	/**
@@ -151,32 +148,6 @@ class WC_Calypso_Bridge_Plugins {
 		update_option( $option_name, 'yes' );
 
 		return $industries;
-	}
-
-	/**
-	 * Disable activation notices, specific for SomewhereWarm plugins as they share the same logic.
-	 * Filters out the `welcome` notice from the list of notices to be displayed.
-	 *
-	 * It's specifically hooked on `load-index.php` and `load-plugins.php`
-	 * as both PB and GC display notices only on these pages.
-	 *
-	 * @since 1.9.4
-	 * @return void
-	 */
-	public function maybe_remove_somewherewarm_maintenance_notices() {
-		// Gift Cards.
-		if ( class_exists( 'WC_GC_Admin_Notices' ) && WC_GC_Admin_Notices::is_maintenance_notice_visible( 'welcome' ) ) {
-			WC_GC_Admin_Notices::$maintenance_notices = array_filter( WC_GC_Admin_Notices::$maintenance_notices, static function ( $element ) {
-				return 'welcome' !== $element;
-			} );
-		}
-
-		// Product Bundles.
-		if ( class_exists( 'WC_PB_Admin_Notices' ) && WC_PB_Admin_Notices::is_maintenance_notice_visible( 'welcome' ) ) {
-			WC_PB_Admin_Notices::$maintenance_notices = array_filter( WC_PB_Admin_Notices::$maintenance_notices, static function ( $element ) {
-				return 'welcome' !== $element;
-			} );
-		}
 	}
 
 }

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 1.9.5 =
+* Disable welcome notices for Facebook for WooCommerce - PR#xxx.
+
 = 1.9.4 =
 * Disable activation notices for Gift Cards and Product Bundles #813.
 * Skip the Onboarding Profiler in the Ecommerce Plan #811 #816.


### PR DESCRIPTION
closes #818 

On the same PR, I moved the code for PB/GC notices into the same file, as it makes more sense - Thanks @xristos3490 