### PR TITLE
Revert the default value of the ecommerce_new_woo_atomic_navigation_enabled filter

### DIFF
--- a/assets/css/ecommerce-navigation.css
+++ b/assets/css/ecommerce-navigation.css
@@ -1,0 +1,16 @@
+/**
+ * Ecommerce navigation feature
+ */
+
+/* Fix the top space in WooCommerce Marketplace. */
+body.woocommerce_page_wc-addons.woocommerce-embed-page #wpbody .woocommerce-layout {
+	padding-top: 0;
+}
+
+/*  Hide tabs in wc-addons page for Ecommerce plan. */
+.woocommerce.wc-addons-wrap .top-bar {
+	display: none;
+}
+.woocommerce.wc-subscriptions-wrap .woo-nav-tab-wrapper {
+	display: none;
+}

--- a/assets/css/ecommerce.css
+++ b/assets/css/ecommerce.css
@@ -20,20 +20,3 @@
 	.components-tab-panel__tabs {
 	display: none;
 }
-
-/**
- * Ecommerce navigation feature
- */
-
-/* Fix the top space in WooCommerce Marketplace. */
-body.woocommerce_page_wc-addons.woocommerce-embed-page #wpbody .woocommerce-layout {
-	padding-top: 0;
-}
-
-/*  Hide tabs in wc-addons page for Ecommerce plan. */
-.woocommerce.wc-addons-wrap .top-bar {
-	display: none;
-}
-.woocommerce.wc-subscriptions-wrap .woo-nav-tab-wrapper {
-	display: none;
-}

--- a/class-wc-calypso-bridge-shared.php
+++ b/class-wc-calypso-bridge-shared.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 1.9.14
+ * @version 1.9.15
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/class-wc-calypso-bridge-shared.php
+++ b/class-wc-calypso-bridge-shared.php
@@ -101,6 +101,7 @@ class WC_Calypso_Bridge_Shared {
 
 		$params       = array(
 			'isEcommercePlan'              => (bool) wc_calypso_bridge_is_ecommerce_plan(),
+			'isWooNavigationEnabled'       => (bool) apply_filters( 'ecommerce_new_woo_atomic_navigation_enabled', true ),
 			'isWooPage'                    => $is_woo_page,
 			'homeUrl'                      => esc_url( get_home_url() ),
 			'siteSlug'                     => $site_suffix,

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 1.9.14
+ * @version 1.9.15
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -379,6 +379,10 @@ class WC_Calypso_Bridge {
 	public function add_ecommerce_plan_styles() {
 		$asset_path = self::$plugin_asset_path ? self::$plugin_asset_path : self::MU_PLUGIN_ASSET_PATH;
 		wp_enqueue_style( 'wp-calypso-bridge-ecommerce', $asset_path . 'assets/css/ecommerce.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
+
+		if ( (bool) apply_filters( 'ecommerce_new_woo_atomic_navigation_enabled', true ) ) {
+			wp_enqueue_style( 'wp-calypso-bridge-ecommerce-navigation', $asset_path . 'assets/css/ecommerce-navigation.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
+		}
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-jetpack.php
+++ b/includes/class-wc-calypso-bridge-jetpack.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Jetpack
  * @since   1.9.8
- * @version 1.9.13
+ * @version 1.9.15
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-calypso-bridge-jetpack.php
+++ b/includes/class-wc-calypso-bridge-jetpack.php
@@ -55,7 +55,18 @@ class WC_Calypso_Bridge_Jetpack {
 		 */
 		add_filter( 'jetpack_admin_menu_class', function ( $menu_controller_class ) {
 
-			if ( class_exists( '\Automattic\Jetpack\Dashboard_Customizations\Atomic_Admin_Menu' ) ) {
+			/**
+			 * `ecommerce_new_woo_atomic_navigation_enabled` filter.
+			 *
+			 * This filter is used to revert the ecommerce menu back to the atomic one. It's also useful for debugging purposes.
+			 *
+			 * @since 1.9.12
+			 *
+			 * @param  bool $enabled
+			 * @return bool
+			 */
+
+			if ( (bool) apply_filters( 'ecommerce_new_woo_atomic_navigation_enabled', true ) && class_exists( '\Automattic\Jetpack\Dashboard_Customizations\Atomic_Admin_Menu' ) ) {
 				require_once dirname( __FILE__ ) . '/class-wc-calypso-bridge-ecommerce-admin-menu.php';
 				return Ecommerce_Atomic_Admin_Menu::class;
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 1.9.15 =
+* Revert the default value of the ecommerce_new_woo_atomic_navigation_enabled filter #.
+
 = 1.9.14 =
 * Fix a fatal error about WC_Calypso_Bridge_Helper_Functions in Business plan #903.
 * Limit JS filters to Ecommerce plans to avoid unwanted menu highlights in Business plan #904.

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,7 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 = 1.9.15 =
-* Revert the default value of the ecommerce_new_woo_atomic_navigation_enabled filter #.
+* Revert the default value of the ecommerce_new_woo_atomic_navigation_enabled filter #XXX.
 
 = 1.9.14 =
 * Fix a fatal error about WC_Calypso_Bridge_Helper_Functions in Business plan #903.

--- a/src/index.js
+++ b/src/index.js
@@ -37,17 +37,19 @@ if ( !! window.wcCalypsoBridge.isEcommercePlan ) {
 	// Filter wc admin pages.
 	addFilter( 'woocommerce_admin_pages_list', 'wc-calypso-bridge', ( pages ) => {
 
+		if ( !! window.wcCalypsoBridge.isWooNavigationEnabled ) {
 			/**
 			 * Ensure that WooCommerce Home page will not highlight the WooCommerce parent menu item.
 			 */
 			pages = pages.map( page => page.path === '/' ? {...page, wpOpenMenu: 'menu-dashboard' } : page );
 			pages = pages.map( page => page.path === '/customers' ? {...page, wpOpenMenu: ''} : page );
+		}
 
 		return pages;
 	} );
 
 	// Embed code on woo pages.
-	if ( !! window.wcCalypsoBridge.showEcommerceNavigationModal && !! window.wcCalypsoBridge.isWooPage ) {
+	if ( !! window.wcCalypsoBridge.isWooNavigationEnabled && !! window.wcCalypsoBridge.showEcommerceNavigationModal && !! window.wcCalypsoBridge.isWooPage ) {
 		const wpBody = document.getElementById( 'wpbody-content' );
 		const wrap =
 			wpBody.querySelector( '.wrap.woocommerce' ) ||


### PR DESCRIPTION
### Specification


This PR brings back the `ecommerce_new_woo_atomic_navigation_enabled` filter as a safety net for easy disabling the Ecommerce navigation and for debugging purposes.