### PR TITLE
Rollback "Tools > Earn" and Jetpack Google Analytics module

### DIFF
--- a/includes/class-wc-calypso-bridge-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-admin-menu.php
@@ -4,20 +4,11 @@
  * Class Ecommerce_Atomic_Admin_Menu.
  *
  * @since   1.9.8
- * @version 1.9.8
+ * @version 1.9.11
  *
  * The admin menu controller for Ecommerce WoA sites.
  */
 class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customizations\Atomic_Admin_Menu {
-
-	/**
-	 * Remove 'Earn' from Tools. Merchants have an idea already about how they want to make money :)
-	 */
-	public function add_tools_menu() {
-		parent::add_tools_menu();
-		// Remove Earn from Tools.
-		$this->hide_submenu_page( 'tools.php', 'https://wordpress.com/earn/' . $this->domain );
-	}
 
 	/**
 	 * Introduce 'Settings > Anti-Spam' and remove 'Settings > Jetpack' from Settings.

--- a/includes/class-wc-calypso-bridge-jetpack.php
+++ b/includes/class-wc-calypso-bridge-jetpack.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Jetpack
  * @since   1.9.8
- * @version 1.9.10
+ * @version 1.9.11
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -63,23 +63,6 @@ class WC_Calypso_Bridge_Jetpack {
 			return $menu_controller_class;
 		} );
 
-		/**
-		 * Limits Jetpack Modules to those relevant to Ecommerce Plan users.
-		 *
-		 * @since 1.9.8
-		 *
-		 * @param  array $mods Available Jetpack modules for activation.
-		 * @return array
-		 */
-		add_filter( 'jetpack_get_available_modules', function ( $mods ) {
-
-			// Removing Google Analytics module as we've activated WooCommerce Google Analytics Integration for all new sites.
-			if ( WC_Calypso_Bridge_Helper_Functions::is_wc_admin_installed_gte( WC_Calypso_Bridge::RELEASE_DATE_PRE_CONFIGURE_JETPACK ) ) {
-				$mods = array_diff_key( $mods, array_flip( array( 'google-analytics' ) ) );
-			}
-
-			return $mods;
-		} );
 	}
 }
 

--- a/includes/class-wc-calypso-bridge-jetpack.php
+++ b/includes/class-wc-calypso-bridge-jetpack.php
@@ -63,6 +63,30 @@ class WC_Calypso_Bridge_Jetpack {
 			return $menu_controller_class;
 		} );
 
+		/**
+		 * Limits Jetpack Modules to those relevant to Ecommerce Plan users.
+		 *
+		 * @since 1.9.8
+		 *
+		 * @param  array $mods Available Jetpack modules for activation.
+		 * @return array
+		 */
+		add_filter( 'jetpack_get_available_modules', function ( $mods ) {
+
+			// Removing Google Analytics module as we've activated WooCommerce Google Analytics Integration for all new sites.
+			if ( WC_Calypso_Bridge_Helper_Functions::is_wc_admin_installed_gte( WC_Calypso_Bridge::RELEASE_DATE_PRE_CONFIGURE_JETPACK ) ) {
+				$ga_options = get_option( 'jetpack_wga' );
+				$ga_enabled = isset( $ga_options['code'] ) && ! empty( $ga_options['code'] );
+
+				// If GA was already enabled before the transfer to atomic, we shouldn't remove the module.
+				if ( ! $ga_enabled ) {
+					$mods = array_diff_key( $mods, array_flip( array( 'google-analytics' ) ) );
+				}
+			}
+
+			return $mods;
+		} );
+
 	}
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 1.9.11 =
+* Rollback Tools > Earn menu item #xxx.
+
 = 1.9.10 =
 * Rollback limiting available Jetpack Modules #870.
 

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,7 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 = 1.9.11 =
-* Rollback Tools > Earn menu item #xxx.
+* Rollback Tools > Earn menu item and Jetpack Google Analytics module #xxx.
 
 = 1.9.10 =
 * Rollback limiting available Jetpack Modules #870.


### PR DESCRIPTION
closes #873 

References

- p9F6qB-aVu-p2
- https://github.com/Automattic/wc-calypso-bridge/pull/844/files#diff-51f09112b24ac5565ec368561d88b359b01240809814e59d5ce1248e675abcaaR13-R20
- #844 