### PR TITLE
Prepare to release 1.9.15

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v1.9.14",
+  "version": "v1.9.15",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,7 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 = 1.9.15 =
-* Revert the default value of the ecommerce_new_woo_atomic_navigation_enabled filter #XXX.
+* Revert the default value of the ecommerce_new_woo_atomic_navigation_enabled filter #908.
 
 = 1.9.14 =
 * Fix a fatal error about WC_Calypso_Bridge_Helper_Functions in Business plan #903.

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 1.9.14
+ * Version: 1.9.15
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -37,7 +37,7 @@ if ( file_exists( WP_PLUGIN_DIR . '/wc-calypso-bridge/wc-calypso-bridge.php' ) )
 }
 
 define( 'WC_CALYSPO_BRIDGE_PLUGIN_FILE', __FILE__ );
-define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.9.14' );
+define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.9.15' );
 define( 'WC_MIN_VERSION', '3.0.0' );
 
 if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_plan' ) ) {


### PR DESCRIPTION
This PR bumps the version to 1.9.15 to release

- https://github.com/Automattic/wc-calypso-bridge/pull/908

```
= 1.9.15 =
* Revert the default value of the ecommerce_new_woo_atomic_navigation_enabled filter #908.
```