### PR TITLE
Limit activity panels to Woo Home page

### DIFF
--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 1.9.4
+ * @version 1.9.5
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -81,15 +81,16 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 	/**
 	 * Add is-woocommerce-home body class.
 	 *
-	 * @param string $classes Body classes.
+	 * @since   1.9.5
 	 *
+	 * @param string $classes Body classes.
 	 * @return string
 	 */
 	public function filter_woocommerce_body_classes( $classes ) {
 
 		$page = PageController::get_instance()->get_current_page();
 
-		if ( $page && 'woocommerce-home' === $page[ 'id' ] ) {
+		if ( $page && 'woocommerce-home' === $page['id'] ) {
 			$classes .= ' is-woocommerce-home';
 		}
 
@@ -99,6 +100,8 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 	/**
 	 * Add custom CSS to hide activity panels in all WooCommerce pages other than Home.
 	 * Note that this is not possible via the 'woocommerce_admin_features' filter, as we don't have access to the screen id at that point.
+	 *
+	 * @since   1.9.5
 	 *
 	 * @return void
 	 */

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -9,6 +9,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\PageController;
+
 /**
  * WC EComm Bridge
  */
@@ -38,6 +40,10 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 
 		add_filter( 'woocommerce_admin_features', array( $this, 'filter_wc_admin_enabled_features' ) );
 		add_filter( 'woocommerce_admin_get_feature_config', array( $this, 'filter_woocommerce_admin_features' ), PHP_INT_MAX );
+
+		// Only show activity panels in Home page.
+		add_filter( 'admin_body_class', array( $this, 'filter_woocommerce_body_classes' ) );
+		add_action( 'admin_init', array( $this, 'add_custom_activity_panels_styles' ) );
 	}
 
 	/**
@@ -70,6 +76,39 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 		}
 
 		return $features;
+	}
+
+	/**
+	 * Add is-woocommerce-home body class.
+	 *
+	 * @param string $classes Body classes.
+	 *
+	 * @return string
+	 */
+	public function filter_woocommerce_body_classes( $classes ) {
+
+		$page = PageController::get_instance()->get_current_page();
+
+		if ( $page && 'woocommerce-home' === $page[ 'id' ] ) {
+			$classes .= ' is-woocommerce-home';
+		}
+
+		return $classes;
+	}
+
+	/**
+	 * Add custom CSS to hide activity panels in all WooCommerce pages other than Home.
+	 * Note that this is not possible via the 'woocommerce_admin_features' filter, as we don't have access to the screen id at that point.
+	 *
+	 * @return void
+	 */
+	public function add_custom_activity_panels_styles() {
+
+		wp_register_style( 'activity-panels-hide', false );
+		wp_enqueue_style( 'activity-panels-hide' );
+
+		$css = 'body:not(.is-woocommerce-home) #wpbody { margin-top: 0 !important; } body:not(.is-woocommerce-home) .woocommerce-layout__header { display:none; } body.is-woocommerce-home #screen-meta-links { display: none; } body.is-woocommerce-home .woocommerce-layout__header-heading, body.is-woocommerce-home .woocommerce-task-progress-header__title { font-size: 20px; font-weight: 400; }';
+		wp_add_inline_style( 'activity-panels-hide', $css );
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -107,7 +107,7 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 		wp_register_style( 'activity-panels-hide', false );
 		wp_enqueue_style( 'activity-panels-hide' );
 
-		$css = 'body:not(.is-woocommerce-home) #wpbody { margin-top: 0 !important; } body:not(.is-woocommerce-home) .woocommerce-layout__header { display:none; } body.is-woocommerce-home #screen-meta-links { display: none; } body.is-woocommerce-home .woocommerce-layout__header-heading, body.is-woocommerce-home .woocommerce-task-progress-header__title { font-size: 20px; font-weight: 400; }';
+		$css = 'body:not(.is-woocommerce-home) #wpbody { margin-top: 0 !important; } body:not(.is-woocommerce-home) .woocommerce-layout__header { display:none; } body.is-woocommerce-home #screen-meta-links { display: none; } body.is-woocommerce-home .woocommerce-layout__header-heading, body.is-woocommerce-home .woocommerce-task-progress-header__title, .woocommerce-layout__inbox-title span { font-size: 20px; font-weight: 400; } body.is-woocommerce-home .woocommerce-layout__inbox-panel-header { padding: 0; } .woocommerce-layout__inbox-subtitle { margin-top: 5px; } .woocommerce-layout__inbox-subtitle span { color: #757575; }';
 		wp_add_inline_style( 'activity-panels-hide', $css );
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 1.9.5 =
+* Limit activity panels to Woo Home page #XXX.
+
 = 1.9.4 =
 * Disable activation notices for Gift Cards and Product Bundles #813.
 * Skip the Onboarding Profiler in the Ecommerce Plan #811 #816.


### PR DESCRIPTION
closes #825 

Before:

<img width="1458" alt="Screen Shot 2022-10-05 at 12 40 57 PM" src="https://user-images.githubusercontent.com/1783726/194031490-48343803-3ec6-4718-b898-b18f3ecb7903.png">
<img width="1458" alt="Screen Shot 2022-10-05 at 12 42 52 PM" src="https://user-images.githubusercontent.com/1783726/194031522-9063e831-3318-46eb-a272-3b96322346e2.png">

After:

<img width="1455" alt="Screen Shot 2022-10-05 at 12 41 32 PM" src="https://user-images.githubusercontent.com/1783726/194031558-8dc335f1-f170-4c88-8a08-8da272b5b260.png">
<img width="1460" alt="Screen Shot 2022-10-05 at 12 42 09 PM" src="https://user-images.githubusercontent.com/1783726/194031582-78a0f839-7ece-4d3e-a087-7eb51279e17b.png">

Note that limiting the Header Bar to the WooCommerce Home required a revision to the Home page heading styles: Since the Header Bar is now a Home-only element, heading sizes should be optimized relative to each other within this context.