### PR TITLE
Hide write button in global bar

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 1.9.5
+ * @version 1.9.8
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -69,10 +69,9 @@ class WC_Calypso_Bridge {
 		/**
 		 * Remove the Write button from the global bar.
 		 *
-		 * @since   1.9.5
+		 * @since   1.9.8
 		 *
 		 * @return void
-		 * @todo    Doesn't work on calypso pages.
 		 */
 		add_action( 'wp_before_admin_bar_render', static function () {
 			global $wp_admin_bar;

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 1.9.4
+ * @version 1.9.5
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -64,6 +64,24 @@ class WC_Calypso_Bridge {
 		 */
 		add_filter( 'pre_option_woocommerce_navigation_enabled', function ( $pre ) {
 			return 'no';
+		}, PHP_INT_MAX );
+
+		/**
+		 * Remove the Write button from the global bar.
+		 *
+		 * @since   1.9.5
+		 *
+		 * @return void
+		 * @todo    Doesn't work on calypso pages.
+		 */
+		add_action( 'wp_before_admin_bar_render', static function () {
+			global $wp_admin_bar;
+
+			if ( ! is_object( $wp_admin_bar ) ) {
+				return;
+			}
+
+			$wp_admin_bar->remove_menu( 'ab-new-post' );
 		}, PHP_INT_MAX );
 
 		if ( ! is_admin() && ! defined( 'DOING_CRON' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -22,7 +22,7 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
-= 1.9.5 =
+= 1.9.8 =
 * Hide write button in global bar #XXX.
 
 = 1.9.4 =

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 1.9.5 =
+* Hide write button in global bar #XXX.
+
 = 1.9.4 =
 * Disable activation notices for Gift Cards and Product Bundles #813.
 * Skip the Onboarding Profiler in the Ecommerce Plan #811 #816.


### PR DESCRIPTION
closes #824

This should not be merged yet, as we cannot hide the `Write` button in Calypso pages. The fix only works in `wp-admin` and `frontend` when logged in.

### Testing

- Navigate to any WP "native" admin pages, and the `write` button should not appear.
- Navigate to home (when logged in), and the `write` button should not appear.
- Navigate to any calypso pages, and should still exist