### PR TITLE
Default to block-based cart/checkout

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -129,12 +129,13 @@ class WC_Calypso_Bridge {
 
 		}, PHP_INT_MAX, 3 );
 
+		// Include calypso-bridge-setup this class as early as possible.
+		// TODO: Any objections to moving this to the top of the file, before the other checks below?
+		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-setup.php';
+
 		if ( ! is_admin() && ! defined( 'DOING_CRON' ) ) {
 			return;
 		}
-
-		// Include calypso-bridge-setup this class as early as possible.
-		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-setup.php';
 
 		add_action( 'plugins_loaded', array( $this, 'initialize' ), 2 );
 	}

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -87,7 +87,7 @@ class WC_Calypso_Bridge {
 		 */
 		add_filter( 'woocommerce_note_where_clauses', static function ( $where_clauses, $args, $context ) {
 
-			$message_names = array(
+			$suppressed_messages = array(
 				'wc-admin-adding-and-managing-products',
 				'wc-admin-choosing-a-theme',
 				'wc-admin-customizing-product-catalog',
@@ -106,27 +106,27 @@ class WC_Calypso_Bridge {
 				'wc-admin-woocommerce-payments',
 				'wc-admin-woocommerce-subscriptions',
 				'wc-pb-bulk-discounts',
-				'wc-admin-marketing-jetpack-backup', // hide for now, to be revisited.
-				'wc-admin-mobile-app', // hide for now, to be revisited.
-				'wc-admin-migrate-from-shopify', // hide for now, to be revisited.
-				'wc-admin-magento-migration', // hide for now, to be revisited.
-				'wc-admin-woocommerce-subscriptions', // hide for now, to be revisited.
-				'wc-admin-online-clothing-store', // hide for now, to be revisited.
-				'wc-admin-selling-online-courses', // hide for now, to be revisited.
+				'wc-admin-marketing-jetpack-backup', // suppress for now, to be revisited.
+				'wc-admin-mobile-app', // suppress for now, to be revisited.
+				'wc-admin-migrate-from-shopify', // suppress for now, to be revisited.
+				'wc-admin-magento-migration', // suppress for now, to be revisited.
+				'wc-admin-woocommerce-subscriptions', // suppress for now, to be revisited.
+				'wc-admin-online-clothing-store', // suppress for now, to be revisited.
+				'wc-admin-selling-online-courses', // suppress for now, to be revisited.
 			);
 
-			// Do not show the message if the site is active for less than 5 days.
+			// Suppress the message if the site is active for less than 5 days.
 			if ( ! WCAdminHelper::is_wc_admin_active_for( 5 * DAY_IN_SECONDS ) ) {
-				$message_names[] = 'wc-refund-returns-page';
+				$suppressed_messages[] = 'wc-refund-returns-page';
 			}
 
-			// Do not show the message if the site is active for less than 2 days.
+			// Suppress the message if the site is active for less than 2 days.
 			if ( ! WCAdminHelper::is_wc_admin_active_for( 2 * DAY_IN_SECONDS ) ) {
-				$message_names[] = 'wc-calypso-bridge-cart-checkout-blocks-default-inbox-note';
+				$suppressed_messages[] = 'wc-calypso-bridge-cart-checkout-blocks-default-inbox-note';
 			}
 
 			$where_excluded_name_array = array();
-			foreach ( $message_names as $name ) {
+			foreach ( $suppressed_messages as $name ) {
 				$where_excluded_name_array[] = sprintf( "'%s'", esc_sql( $name ) );
 			}
 			$escaped_where_excluded_names = implode( ',', $where_excluded_name_array );

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -20,7 +20,7 @@ class WC_Calypso_Bridge {
 	/**
 	 * Ecommerce Plan release timestamps.
 	 */
-	const W44_2022_RELEASE_DATE = 1567389038; // 2022-11-02
+	const RELEASE_DATE_DEFAULT_CHECKOUT_BLOCKS = 1667898000; // Tuesday, November 8, 2022 9:00:00 AM GMT
 
 	/**
 	 * Paths to assets act oddly in production

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -106,7 +106,7 @@ class WC_Calypso_Bridge {
 				'wc-admin-woocommerce-payments',
 				'wc-admin-woocommerce-subscriptions',
 				'wc-pb-bulk-discounts',
-        'wc-payments-notes-set-up-refund-policy',
+				'wc-payments-notes-set-up-refund-policy',
 				'wc-admin-marketing-jetpack-backup', // suppress for now, to be revisited.
 				'wc-admin-mobile-app', // suppress for now, to be revisited.
 				'wc-admin-migrate-from-shopify', // suppress for now, to be revisited.

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 1.9.4
+ * @version 1.9.8
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -15,6 +15,13 @@ use Automattic\WooCommerce\Admin\Loader;
  * WC Calypso Bridge
  */
 class WC_Calypso_Bridge {
+
+	/**
+	 * Ecommerce Plan release timestamps.
+	 */
+	const S2_2022_RELEASE_DATE     = 1665828976;
+	const W44_2022_S4_RELEASE_DATE = 1667389038; // 2022-11-02
+
 	/**
 	 * Paths to assets act oddly in production
 	 */

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -19,8 +19,7 @@ class WC_Calypso_Bridge {
 	/**
 	 * Ecommerce Plan release timestamps.
 	 */
-	const S2_2022_RELEASE_DATE     = 1665828976;
-	const W44_2022_S4_RELEASE_DATE = 1667389038; // 2022-11-02
+	const W44_2022_RELEASE_DATE = 1567389038; // 2022-11-02
 
 	/**
 	 * Paths to assets act oddly in production
@@ -130,7 +129,7 @@ class WC_Calypso_Bridge {
 		}, PHP_INT_MAX, 3 );
 
 		// Include calypso-bridge-setup this class as early as possible.
-		// TODO: Any objections to moving this to the top of the file, before the other checks below?
+		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-helper-functions.php';
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-setup.php';
 
 		if ( ! is_admin() && ! defined( 'DOING_CRON' ) ) {
@@ -200,7 +199,6 @@ class WC_Calypso_Bridge {
 	 */
 	public function load_ecommerce_plan_ui() {
 		// We always want the Calypso branded OBW to run on eCommerce plan sites.
-		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-helper-functions.php';
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-hide-alerts.php';
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-themes-setup.php';
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-page-controller.php';

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -10,6 +10,7 @@
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Admin\Loader;
+use Automattic\WooCommerce\Admin\WCAdminHelper;
 
 /**
  * WC Calypso Bridge
@@ -113,6 +114,16 @@ class WC_Calypso_Bridge {
 				'wc-admin-online-clothing-store', // hide for now, to be revisited.
 				'wc-admin-selling-online-courses', // hide for now, to be revisited.
 			);
+
+			// Do not show the message if the site is active for less than 5 days.
+			if ( ! WCAdminHelper::is_wc_admin_active_for( 5 * DAY_IN_SECONDS ) ) {
+				$message_names[] = 'wc-refund-returns-page';
+			}
+
+			// Do not show the message if the site is active for less than 2 days.
+			if ( ! WCAdminHelper::is_wc_admin_active_for( 2 * DAY_IN_SECONDS ) ) {
+				$message_names[] = 'wc-calypso-bridge-cart-checkout-blocks-default-inbox-note';
+			}
 
 			$where_excluded_name_array = array();
 			foreach ( $message_names as $name ) {

--- a/includes/class-wc-calypso-bridge-helper-functions.php
+++ b/includes/class-wc-calypso-bridge-helper-functions.php
@@ -4,9 +4,10 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.2
- * @version 1.0.2
+ * @version 1.9.8
  */
 
+use Automattic\WooCommerce\Admin\WCAdminHelper;
 /**
  * WC_Calypso_Bridge_Helper_Functions.
  */
@@ -34,6 +35,26 @@ class WC_Calypso_Bridge_Helper_Functions {
 	 */
 	private function __construct() {
 		// Silence.
+	}
+
+	/**
+	 * Checks to see if WC Admin was installed later than a reference time.
+	 *
+	 * @since 1.9.8
+	 *
+	 * @param int $reference_timestamp Time to compare against.
+	 * @return bool
+	 */
+	public static function is_wc_admin_installed_gte( $reference_timestamp ) {
+
+		$install_timestamp = get_option( WCAdminHelper::WC_ADMIN_TIMESTAMP_OPTION );
+
+		if ( ! is_numeric( $install_timestamp ) ) {
+			$install_timestamp = time();
+			update_option( WCAdminHelper::WC_ADMIN_TIMESTAMP_OPTION, $install_timestamp );
+		}
+
+		return $install_timestamp > $reference_timestamp;
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-notes.php
+++ b/includes/class-wc-calypso-bridge-notes.php
@@ -3,6 +3,8 @@
  * Notes.
  *
  * @package WC_Calypso_Bridge/Classes
+ * @since   1.0.0
+ * @version 1.9.5
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -42,7 +44,10 @@ class WC_Calypso_Bridge_Notes {
 	 */
 	public function init() {
 		include_once dirname( __FILE__ ) . '/notes/class-wc-calypso-bridge-payments-remind-me-later-note.php';
+		include_once dirname( __FILE__ ) . '/notes/class-wc-calypso-bridge-cart-checkout-blocks-default-inbox-note.php';
+
 		new WC_Calypso_Bridge_Payments_Remind_Me_Later_Note();
+		new WC_Calypso_Bridge_Cart_Checkout_Blocks_Default_Inbox_Note();
 	}
 
 	/**
@@ -50,6 +55,7 @@ class WC_Calypso_Bridge_Notes {
 	 */
 	public function add_notes() {
 		WC_Calypso_Bridge_Payments_Remind_Me_Later_Note::possibly_add_note();
+		WC_Calypso_Bridge_Cart_Checkout_Blocks_Default_Inbox_Note::possibly_add_note();
 	}
 
 	/**
@@ -57,6 +63,7 @@ class WC_Calypso_Bridge_Notes {
 	 */
 	public function delete_notes() {
 		WC_Calypso_Bridge_Payments_Remind_Me_Later_Note::possibly_clear_note();
+		WC_Calypso_Bridge_Cart_Checkout_Blocks_Default_Inbox_Note::possibly_clear_note();
 	}
 }
 

--- a/includes/class-wc-calypso-bridge-notes.php
+++ b/includes/class-wc-calypso-bridge-notes.php
@@ -3,8 +3,6 @@
  * Notes.
  *
  * @package WC_Calypso_Bridge/Classes
- * @since   1.0.0
- * @version 1.9.5
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -44,10 +42,7 @@ class WC_Calypso_Bridge_Notes {
 	 */
 	public function init() {
 		include_once dirname( __FILE__ ) . '/notes/class-wc-calypso-bridge-payments-remind-me-later-note.php';
-		include_once dirname( __FILE__ ) . '/notes/class-wc-calypso-bridge-cart-checkout-blocks-default-inbox-note.php';
-
 		new WC_Calypso_Bridge_Payments_Remind_Me_Later_Note();
-		new WC_Calypso_Bridge_Cart_Checkout_Blocks_Default_Inbox_Note();
 	}
 
 	/**
@@ -55,7 +50,6 @@ class WC_Calypso_Bridge_Notes {
 	 */
 	public function add_notes() {
 		WC_Calypso_Bridge_Payments_Remind_Me_Later_Note::possibly_add_note();
-		WC_Calypso_Bridge_Cart_Checkout_Blocks_Default_Inbox_Note::possibly_add_note();
 	}
 
 	/**
@@ -63,7 +57,6 @@ class WC_Calypso_Bridge_Notes {
 	 */
 	public function delete_notes() {
 		WC_Calypso_Bridge_Payments_Remind_Me_Later_Note::possibly_clear_note();
-		WC_Calypso_Bridge_Cart_Checkout_Blocks_Default_Inbox_Note::possibly_clear_note();
 	}
 }
 

--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -41,6 +41,7 @@ class WC_Calypso_Bridge_Plugins {
 		add_action( 'update_option_active_plugins', array( $this, 'prevent_woocommerce_deactivation' ), 10, 2 );
 		add_action( 'current_screen', array( $this, 'prevent_woocommerce_deactivation_route' ), 10, 2 );
 		add_action( 'admin_notices', array( $this, 'prevent_woocommerce_deactivation_notice' ), 10, 2 );
+		add_filter( 'woocommerce_admin_onboarding_industries', array( $this, 'maybe_create_wc_pages' ), 10, 2 );
 		add_filter( 'woocommerce_create_pages', array( $this, 'add_blocks_to_cart_checkout_pages' ), 100, 2 );
 		add_filter( 'manage_product_posts_columns', array( $this, 'remove_jetpack_stats_column' ), 100 );
 		add_filter( 'default_hidden_columns', array( $this, 'hide_product_columns' ), 100, 2 );
@@ -103,6 +104,54 @@ class WC_Calypso_Bridge_Plugins {
 		}
 
 		return $actions;
+	}
+
+	/**
+	 * Check WooCommerce pages (shop, cart, my-account, checkout) and create them if the following conditions are met.
+	 *
+	 * 1. This is the first time running this method.
+	 * 2. User has not finished Store details task.
+	 * 3. Shop, cart, my-account, and checkout pages do not exist.
+	 *
+	 * @param array $industries Array of industries.
+	 *
+	 * @return array
+	 */
+	public function maybe_create_wc_pages( $industries ) {
+		global $wpdb;
+
+		$option_name = 'wc_pages_created_by_wc_calypso_bridge';
+
+		// Abort if we have attempted to create the pages already.
+		if ( 'yes' === get_option( $option_name, 'no' ) ) {
+			return $industries;
+		}
+
+		// Abort if the user has completed store details task already.
+		$completed_tasks = get_option( 'woocommerce_task_list_tracked_completed_tasks', [] );
+		if ( in_array( 'store_details', $completed_tasks ) ) {
+			return $industries;
+		}
+
+		$post_count = $wpdb->get_var( "select count(*) from $wpdb->posts where post_name in ('shop', 'cart', 'my-account', 'checkout')" );
+
+		// Abort if we find any existing pages.
+		if ( 0 !== (int) $post_count ) {
+			return $industries;
+		}
+
+		// Reset the woocommerce_*_page_id options.
+		// This is needed as woocommerce_*_page_id options have incorrect values on a fresh installation
+		// for an ecom plan. WC_Install:create_pages() might not create all the
+		// required pages without resetting these options first.
+		foreach ( [ 'shop', 'cart', 'myaccount', 'checkout' ] as $page ) {
+			delete_option( "woocommerce_{$page}_page_id" );
+		}
+
+		WC_Install::create_pages();
+		update_option( $option_name, 'yes' );
+
+		return $industries;
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -5,7 +5,7 @@
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
  * @version 1.9.5
- * @version 1.9.7
+ * @version 1.9.8
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -41,8 +41,6 @@ class WC_Calypso_Bridge_Plugins {
 		add_action( 'update_option_active_plugins', array( $this, 'prevent_woocommerce_deactivation' ), 10, 2 );
 		add_action( 'current_screen', array( $this, 'prevent_woocommerce_deactivation_route' ), 10, 2 );
 		add_action( 'admin_notices', array( $this, 'prevent_woocommerce_deactivation_notice' ), 10, 2 );
-		add_filter( 'woocommerce_admin_onboarding_industries', array( $this, 'maybe_create_wc_pages' ), 10, 2 );
-		add_filter( 'woocommerce_create_pages', array( $this, 'add_blocks_to_cart_checkout_pages' ), 100, 2 );
 		add_filter( 'manage_product_posts_columns', array( $this, 'remove_jetpack_stats_column' ), 100 );
 		add_filter( 'default_hidden_columns', array( $this, 'hide_product_columns' ), 100, 2 );
 	}
@@ -104,76 +102,6 @@ class WC_Calypso_Bridge_Plugins {
 		}
 
 		return $actions;
-	}
-
-	/**
-	 * Check WooCommerce pages (shop, cart, my-account, checkout) and create them if the following conditions are met.
-	 *
-	 * 1. This is the first time running this method.
-	 * 2. User has not finished Store details task.
-	 * 3. Shop, cart, my-account, and checkout pages do not exist.
-	 *
-	 * @param array $industries Array of industries.
-	 *
-	 * @return array
-	 */
-	public function maybe_create_wc_pages( $industries ) {
-		global $wpdb;
-
-		$option_name = 'wc_pages_created_by_wc_calypso_bridge';
-
-		// Abort if we have attempted to create the pages already.
-		if ( 'yes' === get_option( $option_name, 'no' ) ) {
-			return $industries;
-		}
-
-		// Abort if the user has completed store details task already.
-		$completed_tasks = get_option( 'woocommerce_task_list_tracked_completed_tasks', [] );
-		if ( in_array( 'store_details', $completed_tasks ) ) {
-			return $industries;
-		}
-
-		$post_count = $wpdb->get_var( "select count(*) from $wpdb->posts where post_name in ('shop', 'cart', 'my-account', 'checkout')" );
-
-		// Abort if we find any existing pages.
-		if ( 0 !== (int) $post_count ) {
-			return $industries;
-		}
-
-		// Reset the woocommerce_*_page_id options.
-		// This is needed as woocommerce_*_page_id options have incorrect values on a fresh installation
-		// for an ecom plan. WC_Install:create_pages() might not create all the
-		// required pages without resetting these options first.
-		foreach ( [ 'shop', 'cart', 'myaccount', 'checkout' ] as $page ) {
-			delete_option( "woocommerce_{$page}_page_id" );
-		}
-
-		WC_Install::create_pages();
-		update_option( $option_name, 'yes' );
-
-		return $industries;
-	}
-
-	/**
-	 * When WooCommerce creates the pages that it relies on,
-	 * filter the pages to add the blocks to the cart and checkout pages.
-	 *
-	 * @since 1.9.5
-	 *
-	 * @param array $pages Array of pages to be created.
-	 * @return array
-	 */
-	public function add_blocks_to_cart_checkout_pages( $pages ) {
-
-		if ( isset( $pages['cart']['content'] ) ) {
-			$pages['cart']['content'] = '<!-- wp:woocommerce/cart --><div class="wp-block-woocommerce-cart is-loading"><!-- wp:woocommerce/filled-cart-block --><div class="wp-block-woocommerce-filled-cart-block"><!-- wp:woocommerce/cart-items-block --><div class="wp-block-woocommerce-cart-items-block"><!-- wp:woocommerce/cart-line-items-block --><div class="wp-block-woocommerce-cart-line-items-block"></div><!-- /wp:woocommerce/cart-line-items-block --></div><!-- /wp:woocommerce/cart-items-block --><!-- wp:woocommerce/cart-totals-block --><div class="wp-block-woocommerce-cart-totals-block"><!-- wp:woocommerce/cart-order-summary-block --><div class="wp-block-woocommerce-cart-order-summary-block"></div><!-- /wp:woocommerce/cart-order-summary-block --><!-- wp:woocommerce/cart-express-payment-block --><div class="wp-block-woocommerce-cart-express-payment-block"></div><!-- /wp:woocommerce/cart-express-payment-block --><!-- wp:woocommerce/proceed-to-checkout-block --><div class="wp-block-woocommerce-proceed-to-checkout-block"></div><!-- /wp:woocommerce/proceed-to-checkout-block --><!-- wp:woocommerce/cart-accepted-payment-methods-block --><div class="wp-block-woocommerce-cart-accepted-payment-methods-block"></div><!-- /wp:woocommerce/cart-accepted-payment-methods-block --></div><!-- /wp:woocommerce/cart-totals-block --></div><!-- /wp:woocommerce/filled-cart-block --><!-- wp:woocommerce/empty-cart-block --><div class="wp-block-woocommerce-empty-cart-block"><!-- wp:image {"align":"center","sizeSlug":"small"} --><div class="wp-block-image"><figure class="aligncenter size-small"><img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzgiIGhlaWdodD0iMzgiIHZpZXdCb3g9IjAgMCAzOCAzOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE5IDBDOC41MDQwMyAwIDAgOC41MDQwMyAwIDE5QzAgMjkuNDk2IDguNTA0MDMgMzggMTkgMzhDMjkuNDk2IDM4IDM4IDI5LjQ5NiAzOCAxOUMzOCA4LjUwNDAzIDI5LjQ5NiAwIDE5IDBaTTI1LjEyOSAxMi44NzFDMjYuNDg1MSAxMi44NzEgMjcuNTgwNiAxMy45NjY1IDI3LjU4MDYgMTUuMzIyNkMyNy41ODA2IDE2LjY3ODYgMjYuNDg1MSAxNy43NzQyIDI1LjEyOSAxNy43NzQyQzIzLjc3MyAxNy43NzQyIDIyLjY3NzQgMTYuNjc4NiAyMi42Nzc0IDE1LjMyMjZDMjIuNjc3NCAxMy45NjY1IDIzLjc3MyAxMi44NzEgMjUuMTI5IDEyLjg3MVpNMTEuNjQ1MiAzMS4yNTgxQzkuNjE0OTIgMzEuMjU4MSA3Ljk2Nzc0IDI5LjY0OTIgNy45Njc3NCAyNy42NTczQzcuOTY3NzQgMjYuMTI1IDEwLjE1MTIgMjMuMDI5OCAxMS4xNTQ4IDIxLjY5NjhDMTEuNCAyMS4zNjczIDExLjg5MDMgMjEuMzY3MyAxMi4xMzU1IDIxLjY5NjhDMTMuMTM5MSAyMy4wMjk4IDE1LjMyMjYgMjYuMTI1IDE1LjMyMjYgMjcuNjU3M0MxNS4zMjI2IDI5LjY0OTIgMTMuNjc1NCAzMS4yNTgxIDExLjY0NTIgMzEuMjU4MVpNMTIuODcxIDE3Ljc3NDJDMTEuNTE0OSAxNy43NzQyIDEwLjQxOTQgMTYuNjc4NiAxMC40MTk0IDE1LjMyMjZDMTAuNDE5NCAxMy45NjY1IDExLjUxNDkgMTIuODcxIDEyLjg3MSAxMi44NzFDMTQuMjI3IDEyLjg3MSAxNS4zMjI2IDEzLjk2NjUgMTUuMzIyNiAxNS4zMjI2QzE1LjMyMjYgMTYuNjc4NiAxNC4yMjcgMTcuNzc0MiAxMi44NzEgMTcuNzc0MlpNMjUuOTEwNSAyOS41ODc5QzI0LjE5NDQgMjcuNTM0NyAyMS42NzM4IDI2LjM1NDggMTkgMjYuMzU0OEMxNy4zNzU4IDI2LjM1NDggMTcuMzc1OCAyMy45MDMyIDE5IDIzLjkwMzJDMjIuNDAxNiAyMy45MDMyIDI1LjYxMTcgMjUuNDA0OCAyNy43ODc1IDI4LjAyNUMyOC44NDQ4IDI5LjI4MTUgMjYuOTI5NCAzMC44MjE0IDI1LjkxMDUgMjkuNTg3OVoiIGZpbGw9ImJsYWNrIi8+Cjwvc3ZnPgo=" alt=""/></figure></div><!-- /wp:image --><!-- wp:heading {"textAlign":"center","className":"wc-block-cart__empty-cart__title"} --><h2 class="has-text-align-center wc-block-cart__empty-cart__title">Your cart is currently empty!</h2><!-- /wp:heading --><!-- wp:paragraph {"align":"center"} --><p class="has-text-align-center"><a href="http://localhost:8889/shop/">Browse store</a>.</p><!-- /wp:paragraph --><!-- wp:separator {"className":"is-style-dots"} --><hr class="wp-block-separator is-style-dots"/><!-- /wp:separator --><!-- wp:heading {"textAlign":"center"} --><h2 class="has-text-align-center">New in store</h2><!-- /wp:heading --><!-- wp:woocommerce/product-new {"rows":1} /--></div><!-- /wp:woocommerce/empty-cart-block --></div><!-- /wp:woocommerce/cart -->';
-		}
-
-		if ( isset( $pages['checkout']['content'] ) ) {
-			$pages['checkout']['content'] = '<!-- wp:woocommerce/checkout --><div class="wp-block-woocommerce-checkout wc-block-checkout is-loading"><!-- wp:woocommerce/checkout-fields-block --><div class="wp-block-woocommerce-checkout-fields-block"><!-- wp:woocommerce/checkout-express-payment-block --><div class="wp-block-woocommerce-checkout-express-payment-block"></div><!-- /wp:woocommerce/checkout-express-payment-block --><!-- wp:woocommerce/checkout-contact-information-block --><div class="wp-block-woocommerce-checkout-contact-information-block"></div><!-- /wp:woocommerce/checkout-contact-information-block --><!-- wp:woocommerce/checkout-shipping-address-block --><div class="wp-block-woocommerce-checkout-shipping-address-block"></div><!-- /wp:woocommerce/checkout-shipping-address-block --><!-- wp:woocommerce/checkout-billing-address-block --><div class="wp-block-woocommerce-checkout-billing-address-block"></div><!-- /wp:woocommerce/checkout-billing-address-block --><!-- wp:woocommerce/checkout-shipping-methods-block --><div class="wp-block-woocommerce-checkout-shipping-methods-block"></div><!-- /wp:woocommerce/checkout-shipping-methods-block --><!-- wp:woocommerce/checkout-payment-block --><div class="wp-block-woocommerce-checkout-payment-block"></div><!-- /wp:woocommerce/checkout-payment-block --><!-- wp:woocommerce/checkout-order-note-block --><div class="wp-block-woocommerce-checkout-order-note-block"></div><!-- /wp:woocommerce/checkout-order-note-block --><!-- wp:woocommerce/checkout-terms-block --><div class="wp-block-woocommerce-checkout-terms-block"></div><!-- /wp:woocommerce/checkout-terms-block --><!-- wp:woocommerce/checkout-actions-block --><div class="wp-block-woocommerce-checkout-actions-block"></div><!-- /wp:woocommerce/checkout-actions-block --></div><!-- /wp:woocommerce/checkout-fields-block --><!-- wp:woocommerce/checkout-totals-block --><div class="wp-block-woocommerce-checkout-totals-block"><!-- wp:woocommerce/checkout-order-summary-block --><div class="wp-block-woocommerce-checkout-order-summary-block"></div><!-- /wp:woocommerce/checkout-order-summary-block --></div><!-- /wp:woocommerce/checkout-totals-block --></div><!-- /wp:woocommerce/checkout -->';
-		}
-
-		return $pages;
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -190,6 +190,69 @@ class WC_Calypso_Bridge_Setup {
 	}
 
 	/**
+	 * Defines the Jetpack modules active in the Ecommerce Plan by default.
+	 *
+	 * @since 1.9.8
+	 * @return void
+	 */
+	public function set_jetpack_defaults() {
+
+		add_action( 'init', function () {
+
+			$active_modules = array(
+				'manage',
+				'masterbar',
+				'json-api',
+				'sharedaddy',
+				'google-fonts',
+				'sso',
+				'notes',
+				'protect',
+				'latex',
+				'carousel',
+				'comment-likes',
+				'comments',
+				'contact-form',
+				'widgets',
+				'likes',
+				'shortcodes',
+				'markdown',
+				'search',
+				'subscriptions',
+				'tiled-gallery',
+				'videopress',
+				'shortlinks',
+				'woocommerce-analytics',
+				'monitor',
+				'seo-tools',
+				'custom-css',
+				'publicize',
+				'verification-tools',
+				'sitemaps',
+			);
+
+			$sharing_options = array(
+				'global' => array(
+					'button_style'  => 'icon',
+					'sharing_label' => '',
+					'open_links'    => 'same',
+					'show'          => array( 'post' ),
+					'custom'        => array(),
+				),
+			);
+
+			// Set defaults only if the store is brand new (been active for less than 5 minutes).
+			if ( ! WCAdminHelper::is_wc_admin_active_for( 300 ) ) {
+				update_option( 'jetpack_active_modules', $active_modules );
+				update_option( 'sharing-options', $sharing_options );
+			}
+
+			$this->set_one_time_operation_complete( 'set_jetpack_defaults' );
+
+		} );
+	}
+
+	/**
 	 * Save the one-time operations' status .
 	 *
 	 * @since 1.9.4

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -142,6 +142,11 @@ class WC_Calypso_Bridge_Setup {
 				delete_option( "woocommerce_{$page}_page_id" );
 			}
 
+			// Delete the following note, so it can be recreated with the correct page IDs.
+			if ( class_exists( 'Automattic\WooCommerce\Admin\Notes\Notes' ) ) {
+				Automattic\WooCommerce\Admin\Notes\Notes::delete_notes_with_name( 'wc-refund-returns-page' );
+			}
+
 			WC_Install::create_pages();
 			$this->set_one_time_operation_complete( 'woocommerce_create_pages' );
 
@@ -150,6 +155,7 @@ class WC_Calypso_Bridge_Setup {
 		// Gets triggered from the above WC_Install::create_pages call.
 		add_filter( 'woocommerce_create_pages', function ( $pages ) {
 
+			// Set the cart and checkout blocks as defaults.
 			if (
 				class_exists( 'Automattic\WooCommerce\Blocks\Package' )
 				&& WC_Calypso_Bridge_Helper_Functions::is_wc_admin_installed_gte( WC_Calypso_Bridge::W44_2022_RELEASE_DATE )
@@ -162,6 +168,12 @@ class WC_Calypso_Bridge_Setup {
 				if ( isset( $pages['checkout']['content'] ) ) {
 					$pages['checkout']['content'] = '<!-- wp:woocommerce/checkout --><div class="wp-block-woocommerce-checkout wc-block-checkout is-loading"><!-- wp:woocommerce/checkout-fields-block --><div class="wp-block-woocommerce-checkout-fields-block"><!-- wp:woocommerce/checkout-express-payment-block --><div class="wp-block-woocommerce-checkout-express-payment-block"></div><!-- /wp:woocommerce/checkout-express-payment-block --><!-- wp:woocommerce/checkout-contact-information-block --><div class="wp-block-woocommerce-checkout-contact-information-block"></div><!-- /wp:woocommerce/checkout-contact-information-block --><!-- wp:woocommerce/checkout-shipping-address-block --><div class="wp-block-woocommerce-checkout-shipping-address-block"></div><!-- /wp:woocommerce/checkout-shipping-address-block --><!-- wp:woocommerce/checkout-billing-address-block --><div class="wp-block-woocommerce-checkout-billing-address-block"></div><!-- /wp:woocommerce/checkout-billing-address-block --><!-- wp:woocommerce/checkout-shipping-methods-block --><div class="wp-block-woocommerce-checkout-shipping-methods-block"></div><!-- /wp:woocommerce/checkout-shipping-methods-block --><!-- wp:woocommerce/checkout-payment-block --><div class="wp-block-woocommerce-checkout-payment-block"></div><!-- /wp:woocommerce/checkout-payment-block --><!-- wp:woocommerce/checkout-order-note-block --><div class="wp-block-woocommerce-checkout-order-note-block"></div><!-- /wp:woocommerce/checkout-order-note-block --><!-- wp:woocommerce/checkout-terms-block --><div class="wp-block-woocommerce-checkout-terms-block"></div><!-- /wp:woocommerce/checkout-terms-block --><!-- wp:woocommerce/checkout-actions-block --><div class="wp-block-woocommerce-checkout-actions-block"></div><!-- /wp:woocommerce/checkout-actions-block --></div><!-- /wp:woocommerce/checkout-fields-block --><!-- wp:woocommerce/checkout-totals-block --><div class="wp-block-woocommerce-checkout-totals-block"><!-- wp:woocommerce/checkout-order-summary-block --><div class="wp-block-woocommerce-checkout-order-summary-block"></div><!-- /wp:woocommerce/checkout-order-summary-block --></div><!-- /wp:woocommerce/checkout-totals-block --></div><!-- /wp:woocommerce/checkout -->';
 				}
+
+				// Inform the merchant that we've enabled the new checkout experience.
+				include_once dirname( __FILE__ ) . '/notes/class-wc-calypso-bridge-cart-checkout-blocks-default-inbox-note.php';
+				new WC_Calypso_Bridge_Cart_Checkout_Blocks_Default_Inbox_Note();
+				WC_Calypso_Bridge_Cart_Checkout_Blocks_Default_Inbox_Note::possibly_add_note();
+
 			}
 
 			return $pages;

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -115,13 +115,58 @@ class WC_Calypso_Bridge_Setup {
 	}
 
 	/**
-	 * Delete all `wc-admin-coupon-page-moved` notes and sets the operation as completed.
+	 * Create WooCommerce pages, set the cart/checkout blocks and set the operation as completed.
 	 *
 	 * @since 1.9.8
 	 * @return void
-	 * @todo
 	 */
 	public function woocommerce_create_pages_callback() {
+
+		add_action( 'admin_init', function () {
+
+			global $wpdb;
+			$post_count = (int) $wpdb->get_var( "select count(*) from $wpdb->posts where post_name in ('shop', 'cart', 'my-account', 'checkout')" );
+
+			// Abort if we find any existing pages.
+			if ( 4 === $post_count ) {
+				$this->set_one_time_operation_complete( 'woocommerce_create_pages' );
+
+				return;
+			}
+
+			// Reset the woocommerce_*_page_id options.
+			// This is needed as woocommerce_*_page_id options have incorrect values on a fresh installation
+			// for an ecommerce plan. WC_Install:create_pages() might not create all the
+			// required pages without resetting these options first.
+			foreach ( [ 'shop', 'cart', 'myaccount', 'checkout' ] as $page ) {
+				delete_option( "woocommerce_{$page}_page_id" );
+			}
+
+			WC_Install::create_pages();
+			$this->set_one_time_operation_complete( 'woocommerce_create_pages' );
+
+		}, PHP_INT_MAX );
+
+		// Gets triggered from the above WC_Install::create_pages call.
+		add_filter( 'woocommerce_create_pages', function ( $pages ) {
+
+			if (
+				class_exists( 'Automattic\WooCommerce\Blocks\Package' )
+				&& WC_Calypso_Bridge_Helper_Functions::is_wc_admin_installed_gte( WC_Calypso_Bridge::W44_2022_S4_RELEASE_DATE )
+				&& version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '8.7.4' ) >= 0
+			) {
+				if ( isset( $pages['cart']['content'] ) ) {
+					$pages['cart']['content'] = '<!-- wp:woocommerce/cart --><div class="wp-block-woocommerce-cart is-loading"><!-- wp:woocommerce/filled-cart-block --><div class="wp-block-woocommerce-filled-cart-block"><!-- wp:woocommerce/cart-items-block --><div class="wp-block-woocommerce-cart-items-block"><!-- wp:woocommerce/cart-line-items-block --><div class="wp-block-woocommerce-cart-line-items-block"></div><!-- /wp:woocommerce/cart-line-items-block --></div><!-- /wp:woocommerce/cart-items-block --><!-- wp:woocommerce/cart-totals-block --><div class="wp-block-woocommerce-cart-totals-block"><!-- wp:woocommerce/cart-order-summary-block --><div class="wp-block-woocommerce-cart-order-summary-block"></div><!-- /wp:woocommerce/cart-order-summary-block --><!-- wp:woocommerce/cart-express-payment-block --><div class="wp-block-woocommerce-cart-express-payment-block"></div><!-- /wp:woocommerce/cart-express-payment-block --><!-- wp:woocommerce/proceed-to-checkout-block --><div class="wp-block-woocommerce-proceed-to-checkout-block"></div><!-- /wp:woocommerce/proceed-to-checkout-block --><!-- wp:woocommerce/cart-accepted-payment-methods-block --><div class="wp-block-woocommerce-cart-accepted-payment-methods-block"></div><!-- /wp:woocommerce/cart-accepted-payment-methods-block --></div><!-- /wp:woocommerce/cart-totals-block --></div><!-- /wp:woocommerce/filled-cart-block --><!-- wp:woocommerce/empty-cart-block --><div class="wp-block-woocommerce-empty-cart-block"><!-- wp:image {"align":"center","sizeSlug":"small"} --><div class="wp-block-image"><figure class="aligncenter size-small"><img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzgiIGhlaWdodD0iMzgiIHZpZXdCb3g9IjAgMCAzOCAzOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE5IDBDOC41MDQwMyAwIDAgOC41MDQwMyAwIDE5QzAgMjkuNDk2IDguNTA0MDMgMzggMTkgMzhDMjkuNDk2IDM4IDM4IDI5LjQ5NiAzOCAxOUMzOCA4LjUwNDAzIDI5LjQ5NiAwIDE5IDBaTTI1LjEyOSAxMi44NzFDMjYuNDg1MSAxMi44NzEgMjcuNTgwNiAxMy45NjY1IDI3LjU4MDYgMTUuMzIyNkMyNy41ODA2IDE2LjY3ODYgMjYuNDg1MSAxNy43NzQyIDI1LjEyOSAxNy43NzQyQzIzLjc3MyAxNy43NzQyIDIyLjY3NzQgMTYuNjc4NiAyMi42Nzc0IDE1LjMyMjZDMjIuNjc3NCAxMy45NjY1IDIzLjc3MyAxMi44NzEgMjUuMTI5IDEyLjg3MVpNMTEuNjQ1MiAzMS4yNTgxQzkuNjE0OTIgMzEuMjU4MSA3Ljk2Nzc0IDI5LjY0OTIgNy45Njc3NCAyNy42NTczQzcuOTY3NzQgMjYuMTI1IDEwLjE1MTIgMjMuMDI5OCAxMS4xNTQ4IDIxLjY5NjhDMTEuNCAyMS4zNjczIDExLjg5MDMgMjEuMzY3MyAxMi4xMzU1IDIxLjY5NjhDMTMuMTM5MSAyMy4wMjk4IDE1LjMyMjYgMjYuMTI1IDE1LjMyMjYgMjcuNjU3M0MxNS4zMjI2IDI5LjY0OTIgMTMuNjc1NCAzMS4yNTgxIDExLjY0NTIgMzEuMjU4MVpNMTIuODcxIDE3Ljc3NDJDMTEuNTE0OSAxNy43NzQyIDEwLjQxOTQgMTYuNjc4NiAxMC40MTk0IDE1LjMyMjZDMTAuNDE5NCAxMy45NjY1IDExLjUxNDkgMTIuODcxIDEyLjg3MSAxMi44NzFDMTQuMjI3IDEyLjg3MSAxNS4zMjI2IDEzLjk2NjUgMTUuMzIyNiAxNS4zMjI2QzE1LjMyMjYgMTYuNjc4NiAxNC4yMjcgMTcuNzc0MiAxMi44NzEgMTcuNzc0MlpNMjUuOTEwNSAyOS41ODc5QzI0LjE5NDQgMjcuNTM0NyAyMS42NzM4IDI2LjM1NDggMTkgMjYuMzU0OEMxNy4zNzU4IDI2LjM1NDggMTcuMzc1OCAyMy45MDMyIDE5IDIzLjkwMzJDMjIuNDAxNiAyMy45MDMyIDI1LjYxMTcgMjUuNDA0OCAyNy43ODc1IDI4LjAyNUMyOC44NDQ4IDI5LjI4MTUgMjYuOTI5NCAzMC44MjE0IDI1LjkxMDUgMjkuNTg3OVoiIGZpbGw9ImJsYWNrIi8+Cjwvc3ZnPgo=" alt=""/></figure></div><!-- /wp:image --><!-- wp:heading {"textAlign":"center","className":"wc-block-cart__empty-cart__title"} --><h2 class="has-text-align-center wc-block-cart__empty-cart__title">Your cart is currently empty!</h2><!-- /wp:heading --><!-- wp:paragraph {"align":"center"} --><p class="has-text-align-center"><a href="http://localhost:8889/shop/">Browse store</a>.</p><!-- /wp:paragraph --><!-- wp:separator {"className":"is-style-dots"} --><hr class="wp-block-separator is-style-dots"/><!-- /wp:separator --><!-- wp:heading {"textAlign":"center"} --><h2 class="has-text-align-center">New in store</h2><!-- /wp:heading --><!-- wp:woocommerce/product-new {"rows":1} /--></div><!-- /wp:woocommerce/empty-cart-block --></div><!-- /wp:woocommerce/cart -->';
+				}
+
+				if ( isset( $pages['checkout']['content'] ) ) {
+					$pages['checkout']['content'] = '<!-- wp:woocommerce/checkout --><div class="wp-block-woocommerce-checkout wc-block-checkout is-loading"><!-- wp:woocommerce/checkout-fields-block --><div class="wp-block-woocommerce-checkout-fields-block"><!-- wp:woocommerce/checkout-express-payment-block --><div class="wp-block-woocommerce-checkout-express-payment-block"></div><!-- /wp:woocommerce/checkout-express-payment-block --><!-- wp:woocommerce/checkout-contact-information-block --><div class="wp-block-woocommerce-checkout-contact-information-block"></div><!-- /wp:woocommerce/checkout-contact-information-block --><!-- wp:woocommerce/checkout-shipping-address-block --><div class="wp-block-woocommerce-checkout-shipping-address-block"></div><!-- /wp:woocommerce/checkout-shipping-address-block --><!-- wp:woocommerce/checkout-billing-address-block --><div class="wp-block-woocommerce-checkout-billing-address-block"></div><!-- /wp:woocommerce/checkout-billing-address-block --><!-- wp:woocommerce/checkout-shipping-methods-block --><div class="wp-block-woocommerce-checkout-shipping-methods-block"></div><!-- /wp:woocommerce/checkout-shipping-methods-block --><!-- wp:woocommerce/checkout-payment-block --><div class="wp-block-woocommerce-checkout-payment-block"></div><!-- /wp:woocommerce/checkout-payment-block --><!-- wp:woocommerce/checkout-order-note-block --><div class="wp-block-woocommerce-checkout-order-note-block"></div><!-- /wp:woocommerce/checkout-order-note-block --><!-- wp:woocommerce/checkout-terms-block --><div class="wp-block-woocommerce-checkout-terms-block"></div><!-- /wp:woocommerce/checkout-terms-block --><!-- wp:woocommerce/checkout-actions-block --><div class="wp-block-woocommerce-checkout-actions-block"></div><!-- /wp:woocommerce/checkout-actions-block --></div><!-- /wp:woocommerce/checkout-fields-block --><!-- wp:woocommerce/checkout-totals-block --><div class="wp-block-woocommerce-checkout-totals-block"><!-- wp:woocommerce/checkout-order-summary-block --><div class="wp-block-woocommerce-checkout-order-summary-block"></div><!-- /wp:woocommerce/checkout-order-summary-block --></div><!-- /wp:woocommerce/checkout-totals-block --></div><!-- /wp:woocommerce/checkout -->';
+				}
+			}
+
+			return $pages;
+
+		}, PHP_INT_MAX );
 
 	}
 

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -158,7 +158,7 @@ class WC_Calypso_Bridge_Setup {
 			// Set the cart and checkout blocks as defaults.
 			if (
 				class_exists( 'Automattic\WooCommerce\Blocks\Package' )
-				&& WC_Calypso_Bridge_Helper_Functions::is_wc_admin_installed_gte( WC_Calypso_Bridge::W44_2022_RELEASE_DATE )
+				&& WC_Calypso_Bridge_Helper_Functions::is_wc_admin_installed_gte( WC_Calypso_Bridge::RELEASE_DATE_DEFAULT_CHECKOUT_BLOCKS )
 				&& version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '8.7.4' ) >= 0
 			) {
 				if ( isset( $pages['cart']['content'] ) ) {

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -125,10 +125,10 @@ class WC_Calypso_Bridge_Setup {
 		add_action( 'woocommerce_init', function () {
 
 			global $wpdb;
-			$post_count = (int) $wpdb->get_var( "select count(*) from $wpdb->posts where post_name in ('shop', 'cart', 'my-account', 'checkout')" );
+			$post_count = (int) $wpdb->get_var( "select count(*) from $wpdb->posts where post_name in ('shop', 'cart', 'my-account', 'checkout', 'refund_returns')" );
 
 			// Abort if we find any existing pages.
-			if ( 4 === $post_count ) {
+			if ( 5 === $post_count ) {
 				$this->set_one_time_operation_complete( 'woocommerce_create_pages' );
 
 				return;
@@ -138,7 +138,7 @@ class WC_Calypso_Bridge_Setup {
 			// This is needed as woocommerce_*_page_id options have incorrect values on a fresh installation
 			// for an ecommerce plan. WC_Install:create_pages() might not create all the
 			// required pages without resetting these options first.
-			foreach ( [ 'shop', 'cart', 'myaccount', 'checkout' ] as $page ) {
+			foreach ( [ 'shop', 'cart', 'myaccount', 'checkout', 'refund_returns' ] as $page ) {
 				delete_option( "woocommerce_{$page}_page_id" );
 			}
 

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -142,7 +142,7 @@ class WC_Calypso_Bridge_Setup {
 				delete_option( "woocommerce_{$page}_page_id" );
 			}
 
-			// Delete the following note, so it can be recreated with the correct page IDs.
+			// Delete the following note, so it can be recreated with the correct refund page ID.
 			if ( class_exists( 'Automattic\WooCommerce\Admin\Notes\Notes' ) ) {
 				Automattic\WooCommerce\Admin\Notes\Notes::delete_notes_with_name( 'wc-refund-returns-page' );
 			}

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -48,6 +48,7 @@ class WC_Calypso_Bridge_Setup {
 	 */
 	private function __construct() {
 		$this->setup_one_time_operations();
+		add_action( 'shutdown', array( $this, 'save_one_time_operations_status' ), PHP_INT_MAX );
 
 		add_action( 'load-woocommerce_page_wc-settings', array( $this, 'redirect_store_details_onboarding' ) );
 		add_filter( 'pre_option_woocommerce_onboarding_profile', array( $this, 'set_onboarding_status_to_skipped' ), 100 );
@@ -56,7 +57,6 @@ class WC_Calypso_Bridge_Setup {
 		add_filter( 'woocommerce_admin_onboarding_themes', array( $this, 'remove_non_installed_themes' ) );
 		add_filter( 'wp_redirect', array( $this, 'prevent_redirects_on_activation' ), 10, 2 );
 		add_filter( 'pre_option_woocommerce_homescreen_enabled', array( $this, 'always_enable_homescreen' ) );
-		add_action( 'shutdown', array( $this, 'save_one_time_operations_status' ), PHP_INT_MAX );
 	}
 
 	/**
@@ -122,7 +122,7 @@ class WC_Calypso_Bridge_Setup {
 	 */
 	public function woocommerce_create_pages_callback() {
 
-		add_action( 'admin_init', function () {
+		add_action( 'woocommerce_init', function () {
 
 			global $wpdb;
 			$post_count = (int) $wpdb->get_var( "select count(*) from $wpdb->posts where post_name in ('shop', 'cart', 'my-account', 'checkout')" );
@@ -152,7 +152,7 @@ class WC_Calypso_Bridge_Setup {
 
 			if (
 				class_exists( 'Automattic\WooCommerce\Blocks\Package' )
-				&& WC_Calypso_Bridge_Helper_Functions::is_wc_admin_installed_gte( WC_Calypso_Bridge::W44_2022_S4_RELEASE_DATE )
+				&& WC_Calypso_Bridge_Helper_Functions::is_wc_admin_installed_gte( WC_Calypso_Bridge::W44_2022_RELEASE_DATE )
 				&& version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '8.7.4' ) >= 0
 			) {
 				if ( isset( $pages['cart']['content'] ) ) {

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 1.9.4
+ * @version 1.9.8
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -40,6 +40,7 @@ class WC_Calypso_Bridge_Setup {
 	 */
 	protected $one_time_operations = array(
 		'delete_coupon_moved_notes' => 'delete_coupon_moved_notes_callback',
+		'woocommerce_create_pages'  => 'woocommerce_create_pages_callback',
 	);
 
 	/**
@@ -111,6 +112,17 @@ class WC_Calypso_Bridge_Setup {
 			Automattic\WooCommerce\Admin\Notes\Notes::delete_notes_with_name( 'wc-admin-coupon-page-moved' );
 			$this->set_one_time_operation_complete( 'delete_coupon_moved_notes' );
 		}, PHP_INT_MAX );
+	}
+
+	/**
+	 * Delete all `wc-admin-coupon-page-moved` notes and sets the operation as completed.
+	 *
+	 * @since 1.9.8
+	 * @return void
+	 * @todo
+	 */
+	public function woocommerce_create_pages_callback() {
+
 	}
 
 	/**

--- a/includes/notes/class-wc-calypso-bridge-cart-checkout-blocks-default-inbox-note.php
+++ b/includes/notes/class-wc-calypso-bridge-cart-checkout-blocks-default-inbox-note.php
@@ -68,7 +68,7 @@ class WC_Calypso_Bridge_Cart_Checkout_Blocks_Default_Inbox_Note {
 		if (
 			class_exists( 'Automattic\WooCommerce\Blocks\Package' )
 			&& self::wc_admin_active_for( 2 * DAY_IN_SECONDS )
-			&& WC_Calypso_Bridge_Helper_Functions::is_wc_admin_installed_gte( WC_Calypso_Bridge::W44_2022_S4_RELEASE_DATE )
+			&& WC_Calypso_Bridge_Helper_Functions::is_wc_admin_installed_gte( WC_Calypso_Bridge::W44_2022_RELEASE_DATE )
 			&& version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '8.7.4' ) >= 0
 		) {
 			return true;

--- a/includes/notes/class-wc-calypso-bridge-cart-checkout-blocks-default-inbox-note.php
+++ b/includes/notes/class-wc-calypso-bridge-cart-checkout-blocks-default-inbox-note.php
@@ -5,7 +5,7 @@
  *
  * @package WC_Calypso_Bridge/Notes
  * @since   1.9.5
- * @version 1.9.5
+ * @version 1.9.8
  */
 
 use Automattic\WooCommerce\Admin\Notes\Note;
@@ -31,7 +31,6 @@ class WC_Calypso_Bridge_Cart_Checkout_Blocks_Default_Inbox_Note {
 	 * Get the note.
 	 *
 	 * @return void|Note
-	 * @todo Update note content and when to display the inbox note.
 	 */
 	public static function get_note() {
 		if ( ! self::should_display_note() ) {
@@ -42,7 +41,7 @@ class WC_Calypso_Bridge_Cart_Checkout_Blocks_Default_Inbox_Note {
 		$note->set_title( __( 'Meet our new, customizable checkout', 'wc-calypso-bridge' ) );
 		$note->set_content(
 			__(
-				'To future-proof your store, we have enabled our brand-new, conversion-optimized Cart and Checkout Blocks. Please take a few minutes to review some important information on Extension compatibility. Then, go ahead and customize the Cart and Checkout pages to suit your needs.',
+				'To future-proof your store, we have enabled the brand-new, conversion-optimized Cart and Checkout Blocks. Please take a few minutes to review some important information on Extension compatibility. Then, go ahead and customize the Cart and Checkout pages to suit your needs.',
 				'wc-calypso-bridge'
 			)
 		);
@@ -63,15 +62,13 @@ class WC_Calypso_Bridge_Cart_Checkout_Blocks_Default_Inbox_Note {
 	 * Returns true if we should display the note.
 	 *
 	 * @return Boolean
-	 * @todo Set the correct Blocks version, after fixes have been released.
-	 * @see  https://somewherewarmattic.wordpress.com/2022/10/07/enabling-cart-checkout-blocks-on-atomic-on-hold/
 	 */
 	public static function should_display_note() {
 
 		if (
 			class_exists( 'Automattic\WooCommerce\Blocks\Package' )
-			&& version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '7.0.0' ) > 0
 			&& self::wc_admin_active_for( 2 * DAY_IN_SECONDS )
+			&& version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '8.7.4' ) > 0
 		) {
 			return true;
 		}

--- a/includes/notes/class-wc-calypso-bridge-cart-checkout-blocks-default-inbox-note.php
+++ b/includes/notes/class-wc-calypso-bridge-cart-checkout-blocks-default-inbox-note.php
@@ -4,7 +4,7 @@
  * Cart Checkout Blocks Inbox Note
  *
  * @package WC_Calypso_Bridge/Notes
- * @since   1.9.5
+ * @since   1.9.8
  * @version 1.9.8
  */
 
@@ -33,15 +33,13 @@ class WC_Calypso_Bridge_Cart_Checkout_Blocks_Default_Inbox_Note {
 	 * @return void|Note
 	 */
 	public static function get_note() {
-		if ( ! self::should_display_note() ) {
-			return;
-		}
 
+		// Note is added from the woocommerce_create_pages one-time operation.
 		$note = new Note();
 		$note->set_title( __( 'Meet our new, customizable checkout', 'wc-calypso-bridge' ) );
 		$note->set_content(
 			__(
-				'To deliver a smooth checkout experience to your shoppers, we have supercharged your store with our brand-new, conversion-optimized checkout. Please take a few minutes to review some important information on Extension compatibility with the new Cart and Checkout Blocks. Then, go ahead and customize your store's Cart and Checkout pages.',
+				'To deliver a smooth checkout experience to your shoppers, we have supercharged your store with our brand-new, conversion-optimized checkout. Please take a few minutes to review some important information on Extension compatibility with the new Cart and Checkout Blocks. Then, go ahead and customize your store\'s Cart and Checkout pages.',
 				'wc-calypso-bridge'
 			)
 		);
@@ -56,37 +54,6 @@ class WC_Calypso_Bridge_Cart_Checkout_Blocks_Default_Inbox_Note {
 		);
 
 		return $note;
-	}
-
-	/**
-	 * Returns true if we should display the note.
-	 *
-	 * @return Boolean
-	 */
-	public static function should_display_note() {
-
-		if (
-			class_exists( 'Automattic\WooCommerce\Blocks\Package' )
-			&& self::wc_admin_active_for( 2 * DAY_IN_SECONDS )
-			&& WC_Calypso_Bridge_Helper_Functions::is_wc_admin_installed_gte( WC_Calypso_Bridge::W44_2022_RELEASE_DATE )
-			&& version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '8.7.4' ) >= 0
-		) {
-			return true;
-		}
-
-		return false;
-
-	}
-
-	/**
-	 * Delete note if we shouldn't display it and not been actioned on.
-	 *
-	 * @return void
-	 */
-	public static function possibly_clear_note() {
-		if ( ! self::should_display_note() && ! self::has_note_been_actioned() ) {
-			self::possibly_delete_note();
-		}
 	}
 
 }

--- a/includes/notes/class-wc-calypso-bridge-cart-checkout-blocks-default-inbox-note.php
+++ b/includes/notes/class-wc-calypso-bridge-cart-checkout-blocks-default-inbox-note.php
@@ -49,7 +49,7 @@ class WC_Calypso_Bridge_Cart_Checkout_Blocks_Default_Inbox_Note {
 		$note->set_content_data( (object) array() );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
-		$note->set_source( 'woocommerce-admin' );
+		$note->set_source( 'wc-calypso-bridge' );
 		$note->add_action(
 			'learn-more',
 			__( 'Learn more', 'wc-calypso-bridge' ),

--- a/includes/notes/class-wc-calypso-bridge-cart-checkout-blocks-default-inbox-note.php
+++ b/includes/notes/class-wc-calypso-bridge-cart-checkout-blocks-default-inbox-note.php
@@ -39,11 +39,11 @@ class WC_Calypso_Bridge_Cart_Checkout_Blocks_Default_Inbox_Note {
 		}
 
 		$note = new Note();
-		$note->set_title( __( 'TODO: Default Cart/Checkout Blocks', 'wc-calypso-bridge' ) );
+		$note->set_title( __( 'Meet your new, customizable checkout', 'wc-calypso-bridge' ) );
 		$note->set_content(
 			__(
-				'TODO:The new cart and checkout blocks are set by default. Be aware that not all plugins are compatible. You can still use the old blocks if you prefer.',
-				'woocommerce'
+				'To future-proof your store, we have enabled our brand-new, conversion-optimized Cart and Checkout Blocks. Please take a few minutes to review some important information on Extension compatibility. Then, go ahead and customize the Cart and Checkout pages to suit your needs.',
+				'wc-calypso-bridge'
 			)
 		);
 		$note->set_content_data( (object) array() );
@@ -53,7 +53,7 @@ class WC_Calypso_Bridge_Cart_Checkout_Blocks_Default_Inbox_Note {
 		$note->add_action(
 			'learn-more',
 			__( 'Learn more', 'wc-calypso-bridge' ),
-			'https://woocommerce.com/document/managing-products/?utm_source=inbox&utm_medium=product'
+			'https://woocommerce.com/document/cart-checkout-blocks-support-status/'
 		);
 
 		return $note;

--- a/includes/notes/class-wc-calypso-bridge-cart-checkout-blocks-default-inbox-note.php
+++ b/includes/notes/class-wc-calypso-bridge-cart-checkout-blocks-default-inbox-note.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * WooCommerce Calypso Bridge
+ * Cart Checkout Blocks Inbox Note
+ *
+ * @package WC_Calypso_Bridge/Notes
+ * @since   1.9.5
+ * @version 1.9.5
+ */
+
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Calypso_Bridge_Cart_Checkout_Blocks_Default_Inbox_Note
+ */
+class WC_Calypso_Bridge_Cart_Checkout_Blocks_Default_Inbox_Note {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-calypso-bridge-cart-checkout-blocks-default-inbox-note';
+
+	/**
+	 * Get the note.
+	 *
+	 * @return void|Note
+	 * @todo Update note content and when to display the inbox note.
+	 */
+	public static function get_note() {
+		if ( ! self::should_display_note() ) {
+			return;
+		}
+
+		$note = new Note();
+		$note->set_title( __( 'TODO: Default Cart/Checkout Blocks', 'wc-calypso-bridge' ) );
+		$note->set_content(
+			__(
+				'TODO:The new cart and checkout blocks are set by default. Be aware that not all plugins are compatible. You can still use the old blocks if you prefer.',
+				'woocommerce'
+			)
+		);
+		$note->set_content_data( (object) array() );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'learn-more',
+			__( 'Learn more', 'wc-calypso-bridge' ),
+			'https://woocommerce.com/document/managing-products/?utm_source=inbox&utm_medium=product'
+		);
+
+		return $note;
+	}
+
+	/**
+	 * Returns true if we should display the note.
+	 *
+	 * @return Boolean
+	 * @todo Set the correct Blocks version, after fixes have been released.
+	 * @see  https://somewherewarmattic.wordpress.com/2022/10/07/enabling-cart-checkout-blocks-on-atomic-on-hold/
+	 */
+	public static function should_display_note() {
+
+		if (
+			class_exists( 'Automattic\WooCommerce\Blocks\Package' )
+			&& version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '7.0.0' ) > 0
+			&& self::wc_admin_active_for( 2 * DAY_IN_SECONDS )
+		) {
+			return true;
+		}
+
+		return false;
+
+	}
+
+	/**
+	 * Delete note if we shouldn't display it and not been actioned on.
+	 *
+	 * @return void
+	 */
+	public static function possibly_clear_note() {
+		if ( ! self::should_display_note() && ! self::has_note_been_actioned() ) {
+			self::possibly_delete_note();
+		}
+	}
+
+}

--- a/includes/notes/class-wc-calypso-bridge-cart-checkout-blocks-default-inbox-note.php
+++ b/includes/notes/class-wc-calypso-bridge-cart-checkout-blocks-default-inbox-note.php
@@ -68,7 +68,8 @@ class WC_Calypso_Bridge_Cart_Checkout_Blocks_Default_Inbox_Note {
 		if (
 			class_exists( 'Automattic\WooCommerce\Blocks\Package' )
 			&& self::wc_admin_active_for( 2 * DAY_IN_SECONDS )
-			&& version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '8.7.4' ) > 0
+			&& WC_Calypso_Bridge_Helper_Functions::is_wc_admin_installed_gte( WC_Calypso_Bridge::W44_2022_S4_RELEASE_DATE )
+			&& version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '8.7.4' ) >= 0
 		) {
 			return true;
 		}

--- a/includes/notes/class-wc-calypso-bridge-cart-checkout-blocks-default-inbox-note.php
+++ b/includes/notes/class-wc-calypso-bridge-cart-checkout-blocks-default-inbox-note.php
@@ -39,7 +39,7 @@ class WC_Calypso_Bridge_Cart_Checkout_Blocks_Default_Inbox_Note {
 		}
 
 		$note = new Note();
-		$note->set_title( __( 'Meet your new, customizable checkout', 'wc-calypso-bridge' ) );
+		$note->set_title( __( 'Meet our new, customizable checkout', 'wc-calypso-bridge' ) );
 		$note->set_content(
 			__(
 				'To future-proof your store, we have enabled our brand-new, conversion-optimized Cart and Checkout Blocks. Please take a few minutes to review some important information on Extension compatibility. Then, go ahead and customize the Cart and Checkout pages to suit your needs.',

--- a/includes/notes/class-wc-calypso-bridge-cart-checkout-blocks-default-inbox-note.php
+++ b/includes/notes/class-wc-calypso-bridge-cart-checkout-blocks-default-inbox-note.php
@@ -41,7 +41,7 @@ class WC_Calypso_Bridge_Cart_Checkout_Blocks_Default_Inbox_Note {
 		$note->set_title( __( 'Meet our new, customizable checkout', 'wc-calypso-bridge' ) );
 		$note->set_content(
 			__(
-				'To future-proof your store, we have enabled the brand-new, conversion-optimized Cart and Checkout Blocks. Please take a few minutes to review some important information on Extension compatibility. Then, go ahead and customize the Cart and Checkout pages to suit your needs.',
+				'To deliver a smooth checkout experience to your shoppers, we have supercharged your store with our brand-new, conversion-optimized checkout. Please take a few minutes to review some important information on Extension compatibility with the new Cart and Checkout Blocks. Then, go ahead and customize the Cart and Checkout pages to suit your needs.',
 				'wc-calypso-bridge'
 			)
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,10 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 1.9.8 =
+* Create WooCommerce pages with a one-time operation #XXX.
+* Set default to block-based cart/checkout #XXX.
+
 = 1.9.7 =
 * Revert: Hook `maybe_create_wc_pages` on `woocommerce_installed` #842.
 

--- a/readme.txt
+++ b/readme.txt
@@ -24,7 +24,10 @@ This section describes how to install the plugin and get it working.
 
 = 1.9.8 =
 * Create WooCommerce pages with a one-time operation #XXX.
+* Delete wc-refund-returns-page inbox note, so it can be recreated with the correct refund page ID #XXX.
 * Set default to block-based cart/checkout #XXX.
+* Display note about the new block-based cart/checkout if the site is active for more than 2 days  #XXX.
+* Display wc-refund-returns-page inbox note if the site is active for more than 5 days #XXX.
 
 = 1.9.7 =
 * Revert: Hook `maybe_create_wc_pages` on `woocommerce_installed` #842.


### PR DESCRIPTION
closes #822 #848 

* Create WooCommerce pages with a one-time operation
* Delete wc-refund-returns-page inbox note, so it can be recreated with the correct refund page ID
* Set default to block-based cart/checkout
* Display note about the new block-based cart/checkout if the site is active for more than 2 days
* Display wc-refund-returns-page inbox note if the site is active for more than 5 days