### PR TITLE
Prepare to release 1.9.14

### DIFF
--- a/class-wc-calypso-bridge-shared.php
+++ b/class-wc-calypso-bridge-shared.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 1.9.13
+ * @version 1.9.14
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 1.9.13
+ * @version 1.9.14
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v1.9.13",
+  "version": "v1.9.14",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 1.9.13
+ * Version: 1.9.14
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -37,7 +37,7 @@ if ( file_exists( WP_PLUGIN_DIR . '/wc-calypso-bridge/wc-calypso-bridge.php' ) )
 }
 
 define( 'WC_CALYSPO_BRIDGE_PLUGIN_FILE', __FILE__ );
-define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.9.13' );
+define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.9.14' );
 define( 'WC_MIN_VERSION', '3.0.0' );
 
 if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_plan' ) ) {


### PR DESCRIPTION
This PR bumps the version to 1.9.13 to release
- https://github.com/Automattic/wc-calypso-bridge/pull/904
- https://github.com/Automattic/wc-calypso-bridge/pull/903

```
== Changelog ==

= 1.9.14 =
* Fix a fatal error about WC_Calypso_Bridge_Helper_Functions in Business plan #903.
* Limit JS filters to Ecommerce plans to avoid unwanted menu highlights in Business plan #904.
```