### PR TITLE
Rollback limiting available Jetpack Modules

### DIFF
--- a/includes/class-wc-calypso-bridge-jetpack.php
+++ b/includes/class-wc-calypso-bridge-jetpack.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Jetpack
  * @since   1.9.8
- * @version 1.9.8
+ * @version 1.9.10
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -72,8 +72,10 @@ class WC_Calypso_Bridge_Jetpack {
 		 * @return array
 		 */
 		add_filter( 'jetpack_get_available_modules', function ( $mods ) {
+
+			// Removing Google Analytics module as we've activated WooCommerce Google Analytics Integration for all new sites.
 			if ( WC_Calypso_Bridge_Helper_Functions::is_wc_admin_installed_gte( WC_Calypso_Bridge::RELEASE_DATE_PRE_CONFIGURE_JETPACK ) ) {
-				$mods = array_diff_key( $mods, array_flip( array( 'gravatar-hovercards', 'custom-content-types', 'wordads', 'google-analytics', 'widget-visibility', 'post-list', 'infinite-scroll', 'copy-post', 'lazy-images', 'post-by-email', 'related-posts', 'action-bar' ) ) );
+				$mods = array_diff_key( $mods, array_flip( array( 'google-analytics' ) ) );
 			}
 
 			return $mods;

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 1.9.10 =
+* Rollback limiting available Jetpack Modules #xxx.
+
 = 1.9.9 =
 * Introduce locking to one time operations #865.
 * Fix fatal error when pre-configuring Jetpack for Ecommerce Plan users #862.


### PR DESCRIPTION
closes #869 

[This](https://github.com/Automattic/wc-calypso-bridge/pull/844/files#diff-b724d74a3dc5a84c65d2e6c648b01548a2e48e05ba69d28ba5166b2682493e29R66-R80) was too aggressive; after an incident on p9F6qB-aTO-p2 we decided to deactivate the modules (on new sites only) but not remove them from the list.

Done for all modules, except for the Google Analytics module, which has been superseded (for new users!) by the WooCommerce Google Analytics extension.