### PR TITLE
Use updated helper gist on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ update_option( 'woocommerce_setup_ab_wc_admin_onboarding', 'a' );
 update_option( 'wc_onboarding_opt_in', 'no' );
 ```
 
-If you would like to skip all of the above, [just download this gist](https://gist.github.com/psealock/531205e2c3d37be1d8ac4d3ef4f346bc) as a plugin and activate it :).
+If you would like to skip all of the above, [just download this gist](https://gist.github.com/moon0326/cac46c70a2cee81b61faef517fef7178) (recommended) as a plugin and activate it :).
 
 ### Plugin Integrations
 


### PR DESCRIPTION
This PR updated the link to the helper gist. The gist has been updated to work with the latest changes in wc-calypso-bridge.

Added the following class and function to the gist.

```
if ( ! class_exists( 'WPCOM_Features' ) ) {
    class WPCOM_Features {
        const ECOMMERCE_MANAGED_PLUGINS = 'ECOMMERCE_MANAGED_PLUGINS';
    }
}

if ( ! function_exists( 'wpcom_site_has_feature' ) ) {
    function wpcom_site_has_feature( $feature, $blog_id = 0) {
        $at_options = get_option( 'at_options' );
        return isset( $at_options[ 'plan_slug' ] ) && $at_options[ 'plan_slug' ] === 'ecommerce';
    }
}
```