### PR TITLE
Customers Menu Item Visibility when Analytics is disabled

### DIFF
--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -4,7 +4,7 @@
  * Class Ecommerce_Atomic_Admin_Menu.
  *
  * @since   1.9.8
- * @version 1.9.12
+ * @version 1.9.16
  *
  * The admin menu controller for Ecommerce WoA sites.
  */
@@ -230,9 +230,11 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 			);
 		}
 
-		// Move Customers to root menu.
-		$this->hide_submenu_page( 'woocommerce', 'wc-admin&path=/customers' );
-		add_menu_page( __( 'Customers', 'woocommerce' ), __( 'Customers', 'woocommerce' ), 'manage_woocommerce', '/admin.php?page=wc-admin&path=/customers', null, 'dashicons-money', 100 );
+		if ( class_exists( '\Automattic\WooCommerce\Admin\Features\Features' ) && \Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'analytics' ) ) {
+			// Move Customers to root menu.
+			$this->hide_submenu_page( 'woocommerce', 'wc-admin&path=/customers' );
+			add_menu_page( __( 'Customers', 'woocommerce' ), __( 'Customers', 'woocommerce' ), 'manage_woocommerce', '/admin.php?page=wc-admin&path=/customers', null, 'dashicons-money', 100 );
+		}
 
 		// Update WooCommerce to Extensions
 		$this->update_menu( 'woocommerce', null, __( 'Extensions', 'woocommerce' ), null, null, null );

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 1.9.16 =
+* Hide Customers menu item when analytics are disabled #914.
+
 = 1.9.15 =
 * Revert the default value of the ecommerce_new_woo_atomic_navigation_enabled filter #908.
 


### PR DESCRIPTION
### Specification

This PR fixes an issue with the **Customers** menu item showing the "Sorry, you are not allowed to access this page." error when analytics are disabled on a site. 

closes #913 