### PR TITLE
Prepare to release 1.9.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v1.9.7",
+  "version": "v1.9.8",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -23,14 +23,15 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 = 1.9.8 =
-* Create WooCommerce pages with a one-time operation #XXX.
-* Delete wc-refund-returns-page inbox note, so it can be recreated with the correct refund page ID #XXX.
-* Set default to block-based cart/checkout #XXX.
-* Display note about the new block-based cart/checkout if the site is active for more than 2 days  #XXX.
-* Display wc-refund-returns-page inbox note if the site is active for more than 5 days #XXX.
-* Hide write button in global bar #XXX.
-* Prevent deletion of managed Extensions #XXX.
-* Suppress wc-payments-notes-set-up-refund-policy inbox note #xxx.
+* Pre-configure Jetpack for Ecommerce Plan users #844.
+* Create WooCommerce pages with a one-time operation #823.
+* Delete wc-refund-returns-page inbox note, so it can be recreated with the correct refund page ID #823.
+* Set default to block-based cart/checkout #823.
+* Display note about the new block-based cart/checkout if the site is active for more than 2 days #823.
+* Display wc-refund-returns-page inbox note if the site is active for more than 5 days #823.
+* Hide write button in global bar #827.
+* Prevent deletion of managed Extensions #846.
+* Suppress wc-payments-notes-set-up-refund-policy inbox note #849.
 
 = 1.9.7 =
 * Revert: Hook `maybe_create_wc_pages` on `woocommerce_installed` #842.

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 1.9.7
+ * Version: 1.9.8
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -37,7 +37,7 @@ if ( file_exists( WP_PLUGIN_DIR . '/wc-calypso-bridge/wc-calypso-bridge.php' ) )
 }
 
 define( 'WC_CALYSPO_BRIDGE_PLUGIN_FILE', __FILE__ );
-define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.9.7' );
+define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.9.8' );
 define( 'WC_MIN_VERSION', '3.0.0' );
 
 if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_plan' ) ) {


### PR DESCRIPTION
This PR bumps the version to 1.9.8 to release


* #844
* #823 
  * Create WooCommerce pages with a one-time operation
  * Delete wc-refund-returns-page inbox note, so it can be recreated with the correct refund page ID
  * Set default to block-based cart/checkout
  * Display note about the new block-based cart/checkout if the site is active for more than 2 days
  * Display wc-refund-returns-page inbox note if the site is active for more than 5 days
* #827
* #846
* #849