### PR TITLE
Prepare to release 1.9.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v1.9.12",
+  "version": "v1.9.13",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 1.9.12
+ * Version: 1.9.13
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -37,7 +37,7 @@ if ( file_exists( WP_PLUGIN_DIR . '/wc-calypso-bridge/wc-calypso-bridge.php' ) )
 }
 
 define( 'WC_CALYSPO_BRIDGE_PLUGIN_FILE', __FILE__ );
-define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.9.12' );
+define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.9.13' );
 define( 'WC_MIN_VERSION', '3.0.0' );
 
 if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_plan' ) ) {


### PR DESCRIPTION
This PR bumps the version to 1.9.13 to release

- https://github.com/Automattic/wc-calypso-bridge/pull/900
- https://github.com/Automattic/wc-calypso-bridge/pull/899
- https://github.com/Automattic/wc-calypso-bridge/pull/884

```
== Changelog ==

= 1.9.13 =
* Enable the WooCommerce menu and remove the feature flag #899.
* Delete WooCommerce pages before recreating them (new sites only) #900.
* Run DB updates automatically without wp-admin notices #899.
* Fix deprecated function Loader::is_admin_or_embed_page() #884.

```