### PR TITLE
Prevent deletion of new round of managed extensions

### DIFF
--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 1.9.8
+ * @version 1.9.11
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -36,6 +36,14 @@ class WC_Calypso_Bridge_Plugins {
 		'woocommerce-shipping-royalmail/woocommerce-shipping-royalmail.php',
 		'woocommerce-shipping-ups/woocommerce-shipping-ups.php',
 		'woocommerce-shipping-usps/woocommerce-shipping-usps.php',
+		'tiktok-for-woocommerce/tiktok-for-woocommerce.php',
+		'woocommerce-pinterest/pinterest-for-woocommerce.php',
+		'woocommerce-brands/woocommerce-brands.php',
+		'woocommerce-back-in-stock-notifications/woocommerce-back-in-stock-notifications.php',
+		'woocommerce-eu-vat-number/woocommerce-eu-vat-number.php',
+		'woocommerce-shipment-tracking/woocommerce-shipment-tracking.php',
+		'crowdsignal-forms/crowdsignal-forms.php',
+		'polldaddy/polldaddy.php',
 	);
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 1.9.11 =
+* Prevent deletion of new round of managed extensions #xxx.
+
 = 1.9.10 =
 * Rollback limiting available Jetpack Modules #870.
 


### PR DESCRIPTION
We've introduced a new round of extentions in WPCOM D93704-code, we need to prevent them from being deleted

closes #875 