### PR TITLE
Prevent deletion of managed plugins (Product Recommendations, AutomateWoo, MailPoet Free)

### DIFF
--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 1.9.16
+ * @version 1.9.17
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 1.9.11
+ * @version 1.9.16
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -44,6 +44,9 @@ class WC_Calypso_Bridge_Plugins {
 		'woocommerce-shipment-tracking/woocommerce-shipment-tracking.php',
 		'crowdsignal-forms/crowdsignal-forms.php',
 		'polldaddy/polldaddy.php',
+		'mailpoet/mailpoet.php',
+		'automatewoo/automatewoo.php',
+		'woocommerce-product-recommendations/woocommerce-product-recommendations.php',
 	);
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 1.9.16 =
+* Prevent deletion of new round of managed plugins (Product Recommendations, AutomateWoo, MailPoet Free) #xxx.
+
 = 1.9.15 =
 * Revert the default value of the ecommerce_new_woo_atomic_navigation_enabled filter #908.
 

--- a/readme.txt
+++ b/readme.txt
@@ -22,7 +22,7 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
-= 1.9.16 =
+= 1.9.17 =
 * Prevent deletion of new round of managed plugins (Product Recommendations, AutomateWoo, MailPoet Free) #xxx.
 
 = 1.9.15 =


### PR DESCRIPTION
We'll be introducing a new [round of extensions in WPCOM](peapX7-1r9-p2), we need to prevent them from being deleted

closes #906