### PR TITLE
Fix deprecated function

### DIFF
--- a/class-wc-calypso-bridge-shared.php
+++ b/class-wc-calypso-bridge-shared.php
@@ -65,7 +65,7 @@ class WC_Calypso_Bridge_Shared {
 	public function add_extension_register_script() {
 
 		$is_woo_page = class_exists( 'Automattic\WooCommerce\Admin\Loader' )
-			&& \Automattic\WooCommerce\Admin\Loader::is_admin_or_embed_page()
+			&& \Automattic\WooCommerce\Admin\PageController::is_admin_or_embed_page()
 			? true
 			: false;
 

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleased =
+* Fix deprecated function Loader::is_admin_or_embed_page() #884
+
 = 1.9.12 =
 * Introduce add-a-domain and launch-your-store tasks in the setup list #879.
 * Flatten the WooCommerce menu under a feature gate #879.


### PR DESCRIPTION
The function was deprecated in 6.3, producing this error:
<img width="1033" alt="image" src="https://user-images.githubusercontent.com/3747241/208675904-5ece3034-123c-456b-94b1-313e6c40268a.png">

**Testing instructions**:

1. Go to WooCommerce > Home
2. Make sure it loads fine and no errors/warning is shown
3. Check `debug.log` to confirm there's no error hidden
