### PR TITLE
Flatten the WooCommerce menu in Ecommerce plan

### DIFF
--- a/assets/css/ecommerce.css
+++ b/assets/css/ecommerce.css
@@ -20,3 +20,16 @@
 	.components-tab-panel__tabs {
 	display: none;
 }
+
+/* Fix the top space in WooCommerce Marketplace. */
+body.woocommerce_page_wc-addons.woocommerce-embed-page #wpbody .woocommerce-layout {
+	padding-top: 0;
+}
+
+/*  Hide tabs in wc-addons page for Ecommerce plan. */
+.woocommerce.wc-addons-wrap .top-bar {
+	display: none;
+}
+.woocommerce.wc-subscriptions-wrap .woo-nav-tab-wrapper {
+	display: none;
+}

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -287,7 +287,7 @@ class WC_Calypso_Bridge {
 	 */
 	public function add_ecommerce_plan_styles() {
 		$asset_path = self::$plugin_asset_path ? self::$plugin_asset_path : self::MU_PLUGIN_ASSET_PATH;
-		wp_enqueue_style( 'wp-calypso-bridge-ecommerce', get_home_url() . $asset_path . 'assets/css/ecommerce.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
+		wp_enqueue_style( 'wp-calypso-bridge-ecommerce', $asset_path . 'assets/css/ecommerce.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
 	}
 
 	/**

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -258,6 +258,7 @@ class WC_Calypso_Bridge {
 	 * Updates required UI elements for calypso bridge pages only.
 	 */
 	public function load_ui_elements() {
+
 		if ( is_wc_calypso_bridge_page() ) {
 			add_action( 'admin_init', array( $this, 'remove_woocommerce_core_footer_text' ) );
 			add_filter( 'admin_footer_text', array( $this, 'update_woocommerce_footer' ) );
@@ -286,7 +287,7 @@ class WC_Calypso_Bridge {
 	 */
 	public function add_ecommerce_plan_styles() {
 		$asset_path = self::$plugin_asset_path ? self::$plugin_asset_path : self::MU_PLUGIN_ASSET_PATH;
-		wp_enqueue_style( 'wp-calypso-bridge-ecommerce', $asset_path . 'assets/css/ecommerce.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
+		wp_enqueue_style( 'wp-calypso-bridge-ecommerce', get_home_url() . $asset_path . 'assets/css/ecommerce.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-admin-menu.php
@@ -9,6 +9,230 @@
  */
 class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customizations\Atomic_Admin_Menu {
 
+	const WPCOM_ECOMMERCE_MANAGED_PAGES = array(
+		'wc-admin',
+		'wc-admin&path=/customers',
+		'edit.php?post_type=shop_order',
+		'wc-reports',
+		'wc-settings',
+		'wc-status',
+		'wc-addons',
+	);
+
+	/**
+	 * Override constructor and add custom actions.
+	 */
+	public function __construct() {
+		parent::__construct();
+		add_action( 'admin_menu', array( $this, 'add_woocommerce_menu' ), 99999 );
+		add_filter( 'menu_order', array( $this, 'menu_order' ), 100 );
+
+		if ( ! $this->is_api_request ) {
+			add_filter( 'submenu_file', array( $this, 'modify_woocommerce_menu_highlighting' ), 99999 );
+		}
+
+		// Move Orders.
+		//
+		// TODO: menu_order_count at class-wc-admin-menu.php -- woocommerce_include_processing_order_count_in_menu
+		// TODO: What about the COT menu?
+		add_filter( 'woocommerce_register_post_type_shop_order', function( $args ) {
+			$args[ 'show_in_menu' ] = true;
+			$args[ 'menu_icon' ]    = 'dashicons-cart';
+			return $args;
+		} );
+	}
+
+	/**
+	 * Groups WooCommerce items.
+	 */
+	public static function menu_order( $menu_order ) {
+
+		// Initialize our custom order array.
+		$woocommerce_menu_order = array();
+
+		// Get the index of our managed pages.
+		$orders    = array_search( 'edit.php?post_type=shop_order', $menu_order, true );
+		$customers = array_search( 'admin.php?page=wc-admin&path=/customers', $menu_order, true );
+		$products  = array_search( 'edit.php?post_type=product', $menu_order, true );
+		$analytics = array_search( 'wc-admin&path=/analytics/overview', $menu_order, true );
+		$marketing = array_search( 'woocommerce-marketing', $menu_order, true );
+
+		// Loop through menu order and do some rearranging.
+		foreach ( $menu_order as $index => $item ) {
+
+			$extensions                = array_search( 'woocommerce', $menu_order, true );
+			$woocommerce_separator     = array_search( 'separator-woocommerce', $menu_order, true );
+			$woocommerce_separator_top = array_search( 'wc-calypso-bridge-separator-top', $menu_order, true );
+
+			// Move the WC group above the "Posts" menu item.
+			if ( 'edit.php' === $item ) {
+				$woocommerce_menu_order[] = 'wc-calypso-bridge-separator-top'; // Separator WC top.
+				$woocommerce_menu_order[] = 'edit.php?post_type=shop_order'; // Orders.
+				$woocommerce_menu_order[] = 'edit.php?post_type=product'; // Products.
+				$woocommerce_menu_order[] = 'admin.php?page=wc-admin&path=/customers'; // Customers.
+				$woocommerce_menu_order[] = 'wc-admin&path=/analytics/overview'; // Analytics.
+				$woocommerce_menu_order[] = 'woocommerce-marketing'; // Marketing.
+				$woocommerce_menu_order[] = 'woocommerce'; // Extensions.
+				$woocommerce_menu_order[] = 'separator-woocommerce'; // Separator WC.
+				$woocommerce_menu_order[] = $item; // Posts.
+				unset( $menu_order[ $orders ] );
+				unset( $menu_order[ $customers ] );
+				unset( $menu_order[ $products ] );
+				unset( $menu_order[ $analytics ] );
+				unset( $menu_order[ $marketing ] );
+				unset( $menu_order[ $extensions ] );
+				unset( $menu_order[ $woocommerce_separator ] );
+				unset( $menu_order[ $woocommerce_separator_top ] );
+			} elseif ( ! in_array( $item, array( 'wc-calypso-bridge-separator-top', 'separator-woocommerce', 'woocommerce', 'woocommerce-marketing', 'wc-admin&path=/analytics/overview', 'edit.php?post_type=product', 'edit.php?post_type=shop_order', 'admin.php?page=wc-admin&path=/customers'), true ) ) {
+				$woocommerce_menu_order[] = $item;
+			}
+		}
+
+		// Return order.
+		return $woocommerce_menu_order;
+	}
+
+	/**
+	 * Adds My Home menu.
+	 */
+	public function add_my_home_menu() {
+		$this->update_menu( 'index.php', '/admin.php?page=wc-admin', __( 'My Home', 'jetpack' ), 'edit_posts', 'dashicons-admin-home' );
+	}
+
+	/**
+	 * Fixes the menu highligting based on the changes of the self::add_woocommerce_menu.
+	 *
+	 * @param  string  $submenu_file
+	 * @return string
+	 */
+	public function modify_woocommerce_menu_highlighting( $submenu_file ) {
+		global $parent_file, $submenu_file, $plugin_page, $current_screen;
+
+		// Move WooCommerce > Settings under under Settings > WooCommerce.
+		$screen_id = is_a( $current_screen, 'WP_Screen' ) ? $current_screen->id : '';
+		if ( in_array( $screen_id, array( 'woocommerce_page_wc-settings' ), true ) ) {
+			// We change the global $plugin_page due to the get_admin_page_parent() that replaces parent_file with this.
+			$plugin_page  = 'options-general.php';
+			$submenu_file = 'admin.php?page=wc-settings';
+		}
+
+		// Move WooCommerce > Status under under Tools > WooCommerce Status.
+		if ( in_array( $screen_id, array( 'woocommerce_page_wc-status' ), true ) ) {
+			// We change the global $plugin_page due to the get_admin_page_parent() that replaces parent_file with this.
+			$plugin_page  = 'tools.php';
+			$submenu_file = 'admin.php?page=wc-status';
+		}
+
+		if ( in_array( $screen_id, array( 'woocommerce_page_wc-admin' ), true ) ) {
+			// We change the global $plugin_page due to the get_admin_page_parent() that replaces parent_file with this.
+			// $parent_file  = 'admin.php?page=wc-admin';
+			$plugin_page  = 'admin.php?page=wc-admin';
+			$submenu_file = 'admin.php?page=wc-admin';
+		}
+
+		return $submenu_file;
+	}
+
+	/**
+	 * Handle WooCommerce menu.
+	 */
+	public function add_woocommerce_menu() {
+
+		// Seperator1 gets removed on Atomic_Admin_Menu class.
+		// We add one more here to be used on top of the WC group.
+		$separator_top = array(
+			'',                   // Menu title (ignored).
+			'manage_woocommerce', // Required capability.
+			'wc-calypso-bridge-separator-top',  // URL or file (ignored, but must be unique).
+			'',                   // Page title (ignored).
+			'wp-menu-separator',  // CSS class. Identifies this item as a separator.
+		);
+
+		$this->set_menu_item( $separator_top, null );
+
+		// Hide WooCommerce > Home.
+		$this->hide_submenu_page( 'woocommerce', 'wc-admin' );
+
+		// Restore the Orders submenu page for backwards compatibility.
+		add_submenu_page( 'woocommerce', __( 'Orders','wc-calypso-bridge' ), __( 'Orders','wc-calypso-bridge' ), 'manage_woocommerce', 'edit.php?post_type=shop_order', '', 1 );
+		$this->hide_submenu_page( 'woocommerce', 'edit.php?post_type=shop_order' );
+
+		// Move WooCommerce > Settings under Settings > WooCommerce.
+		$this->hide_submenu_page( 'woocommerce', 'wc-settings' );
+		add_submenu_page( 'options-general.php', __( 'WooCommerce Settings','wc-calypso-bridge' ), __( 'WooCommerce','wc-calypso-bridge' ), 'manage_woocommerce', 'admin.php?page=wc-settings', '', 10 );
+
+		// Move WooCommerce > Status under Tools > WooCommerce Status.
+		$this->hide_submenu_page( 'woocommerce', 'wc-status' );
+		add_submenu_page( 'tools.php', __( 'WooCommerce Status','wc-calypso-bridge' ), __( 'WooCommerce Status','wc-calypso-bridge' ), 'manage_woocommerce', 'admin.php?page=wc-status', '', 10 );
+
+		// Hide legacy reports.
+		$this->hide_submenu_page( 'woocommerce', 'wc-reports' );
+
+		// Move Customers to root menu.
+		$this->hide_submenu_page( 'woocommerce', 'wc-admin&path=/customers' );
+		add_menu_page( __( 'Customers', 'woocommerce' ), __( 'Customers', 'woocommerce' ), 'manage_woocommerce', '/admin.php?page=wc-admin&path=/customers', null, 'dashicons-money', 100 );
+
+		// Update WooCommerce to Extensions
+		$this->update_menu( 'woocommerce', null, 'Extensions', null, null, null );
+
+		global $submenu, $menu;
+
+		// Move WooCommerce > Extensions under Extensions > Discover.
+		foreach ( $submenu['woocommerce'] as $key => $data ) {
+			if ( 'wc-addons' !== $data[2] ) {
+				continue;
+			}
+			$submenu['woocommerce'][$key][0] = __( 'Discover', 'wc-calypso-bridge' );
+		}
+
+		// Add Orders count.
+		if ( apply_filters( 'woocommerce_include_processing_order_count_in_menu', true ) && current_user_can( 'edit_others_shop_orders' ) ) {
+			$order_count = (int) apply_filters( 'woocommerce_menu_order_count', wc_processing_order_count() );
+
+			if ( $order_count ) {
+				foreach ( $menu as $i => $menu_item ) {
+					if ( 'edit.php?post_type=shop_order' === $menu_item[2] ) {
+						$menu[$i][0] .= ' <span class="awaiting-mod update-plugins count-' . esc_attr( $order_count ) . '"><span class="processing-count">' . number_format_i18n( $order_count ) . '</span></span>'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+						break;
+					}
+				}
+			}
+		}
+
+		if ( empty( $submenu['woocommerce'] ) || ! is_array( $submenu['woocommerce'] ) ) {
+			// return;
+		}
+
+		// Make sure that the managed and hidden are the last on the submenu list. THis is make the parent "WooCommerce" item to point to an extension instead of a hidden page.
+		uasort( $submenu['woocommerce'], function( $a, $b ) {
+
+			// Helper weights.
+			$A = 1;
+			$B = 1;
+			if ( in_array( $a[2], self::WPCOM_ECOMMERCE_MANAGED_PAGES ) ) {
+				if ( 'wc-addons' === $a[2] ) {
+					$A = 0;
+				} else {
+					$A = 2;
+				}
+			}
+
+			if ( in_array( $b[2], self::WPCOM_ECOMMERCE_MANAGED_PAGES ) ) {
+				if ( 'wc-addons' === $b[2] ) {
+					$B = 0;
+				} else {
+					$B = 2;
+				}
+			}
+
+			if ( $A == $B ) {
+				return 0;
+			}
+
+			return ( $A < $B ) ? -1 : 1;
+		} );
+	}
+
 	/**
 	 * Remove Stats menu.
 	 */
@@ -19,6 +243,7 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 	 */
 	public function add_tools_menu() {
 		parent::add_tools_menu();
+
 		// Remove Earn from Tools.
 		$this->hide_submenu_page( 'tools.php', 'https://wordpress.com/earn/' . $this->domain );
 	}
@@ -28,6 +253,7 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 	 */
 	public function add_options_menu() {
 		parent::add_options_menu();
+
 		// Introduce 'Settings > Anti-Spam'.
 		add_submenu_page( 'options-general.php', __( 'Anti-Spam', 'wc-calypso-bridge' ), __( 'Anti-Spam' , 'wc-calypso-bridge' ), 'manage_options', 'akismet-key-config', array( 'Akismet_Admin', 'display_page' ), 12 );
 		// Remove 'Settings > Jetpack' from Settings.

--- a/includes/class-wc-calypso-bridge-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-admin-menu.php
@@ -59,7 +59,8 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 		$extensions_index           = array_search( 'woocommerce', $menu_order, true );
 		$woocommerce_sep_index      = array_search( 'separator-woocommerce', $menu_order, true );
 		$woocommerce_sep_top_index  = array_search( 'wc-calypso-bridge-separator-top', $menu_order, true );
-		$woocommerce_payments_index = array_search( 'wc-admin&path=/payments/connect', $menu_order, true );
+		$payments_connect_index     = array_search( 'wc-admin&path=/payments/connect', $menu_order, true );
+		$payments_overview_index    = array_search( 'wc-admin&path=/payments/overview', $menu_order, true );
 
 		// Loop through menu order and do some rearranging.
 		foreach ( $menu_order as $index => $item ) {
@@ -71,8 +72,10 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 				$woocommerce_menu_order[] = 'edit.php?post_type=shop_order'; // Orders.
 				$woocommerce_menu_order[] = 'edit.php?post_type=product'; // Products.
 				$woocommerce_menu_order[] = 'admin.php?page=wc-admin&path=/customers'; // Customers.
-				if ( false !== $woocommerce_payments_index ) {
+				if ( false !== $payments_connect_index ) {
 					$woocommerce_menu_order[] = 'wc-admin&path=/payments/connect'; // Payments.
+				}elseif ( false !== $payments_overview_index ) {
+					$woocommerce_menu_order[] = 'wc-admin&path=/payments/overview'; // Payments.
 				}
 
 				$woocommerce_menu_order[] = 'wc-admin&path=/analytics/overview'; // Analytics.
@@ -105,12 +108,16 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 				if ( false !== $woocommerce_sep_top_index ) {
 					unset( $menu_order[ $woocommerce_sep_top_index ] );
 				}
-				if ( false !== $woocommerce_payments ) {
-					unset( $menu_order[ $woocommerce_payments ] );
+				if ( false !== $payments_connect_index ) {
+					unset( $menu_order[ $payments_connect_index ] );
+				}
+				if ( false !== $payments_overview_index ) {
+					unset( $menu_order[ $payments_overview_index ] );
 				}
 
 			} elseif ( ! in_array( $item, array(
 					'wc-admin&path=/payments/connect',
+					'wc-admin&path=/payments/overview',
 					'wc-calypso-bridge-separator-top',
 					'separator-woocommerce',
 					'woocommerce',
@@ -256,6 +263,7 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 			}
 		}
 
+		// Re-order submenus.
 		$this->reorder_woocommerce_menu();
 		$this->reorder_settings_menu();
 		$this->reorder_analytics_menu();

--- a/includes/class-wc-calypso-bridge-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-admin-menu.php
@@ -33,12 +33,11 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 		}
 
 		// Move Orders.
-		//
-		// TODO: menu_order_count at class-wc-admin-menu.php -- woocommerce_include_processing_order_count_in_menu
 		// TODO: What about the COT menu?
 		add_filter( 'woocommerce_register_post_type_shop_order', function( $args ) {
-			$args[ 'show_in_menu' ] = true;
-			$args[ 'menu_icon' ]    = 'dashicons-cart';
+			$args[ 'labels' ][ 'add_new' ] = __( 'Add new', 'woocommerce' );
+			$args[ 'show_in_menu' ]        = true;
+			$args[ 'menu_icon' ]           = 'dashicons-cart';
 			return $args;
 		} );
 	}
@@ -57,13 +56,13 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 		$products  = array_search( 'edit.php?post_type=product', $menu_order, true );
 		$analytics = array_search( 'wc-admin&path=/analytics/overview', $menu_order, true );
 		$marketing = array_search( 'woocommerce-marketing', $menu_order, true );
-
+		$extensions                = array_search( 'woocommerce', $menu_order, true );
+		$woocommerce_separator     = array_search( 'separator-woocommerce', $menu_order, true );
+		$woocommerce_separator_top = array_search( 'wc-calypso-bridge-separator-top', $menu_order, true );
+		$woocommerce_payments      = array_search( 'wc-admin&path=/payments/connect', $menu_order, true );
+		error_log( "woocommerce_payments:" . $woocommerce_payments );
 		// Loop through menu order and do some rearranging.
 		foreach ( $menu_order as $index => $item ) {
-
-			$extensions                = array_search( 'woocommerce', $menu_order, true );
-			$woocommerce_separator     = array_search( 'separator-woocommerce', $menu_order, true );
-			$woocommerce_separator_top = array_search( 'wc-calypso-bridge-separator-top', $menu_order, true );
 
 			// Move the WC group above the "Posts" menu item.
 			if ( 'edit.php' === $item ) {
@@ -71,6 +70,10 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 				$woocommerce_menu_order[] = 'edit.php?post_type=shop_order'; // Orders.
 				$woocommerce_menu_order[] = 'edit.php?post_type=product'; // Products.
 				$woocommerce_menu_order[] = 'admin.php?page=wc-admin&path=/customers'; // Customers.
+				if ( false !== $woocommerce_payments ) {
+					$woocommerce_menu_order[] = 'wc-admin&path=/payments/connect'; // Payments.
+				}
+
 				$woocommerce_menu_order[] = 'wc-admin&path=/analytics/overview'; // Analytics.
 				$woocommerce_menu_order[] = 'woocommerce-marketing'; // Marketing.
 				$woocommerce_menu_order[] = 'woocommerce'; // Extensions.
@@ -84,7 +87,12 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 				unset( $menu_order[ $extensions ] );
 				unset( $menu_order[ $woocommerce_separator ] );
 				unset( $menu_order[ $woocommerce_separator_top ] );
-			} elseif ( ! in_array( $item, array( 'wc-calypso-bridge-separator-top', 'separator-woocommerce', 'woocommerce', 'woocommerce-marketing', 'wc-admin&path=/analytics/overview', 'edit.php?post_type=product', 'edit.php?post_type=shop_order', 'admin.php?page=wc-admin&path=/customers'), true ) ) {
+
+				if ( false !== $woocommerce_payments ) {
+					unset( $menu_order[ $woocommerce_payments ] );
+				}
+
+			} elseif ( ! in_array( $item, array( 'wc-admin&path=/payments/connect', 'wc-calypso-bridge-separator-top', 'separator-woocommerce', 'woocommerce', 'woocommerce-marketing', 'wc-admin&path=/analytics/overview', 'edit.php?post_type=product', 'edit.php?post_type=shop_order', 'admin.php?page=wc-admin&path=/customers'), true ) ) {
 				$woocommerce_menu_order[] = $item;
 			}
 		}

--- a/includes/class-wc-calypso-bridge-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-admin-menu.php
@@ -143,7 +143,7 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 			$submenu_file = 'admin.php?page=wc-addons&section=helper';
 		}
 
-		// Move WooCommerce > Reports to Anaytics > Reports (Legacy).
+		// Move WooCommerce > Reports to Anaytics > Legacy Reports.
 		if ( in_array( $screen_id, array( 'woocommerce_page_wc-reports' ), true ) ) {
 			$plugin_page  = 'wc-admin&path=/analytics/overview';
 			$submenu_file = 'admin.php?page=wc-reports';
@@ -190,10 +190,10 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 		// Force-add the "Report (Legacy)" submenu item.
 		if ( ! empty( $submenu['wc-admin&path=/analytics/overview'] ) && is_array( $submenu['wc-admin&path=/analytics/overview'] ) ) {
 			$submenu['wc-admin&path=/analytics/overview'][] = array(
-				__( 'Reports (Legacy)', 'wc-calypso-bridge' ),
+				__( 'Legacy Reports', 'wc-calypso-bridge' ),
 				'manage_woocommerce',
 				'admin.php?page=wc-reports',
-				'Reports (Legacy)'
+				'Legacy Reports'
 			);
 		}
 
@@ -299,7 +299,7 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 			} );
 		}
 
-		// Order wc-admin&path=/analytics/overview -- ensure settings are always last and "Reports (legacy)" is the one above it.
+		// Order wc-admin&path=/analytics/overview -- ensure settings are always last and "Legacy Reports" is the one above it.
 		if ( ! empty( $submenu['wc-admin&path=/analytics/overview'] ) && is_array( $submenu['wc-admin&path=/analytics/overview'] ) ) {
 
 			uasort( $submenu['wc-admin&path=/analytics/overview'], function( $a, $b ) {

--- a/includes/class-wc-calypso-bridge-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-admin-menu.php
@@ -51,26 +51,27 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 		$woocommerce_menu_order = array();
 
 		// Get the index of our managed pages.
-		$orders    = array_search( 'edit.php?post_type=shop_order', $menu_order, true );
-		$customers = array_search( 'admin.php?page=wc-admin&path=/customers', $menu_order, true );
-		$products  = array_search( 'edit.php?post_type=product', $menu_order, true );
-		$analytics = array_search( 'wc-admin&path=/analytics/overview', $menu_order, true );
-		$marketing = array_search( 'woocommerce-marketing', $menu_order, true );
-		$extensions                = array_search( 'woocommerce', $menu_order, true );
-		$woocommerce_separator     = array_search( 'separator-woocommerce', $menu_order, true );
-		$woocommerce_separator_top = array_search( 'wc-calypso-bridge-separator-top', $menu_order, true );
-		$woocommerce_payments      = array_search( 'wc-admin&path=/payments/connect', $menu_order, true );
-		error_log( "woocommerce_payments:" . $woocommerce_payments );
+		$orders_index               = array_search( 'edit.php?post_type=shop_order', $menu_order, true );
+		$customers_index            = array_search( 'admin.php?page=wc-admin&path=/customers', $menu_order, true );
+		$products_index             = array_search( 'edit.php?post_type=product', $menu_order, true );
+		$analytics_index            = array_search( 'wc-admin&path=/analytics/overview', $menu_order, true );
+		$marketing_index            = array_search( 'woocommerce-marketing', $menu_order, true );
+		$extensions_index           = array_search( 'woocommerce', $menu_order, true );
+		$woocommerce_sep_index      = array_search( 'separator-woocommerce', $menu_order, true );
+		$woocommerce_sep_top_index  = array_search( 'wc-calypso-bridge-separator-top', $menu_order, true );
+		$woocommerce_payments_index = array_search( 'wc-admin&path=/payments/connect', $menu_order, true );
+
 		// Loop through menu order and do some rearranging.
 		foreach ( $menu_order as $index => $item ) {
 
 			// Move the WC group above the "Posts" menu item.
 			if ( 'edit.php' === $item ) {
+
 				$woocommerce_menu_order[] = 'wc-calypso-bridge-separator-top'; // Separator WC top.
 				$woocommerce_menu_order[] = 'edit.php?post_type=shop_order'; // Orders.
 				$woocommerce_menu_order[] = 'edit.php?post_type=product'; // Products.
 				$woocommerce_menu_order[] = 'admin.php?page=wc-admin&path=/customers'; // Customers.
-				if ( false !== $woocommerce_payments ) {
+				if ( false !== $woocommerce_payments_index ) {
 					$woocommerce_menu_order[] = 'wc-admin&path=/payments/connect'; // Payments.
 				}
 
@@ -79,20 +80,46 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 				$woocommerce_menu_order[] = 'woocommerce'; // Extensions.
 				$woocommerce_menu_order[] = 'separator-woocommerce'; // Separator WC.
 				$woocommerce_menu_order[] = $item; // Posts.
-				unset( $menu_order[ $orders ] );
-				unset( $menu_order[ $customers ] );
-				unset( $menu_order[ $products ] );
-				unset( $menu_order[ $analytics ] );
-				unset( $menu_order[ $marketing ] );
-				unset( $menu_order[ $extensions ] );
-				unset( $menu_order[ $woocommerce_separator ] );
-				unset( $menu_order[ $woocommerce_separator_top ] );
 
+				if ( false !== $orders_index ) {
+					unset( $menu_order[ $orders_index ] );
+				}
+				if ( false !== $customers_index ) {
+					unset( $menu_order[ $customers_index ] );
+				}
+				if ( false !== $products_index ) {
+					unset( $menu_order[ $products_index ] );
+				}
+				if ( false !== $analytics_index ) {
+					unset( $menu_order[ $analytics_index ] );
+				}
+				if ( false !== $marketing_index ) {
+					unset( $menu_order[ $marketing_index ] );
+				}
+				if ( false !== $extensions_index ) {
+					unset( $menu_order[ $extensions_index ] );
+				}
+				if ( false !== $woocommerce_sep_index ) {
+					unset( $menu_order[ $woocommerce_sep_index ] );
+				}
+				if ( false !== $woocommerce_sep_top_index ) {
+					unset( $menu_order[ $woocommerce_sep_top_index ] );
+				}
 				if ( false !== $woocommerce_payments ) {
 					unset( $menu_order[ $woocommerce_payments ] );
 				}
 
-			} elseif ( ! in_array( $item, array( 'wc-admin&path=/payments/connect', 'wc-calypso-bridge-separator-top', 'separator-woocommerce', 'woocommerce', 'woocommerce-marketing', 'wc-admin&path=/analytics/overview', 'edit.php?post_type=product', 'edit.php?post_type=shop_order', 'admin.php?page=wc-admin&path=/customers'), true ) ) {
+			} elseif ( ! in_array( $item, array(
+					'wc-admin&path=/payments/connect',
+					'wc-calypso-bridge-separator-top',
+					'separator-woocommerce',
+					'woocommerce',
+					'woocommerce-marketing',
+					'wc-admin&path=/analytics/overview',
+					'edit.php?post_type=product',
+					'edit.php?post_type=shop_order',
+					'admin.php?page=wc-admin&path=/customers'
+				), true ) ) {
 				$woocommerce_menu_order[] = $item;
 			}
 		}
@@ -207,7 +234,6 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 		// Add Extensions > Manage submenu.
 		add_submenu_page( 'woocommerce', __( 'WooCommerce Subscriptions','wc-calypso-bridge' ), __( 'Manage','wc-calypso-bridge' ), 'manage_woocommerce', 'admin.php?page=wc-addons&section=helper', '', 10 );
 
-
 		// Move WooCommerce > Extensions under Extensions > Discover.
 		foreach ( $submenu['woocommerce'] as $key => $data ) {
 			if ( 'wc-addons' !== $data[2] ) {
@@ -229,6 +255,17 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 				}
 			}
 		}
+
+		$this->reorder_woocommerce_menu();
+		$this->reorder_settings_menu();
+		$this->reorder_analytics_menu();
+	}
+
+	/**
+	 * Re-Order WooCommerce submenu.
+	 */
+	private function reorder_woocommerce_menu() {
+		global $submenu;
 
 		if ( ! empty( $submenu['woocommerce'] ) && is_array( $submenu['woocommerce'] ) ) {
 
@@ -269,6 +306,13 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 				return ( $A < $B ) ? -1 : 1;
 			} );
 		}
+	}
+
+	/**
+	 * Re-Order Settings submenu.
+	 */
+	private function reorder_settings_menu() {
+		global $submenu;
 
 		// Order options-general.php -- ensure WooCommerce is right after "General".
 		if ( ! empty( $submenu['options-general.php'] ) && is_array( $submenu['options-general.php'] ) ) {
@@ -298,6 +342,13 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 				return ( $A < $B ) ? -1 : 1;
 			} );
 		}
+	}
+
+	/**
+	 * Re-Order Analytics submenu.
+	 */
+	private function reorder_analytics_menu() {
+		global $submenu;
 
 		// Order wc-admin&path=/analytics/overview -- ensure settings are always last and "Legacy Reports" is the one above it.
 		if ( ! empty( $submenu['wc-admin&path=/analytics/overview'] ) && is_array( $submenu['wc-admin&path=/analytics/overview'] ) ) {

--- a/includes/class-wc-calypso-bridge-payments.php
+++ b/includes/class-wc-calypso-bridge-payments.php
@@ -155,7 +155,7 @@ class WC_Calypso_Bridge_Payments {
 	 */
 	public function add_wc_payments_style() {
 		$asset_path = WC_Calypso_Bridge_Shared::$plugin_asset_path ? WC_Calypso_Bridge_Shared::$plugin_asset_path : WC_Calypso_Bridge_Shared::MU_PLUGIN_ASSET_PATH;
-		wp_enqueue_style( 'wp-calypso-bridge-ecommerce', $asset_path . 'assets/css/wc-payments.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
+		wp_enqueue_style( 'wp-calypso-bridge-ecommerce-payments', $asset_path . 'assets/css/wc-payments.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
 	}
 
 	/**

--- a/src/index.js
+++ b/src/index.js
@@ -25,5 +25,10 @@ addFilter( 'woocommerce_admin_pages_list', 'wc-calypso-bridge', ( pages ) => {
 		},
 	} );
 
+	/**
+	 * Ensure that WooCommerce Home page will not highlight the WooCommerce parent menu item.
+	 */
+	pages = pages.map( page => page.path === '/' ? {...page, wpOpenMenu: 'toplevel_page_admin-page-wc-admin'} : page );
+
 	return pages;
 } );

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ addFilter( 'woocommerce_admin_pages_list', 'wc-calypso-bridge', ( pages ) => {
 	 * Ensure that WooCommerce Home page will not highlight the WooCommerce parent menu item.
 	 */
 	pages = pages.map( page => page.path === '/' ? {...page, wpOpenMenu: 'toplevel_page_admin-page-wc-admin'} : page );
+	pages = pages.map( page => page.path === '/customers' ? {...page, wpOpenMenu: ''} : page );
 
 	return pages;
 } );

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ addFilter( 'woocommerce_admin_pages_list', 'wc-calypso-bridge', ( pages ) => {
 	/**
 	 * Ensure that WooCommerce Home page will not highlight the WooCommerce parent menu item.
 	 */
-	pages = pages.map( page => page.path === '/' ? {...page, wpOpenMenu: 'toplevel_page_admin-page-wc-admin'} : page );
+	pages = pages.map( page => page.path === '/' ? {...page, wpOpenMenu: 'menu-dashboard' } : page );
 	pages = pages.map( page => page.path === '/customers' ? {...page, wpOpenMenu: ''} : page );
 
 	return pages;

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -32,7 +32,7 @@ if ( ! file_exists( WP_PLUGIN_DIR . '/' . $wc_plugin_path ) || ! is_plugin_activ
 if ( file_exists( WP_PLUGIN_DIR . '/wc-calypso-bridge/wc-calypso-bridge.php' ) ) {
 	if ( WP_PLUGIN_DIR . '/wc-calypso-bridge/' !== plugin_dir_path( __FILE__ ) ) {
 		// wc-calypso-bridge is already installed conventionally, exiting to avoid conflict.
-		return;
+		// return;
 	}
 }
 

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -32,7 +32,7 @@ if ( ! file_exists( WP_PLUGIN_DIR . '/' . $wc_plugin_path ) || ! is_plugin_activ
 if ( file_exists( WP_PLUGIN_DIR . '/wc-calypso-bridge/wc-calypso-bridge.php' ) ) {
 	if ( WP_PLUGIN_DIR . '/wc-calypso-bridge/' !== plugin_dir_path( __FILE__ ) ) {
 		// wc-calypso-bridge is already installed conventionally, exiting to avoid conflict.
-		// return;
+		return;
 	}
 }
 


### PR DESCRIPTION
Closes #850 

### Description

This PR aims to flatten the WooCommerce menu experience.

In a nutshell, we have:

- Moved the **Orders** menu item to the top level of our navigation, and expose **All Orders** and **New Order** submenu items.
- Moved the **Customers** menu item to the top level of our navigation.
- Moved **WooCommerce > Status** to **Tools > WooCommerce Status**.
- Moved **WooCommerce > Settings** to **Settings > WooCommerce**.
- Moved the legacy, now-deprecated **WooCommerce > Reports** section to **Analytics > Legacy Reports**.
- Finally, relabelled the **WooCommerce** menu item to **Extensions** and moved **WooCommerce > Extensions** to the top as **Extensions > Discover**.