### PR TITLE
Optimize jetpack for commerce

### DIFF
--- a/class-wc-calypso-bridge-shared.php
+++ b/class-wc-calypso-bridge-shared.php
@@ -61,6 +61,7 @@ class WC_Calypso_Bridge_Shared {
 	 * Registers scripts.
 	 */
 	public function add_extension_register_script() {
+
 		$is_woo_page = class_exists( 'Automattic\WooCommerce\Admin\Loader' )
 			&& \Automattic\WooCommerce\Admin\Loader::is_admin_or_embed_page()
 			? true
@@ -140,13 +141,11 @@ class WC_Calypso_Bridge_Shared {
 			include_once $connect_file;
 		}
 
-		if ( is_wc_calypso_bridge_page() ) {
-			// Nav unification fixes.
-			if ( function_exists( 'wpcomsh_activate_nav_unification' )
+		// Nav unification fixes.
+		if ( function_exists( 'wpcomsh_activate_nav_unification' )
 			&& wpcomsh_activate_nav_unification( false )
 			&& ! Loader::is_feature_enabled( 'navigation' ) ) {
-				add_action( 'admin_enqueue_scripts', array( $this, 'add_nav_unification_styles' ) );
-			}
+			add_action( 'admin_enqueue_scripts', array( $this, 'add_nav_unification_styles' ) );
 		}
 	}
 

--- a/class-wc-calypso-bridge-shared.php
+++ b/class-wc-calypso-bridge-shared.php
@@ -142,10 +142,12 @@ class WC_Calypso_Bridge_Shared {
 		}
 
 		// Nav unification fixes.
-		if ( function_exists( 'wpcomsh_activate_nav_unification' )
-			&& wpcomsh_activate_nav_unification( false )
-			&& ! Loader::is_feature_enabled( 'navigation' ) ) {
-			add_action( 'admin_enqueue_scripts', array( $this, 'add_nav_unification_styles' ) );
+		if ( is_wc_calypso_bridge_page() ) {
+			if ( function_exists( 'wpcomsh_activate_nav_unification' )
+				&& wpcomsh_activate_nav_unification( false )
+				&& ! Loader::is_feature_enabled( 'navigation' ) ) {
+				add_action( 'admin_enqueue_scripts', array( $this, 'add_nav_unification_styles' ) );
+			}
 		}
 	}
 

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -15,10 +15,16 @@ use Automattic\WooCommerce\Admin\Loader;
  * WC Calypso Bridge
  */
 class WC_Calypso_Bridge {
+
 	/**
 	 * Paths to assets act oddly in production
 	 */
 	const MU_PLUGIN_ASSET_PATH = '/wp-content/mu-plugins/wpcomsh/vendor/automattic/wc-calypso-bridge/';
+
+	/**
+	 * Ecommerce Plan release timestamps.
+	 */
+	const S2_2022_RELEASE_DATE = 1665828976;
 
 	/**
 	 * Plugin asset path
@@ -66,22 +72,8 @@ class WC_Calypso_Bridge {
 			return 'no';
 		}, PHP_INT_MAX );
 
-		/**
-		 * Inject the Ecommerce admin menu controller into Jetpack.
-		 *
-		 * @since x.x.x
-		 *
-		 * @param  string  $menu_controller_class  The name of the menu controller class.
-		 * @return string
-		 */
-		add_filter( 'jetpack_admin_menu_class', function( $menu_controller_class ) {
-			if ( class_exists( '\Automattic\Jetpack\Dashboard_Customizations\Atomic_Admin_Menu' ) ) {
-				require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-admin-menu.php';
-				return Ecommerce_Atomic_Admin_Menu::class;
-			}
-
-			return $menu_controller_class;
-		} );
+		// Include Jetpack modifications.
+		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-jetpack.php';
 
 		if ( ! is_admin() && ! defined( 'DOING_CRON' ) ) {
 			return;
@@ -89,6 +81,7 @@ class WC_Calypso_Bridge {
 
 		// Include calypso-bridge-setup this class as early as possible.
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-setup.php';
+		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-helper-functions.php';
 
 		add_action( 'plugins_loaded', array( $this, 'initialize' ), 2 );
 	}
@@ -152,8 +145,7 @@ class WC_Calypso_Bridge {
 	 * Load ecommere plan specific UI changes.
 	 */
 	public function load_ecommerce_plan_ui() {
-		// We always want the Calypso branded OBW to run on eCommerce plan sites.
-		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-helper-functions.php';
+
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-hide-alerts.php';
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-themes-setup.php';
 		include_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-page-controller.php';

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -66,6 +66,15 @@ class WC_Calypso_Bridge {
 			return 'no';
 		}, PHP_INT_MAX );
 
+		add_filter( 'jetpack_admin_menu_class', function( $admin_class ) {
+			if ( class_exists( '\Automattic\Jetpack\Dashboard_Customizations\Atomic_Admin_Menu' ) ) {
+				require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-admin-menu.php';
+				return Ecommerce_Atomic_Admin_Menu::class;
+			}
+
+			return $admin_class;
+		} );
+
 		if ( ! is_admin() && ! defined( 'DOING_CRON' ) ) {
 			return;
 		}

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -66,13 +66,21 @@ class WC_Calypso_Bridge {
 			return 'no';
 		}, PHP_INT_MAX );
 
-		add_filter( 'jetpack_admin_menu_class', function( $admin_class ) {
+		/**
+		 * Inject the Ecommerce admin menu controller into Jetpack.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param  string  $menu_controller_class  The name of the menu controller class.
+		 * @return string
+		 */
+		add_filter( 'jetpack_admin_menu_class', function( $menu_controller_class ) {
 			if ( class_exists( '\Automattic\Jetpack\Dashboard_Customizations\Atomic_Admin_Menu' ) ) {
 				require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-admin-menu.php';
 				return Ecommerce_Atomic_Admin_Menu::class;
 			}
 
-			return $admin_class;
+			return $menu_controller_class;
 		} );
 
 		if ( ! is_admin() && ! defined( 'DOING_CRON' ) ) {

--- a/includes/class-wc-calypso-bridge-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-admin-menu.php
@@ -3,6 +3,7 @@
 /**
  * Class Ecommerce_Atomic_Admin_Menu.
  *
+ * @since x.x.x
  * This class comes up in the wp-admin of a WoA site.
  */
 class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customizations\Atomic_Admin_Menu {
@@ -10,9 +11,16 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 	public function __construct() {
 		parent::__construct();
 
-		add_action( 'admin_menu', array( $this, 'update' ), 99999 );
+		add_action( 'admin_menu', array( $this, 'hide_woocommerce_menu_items' ), 99999 );
 		add_action( 'admin_menu', function() {
 
+			/**
+			 * Add the home page behind the scenes to avoid 404 errors.
+			 *
+			 * This change will change the screen id from `woocommerce_page_wc-admin` to `admin_page_wc-admin`.
+			 *
+			 * @see self::get_screen_id_replacement()
+			 */
 			wc_admin_register_page(
 				array(
 					'id'         => 'woocommerce-home',
@@ -22,6 +30,24 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 				)
 			);
 		}, 9 );
+
+		/**
+		 * Fix/Replace broken screen IDs for WooCommerce core pages.
+		 */
+		add_action( 'current_screen', function() {
+
+			$current_screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+			if ( ! is_a( $current_screen, 'WP_Screen' ) ) {
+				return;
+			}
+
+			$replacement = $this->get_screen_id_replacement( $current_screen->id );
+			if ( false !== $replacement ) {
+				$current_screen->id = $replacement;
+				$current_screen->base = $replacement;
+			}
+
+		}, -99999 );
 	}
 
 	/**
@@ -32,7 +58,10 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 
 	}
 
-	public function update() {
+	/**
+	 * Hide default WC menu items.
+	 */
+	public function hide_woocommerce_menu_items() {
 		global $submenu;
 
 		$home = array_shift($submenu['woocommerce']);
@@ -51,5 +80,29 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 	 */
 	public function add_stats_menu() {
 		// ...
+	}
+
+	/**
+	 * Backwards compatible screen IDs mapper for the new Ecommerce menu structure.
+	 *
+	 * @param  $screen_id (Optional)  The screen ID
+	 * @return array|string|false    Returns an array with all the replacements if no argument passed, or the string replacement screen ID.
+	 */
+	private function get_screen_id_replacement( $screen_id = null ) {
+
+		/**
+		 * This array maps new screen IDs with legacy ones.
+		 *
+		 * The format is: `new_screen_id` => `legacy_screen_id`
+		 */
+		$screen_map = array(
+			'admin_page_wc-admin' => 'woocommerce_page_wc-admin',
+		);
+
+		if ( $screen_id ) {
+			return array_key_exists( $screen_id, $screen_map ) ? $screen_map[ $screen_id ] : '';
+		} else {
+			return $screen_map;
+		}
 	}
 }

--- a/includes/class-wc-calypso-bridge-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-admin-menu.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Class Ecommerce_Atomic_Admin_Menu.
+ *
+ * This class comes up in the wp-admin of a WoA site.
+ */
+class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customizations\Atomic_Admin_Menu {
+
+	public function __construct() {
+		parent::__construct();
+
+		add_action( 'admin_menu', array( $this, 'update' ), 99999 );
+		add_action( 'admin_menu', function() {
+
+			wc_admin_register_page(
+				array(
+					'id'         => 'woocommerce-home',
+					'title'      => __( 'Home', 'woocommerce' ),
+					'parent'     => '',
+					'path'       => \Automattic\WooCommerce\Internal\Admin\Homescreen::MENU_SLUG,
+				)
+			);
+		}, 9 );
+	}
+
+	/**
+	 * Create the desired menu output.
+	 */
+	public function reregister_menu_items() {
+		parent::reregister_menu_items();
+
+	}
+
+	public function update() {
+		global $submenu;
+
+		$home = array_shift($submenu['woocommerce']);
+		$this->hide_submenu_element( 'woocommerce-home', 'woocommerce', $home );
+	}
+
+	/**
+	 * Adds My Home menu.
+	 */
+	public function add_my_home_menu() {
+		$this->update_menu( 'index.php', '/admin.php?page=wc-admin', __( 'My Home', 'jetpack' ), 'edit_posts', 'dashicons-admin-home' );
+	}
+
+	/**
+	 * Remove Stats menu.
+	 */
+	public function add_stats_menu() {
+		// ...
+	}
+}

--- a/includes/class-wc-calypso-bridge-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-admin-menu.php
@@ -82,8 +82,12 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 	/**
 	 * Backwards compatible screen IDs mapper for the new Ecommerce menu structure.
 	 *
+	 * Changing menu item positions, by definition, changes the internal WP_Screen ID of each page.
+	 * This method is responsible for replacing newly introduced screen ids with legacy ones to be compatible with 3PD codebases.
+	 * (e.g., A 3PD code injects some custom CSS into the `woocommerce_admin_wc-admin` screen)
+	 *
 	 * @param  $screen_id (Optional)  The screen ID
-	 * @return array|string|false    Returns an array with all the replacements if no argument passed, or the string replacement screen ID.
+	 * @return array|string|false     Returns an array with all the replacements if no argument passed, or the string replacement screen ID.
 	 */
 	private function get_screen_id_replacement( $screen_id = null ) {
 
@@ -96,10 +100,10 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 			'admin_page_wc-admin' => 'woocommerce_page_wc-admin',
 		);
 
-		if ( $screen_id ) {
-			return array_key_exists( $screen_id, $screen_map ) ? $screen_map[ $screen_id ] : '';
-		} else {
+		if ( is_null( $screen_id ) ) {
 			return $screen_map;
 		}
+
+		return array_key_exists( $screen_id, $screen_map ) ? $screen_map[ $screen_id ] : false;
 	}
 }

--- a/includes/class-wc-calypso-bridge-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-admin-menu.php
@@ -4,7 +4,8 @@
  * Class Ecommerce_Atomic_Admin_Menu.
  *
  * @since x.x.x
- * This class comes up in the wp-admin of a WoA site.
+ *
+ * The admin menu controller for Ecommerce WoA sites.
  */
 class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customizations\Atomic_Admin_Menu {
 
@@ -13,6 +14,10 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 
 		add_action( 'admin_menu', array( $this, 'hide_woocommerce_menu_items' ), 99999 );
 		add_action( 'admin_menu', function() {
+
+			if ( ! class_exists( '\Automattic\WooCommerce\Internal\Admin\Homescreen' ) ) {
+				return;
+			}
 
 			/**
 			 * Add the home page behind the scenes to avoid 404 errors.
@@ -29,7 +34,7 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 					'path'       => \Automattic\WooCommerce\Internal\Admin\Homescreen::MENU_SLUG,
 				)
 			);
-		}, 9 );
+		} );
 
 		/**
 		 * Fix/Replace broken screen IDs for WooCommerce core pages.
@@ -51,21 +56,13 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 	}
 
 	/**
-	 * Create the desired menu output.
-	 */
-	public function reregister_menu_items() {
-		parent::reregister_menu_items();
-
-	}
-
-	/**
 	 * Hide default WC menu items.
 	 */
 	public function hide_woocommerce_menu_items() {
 		global $submenu;
 
-		$home = array_shift($submenu['woocommerce']);
-		$this->hide_submenu_element( 'woocommerce-home', 'woocommerce', $home );
+		// Remove the WooCommerce > Home menu item.
+		array_shift( $submenu['woocommerce'] );
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-admin-menu.php
@@ -76,7 +76,51 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 	 * Remove Stats menu.
 	 */
 	public function add_stats_menu() {
-		// ...
+		if ( Jetpack::is_module_active( 'stats' ) ) {
+			parent::add_stats_menu();
+		}
+	}
+
+	/**
+	 * Adds Inbox menu.
+	 */
+	public function add_inbox_menu() {
+		add_menu_page( __( 'Emails', 'jetpack' ), __( 'Emails', 'jetpack' ), 'manage_options', 'https://wordpress.com/inbox/' . $this->domain, null, 'dashicons-email', '4.64424' );
+	}
+
+	/**
+	 * Remove the Jetpack menu
+	 */
+	public function add_jetpack_menu() {
+
+		global $submenu;
+
+		parent::add_jetpack_menu();
+
+		$submenu[ 'jetpack' ][ 0 ][ 2 ] = admin_url( 'admin.php?page=jetpack#/settings' );
+
+		// Remove Jetpack Search menu item. Already exposed in the Jetpack Dashboard.
+		$this->hide_submenu_page( 'jetpack', 'jetpack-search' );
+
+		// Move Akismet under Settings
+		$this->hide_submenu_page( 'jetpack', 'akismet-key-config' );
+		add_submenu_page( 'options-general.php', __( 'Anti-Spam', 'wc-calypso-bridge' ), __( 'Anti-Spam' , 'wc-calypso-bridge' ), 'manage_options', 'akismet-key-config', array( 'Akismet_Admin', 'display_page' ), 12 );
+
+		// Add Backup and Activity under Tools.
+
+		// $this->hide_submenu_page( 'jetpack', 'https://wordpress.com/activity-log/' . $this->domain );
+		// add_submenu_page( 'tools.php', esc_attr__( 'Activity', 'jetpack' ), __( 'Activity', 'jetpack' ), 'manage_options', 'https://wordpress.com/activity-log/' . $this->domain, null, 0 );
+		// $this->hide_submenu_page( 'jetpack', 'https://wordpress.com/backup/' . $this->domain );
+		// add_submenu_page( 'tools.php', esc_attr__( 'Backup', 'jetpack' ), __( 'Backup', 'jetpack' ), 'manage_options', 'https://wordpress.com/backup/' . $this->domain, null, 1 );
+
+
+		// Move Jetpack Status screen from Settings to Tools.
+		remove_submenu_page( 'options-general.php', 'https://wordpress.com/settings/jetpack/' . $this->domain );
+		add_submenu_page( 'tools.php', esc_attr__( 'Jetpack Status', 'wc-calypso-bridge' ), __( 'Jetpack Status', 'wc-calypso-bridge' ), 'manage_options', 'https://wordpress.com/settings/jetpack/' . $this->domain, null, 100 );
+
+		// Remove Marketing and Earn from Tools.
+		$this->hide_submenu_page( 'tools.php', 'https://wordpress.com/marketing/tools/' . $this->domain );
+		$this->hide_submenu_page( 'tools.php', 'https://wordpress.com/earn/' . $this->domain );
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-helper-functions.php
+++ b/includes/class-wc-calypso-bridge-helper-functions.php
@@ -7,6 +7,8 @@
  * @version 1.0.2
  */
 
+use Automattic\WooCommerce\Admin\WCAdminHelper;
+
 /**
  * WC_Calypso_Bridge_Helper_Functions.
  */
@@ -35,6 +37,24 @@ class WC_Calypso_Bridge_Helper_Functions {
 	private function __construct() {
 		// Silence.
 	}
+
+	/**
+	 * Checks to see if WC Admin was installed later than a reference time.
+	 * @param  int  $reference_timestamp  Time to compare against.
+	 * @return bool
+	 */
+	public static function is_wc_admin_installed_gte( $reference_timestamp ) {
+
+		$install_timestamp = get_option( WCAdminHelper::WC_ADMIN_TIMESTAMP_OPTION );
+
+		if ( ! is_numeric( $install_timestamp ) ) {
+			$install_timestamp = time();
+			update_option( WCAdminHelper::WC_ADMIN_TIMESTAMP_OPTION, $install_timestamp );
+		}
+
+		return $install_timestamp > $reference_timestamp;
+	}
+
 
 	/**
 	 * Remove Class Filter Without Access to Class Object

--- a/includes/class-wc-calypso-bridge-hide-alerts.php
+++ b/includes/class-wc-calypso-bridge-hide-alerts.php
@@ -35,12 +35,13 @@ class WC_Calypso_Bridge_Hide_Alerts {
 	 * Constructor
 	 */
 	private function __construct() {
+
 		add_action( 'admin_head', array( $this, 'suppress_admin_notices' ) );
+		add_action( 'admin_head', array( $this, 'hide_alerts_on_non_settings_pages' ) );
+
 		add_filter( 'woocommerce_helper_suppress_connect_notice', '__return_true' );
 		add_filter( 'woocommerce_show_admin_notice', '__return_false' );
 		add_filter( 'woocommerce_allow_marketplace_suggestions', '__return_false' );
-
-		add_action( 'admin_head', array( $this, 'hide_alerts_on_non_settings_pages' ) );
 	}
 
 	/**
@@ -110,6 +111,7 @@ class WC_Calypso_Bridge_Hide_Alerts {
 
 		// Suppress: Product Add Ons Activation Notice.
 		$deleted = delete_option( 'wpa_activation_notice' );
+
 		// Suppress all other WC Admin Notices not specified above.
 		WC_Admin_Notices::remove_notice( 'wootenberg' );
 		WC_Admin_Notices::remove_all_notices();

--- a/includes/class-wc-calypso-bridge-jetpack.php
+++ b/includes/class-wc-calypso-bridge-jetpack.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Jetpack customizations.
+ *
+ * @package WC_Calypso_Bridge/Jetpack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Calypso_Bridge_Jetpack Class.
+ */
+class WC_Calypso_Bridge_Jetpack {
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var object
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return object Instance.
+	 */
+	final public static function get_instance() {
+		if ( null === static::$instance ) {
+			static::$instance = new static();
+		}
+		return static::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->init();
+	}
+
+	/**
+	 * Initialize hooks.
+	 */
+	public function init() {
+
+		/**
+		 * Inject the Ecommerce admin menu controller into Jetpack.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param  string  $menu_controller_class  The name of the menu controller class.
+		 * @return string
+		 */
+		add_filter( 'jetpack_admin_menu_class', function( $menu_controller_class ) {
+			if ( class_exists( '\Automattic\Jetpack\Dashboard_Customizations\Atomic_Admin_Menu' ) ) {
+				require_once dirname( __FILE__ ) . '/class-wc-calypso-bridge-admin-menu.php';
+				return Ecommerce_Atomic_Admin_Menu::class;
+			}
+
+			return $menu_controller_class;
+		} );
+
+		/**
+		 * Cleans up the Jetpack Dashboard -- Ecommerce Plan users only need to see the Jetpack settings.
+		 *
+		 * @since x.x.x
+		 *
+		 * @return void
+		 */
+		add_action( 'admin_print_styles', function() {
+
+			$css = '.jp-masthead__nav { display: none !important; }';
+			wp_add_inline_style( 'jetpack-admin', $css );
+		} );
+
+		/**
+		 * Limits Jetpack Modules to those relevant to Ecommerce Plan users.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param  array  $mods  Available Jetpack modules for activation.
+		 * @return array
+		 */
+		add_filter( 'jetpack_get_available_modules', function( $mods ) {
+			if ( WC_Calypso_Bridge_Helper_Functions::is_wc_admin_installed_gte( WC_Calypso_Bridge::S2_2022_RELEASE_DATE ) ) {
+				$mods = array_diff_key( $mods, array_flip( array( 'gravatar-hovercards', 'custom-content-types', 'wordads', 'google-analytics', 'widget-visibility', 'post-list', 'infinite-scroll', 'copy-post', 'lazy-images', 'post-by-email', 'related-posts', 'action-bar' ) ) );
+			}
+			return $mods;
+		} );
+	}
+}
+
+WC_Calypso_Bridge_Jetpack::get_instance();

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -7,6 +7,8 @@
  * @version 1.9.4
  */
 
+use Automattic\WooCommerce\Admin\WCAdminHelper;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -40,6 +42,7 @@ class WC_Calypso_Bridge_Setup {
 	 */
 	protected $one_time_operations = array(
 		'delete_coupon_moved_notes' => 'delete_coupon_moved_notes_callback',
+		'set_jetpack_defaults'      => 'set_jetpack_defaults'
 	);
 
 	/**
@@ -97,7 +100,9 @@ class WC_Calypso_Bridge_Setup {
 	 * @return void
 	 */
 	public function delete_coupon_moved_notes_callback() {
+
 		add_action( 'admin_init', function () {
+
 			if ( ! class_exists( 'Automattic\WooCommerce\Admin\Notes\Notes' ) ) {
 				return;
 			}
@@ -109,10 +114,75 @@ class WC_Calypso_Bridge_Setup {
 
 				return;
 			}
+
 			Automattic\WooCommerce\Admin\Notes\Notes::delete_notes_with_name( 'wc-admin-coupon-page-moved' );
 			$this->set_one_time_operation_complete( 'delete_coupon_moved_notes' );
+
 		}, PHP_INT_MAX );
 	}
+
+	/**
+	 * Defines the Jetpack modules active in the Ecommerce Plan by default.
+	 *
+	 * @since 1.9.4
+	 * @return void
+	 */
+	public function set_jetpack_defaults() {
+
+		add_action( 'init', function() {
+
+			$active_modules = array(
+				'manage',
+				'masterbar',
+				'json-api',
+				'sharedaddy',
+				'google-fonts',
+				'sso',
+				'notes',
+				'protect',
+				'latex',
+				'carousel',
+				'comment-likes',
+				'comments',
+				'contact-form',
+				'widgets',
+				'likes',
+				'shortcodes',
+				'markdown',
+				'search',
+				'subscriptions',
+				'tiled-gallery',
+				'videopress',
+				'shortlinks',
+				'woocommerce-analytics',
+				'monitor',
+				'seo-tools',
+				'custom-css',
+				'publicize',
+				'verification-tools',
+				'sitemaps'
+			);
+
+			$sharing_options = array(
+				'global' => array(
+					'button_style' => 'icon',
+					'sharing_label' => '',
+					'open_links' => 'same',
+					'show' => array( 'post' ),
+					'custom' => array()
+			) );
+
+			// Set defaults only if the store is brand new (been active for less than 5 minutes).
+			if ( ! WCAdminHelper::is_wc_admin_active_for( 300 ) ) {
+				update_option( 'jetpack_active_modules', $active_modules );
+				update_option( 'sharing-options', $sharing_options );
+			}
+
+			$this->set_one_time_operation_complete( 'set_jetpack_defaults' );
+
+		} );
+	}
+
 
 	/**
 	 * Save the one-time operations' status .

--- a/includes/connect/woocommerce-admin.php
+++ b/includes/connect/woocommerce-admin.php
@@ -17,14 +17,6 @@ wc_calypso_bridge_connect_page(
 
 wc_calypso_bridge_connect_page(
 	array(
-		'screen_id' => 'toplevel_page_wc-admin',
-		'menu'      => 'woocommerce',
-		'submenu'   => 'page=wc-admin',
-	)
-);
-
-wc_calypso_bridge_connect_page(
-	array(
 		'screen_id' => 'woocommerce-revenue',
 		'menu'      => 'wc-admin&path=/analytics/overview',
 		'submenu'   => 'wc-admin&path=/analytics/overview',

--- a/includes/connect/woocommerce-admin.php
+++ b/includes/connect/woocommerce-admin.php
@@ -17,6 +17,14 @@ wc_calypso_bridge_connect_page(
 
 wc_calypso_bridge_connect_page(
 	array(
+		'screen_id' => 'toplevel_page_wc-admin',
+		'menu'      => 'woocommerce',
+		'submenu'   => 'page=wc-admin',
+	)
+);
+
+wc_calypso_bridge_connect_page(
+	array(
 		'screen_id' => 'woocommerce-revenue',
 		'menu'      => 'wc-admin&path=/analytics/overview',
 		'submenu'   => 'wc-admin&path=/analytics/overview',

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,9 @@ import './index.scss';
 
 wcNavFilterRootUrl();
 
+
 addFilter( 'woocommerce_admin_pages_list', 'wc-calypso-bridge', ( pages ) => {
+
 	pages.push( {
 		container: PaymentsWelcomePage,
 		path: '/payments-welcome',
@@ -22,6 +24,8 @@ addFilter( 'woocommerce_admin_pages_list', 'wc-calypso-bridge', ( pages ) => {
 			id: 'wc-calypso-bridge-payments-welcome-page',
 		},
 	} );
+
+	pages = pages.map( page => page.path === '/' ? {...page, wpOpenMenu: ''} : page );
 
 	return pages;
 } );

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,9 @@ addFilter( 'woocommerce_admin_pages_list', 'wc-calypso-bridge', ( pages ) => {
 		},
 	} );
 
+	/**
+	 * Ensure that WooCommerce Home page will not highlight the WooCommerce parent menu item.
+	 */
 	pages = pages.map( page => page.path === '/' ? {...page, wpOpenMenu: ''} : page );
 
 	return pages;


### PR DESCRIPTION
closes #834 

I'd love to also: 

- Move "Activity" and "Backup" under "Tools".
- Repurpose the entire "Jetpack" menu as a "Jetpack" submenu of Settings.

cc @xristos3490 