### PR TITLE
Prepare to release 1.9.17

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v1.9.16",
+  "version": "v1.9.17",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -23,8 +23,8 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 = 1.9.17 =
-* Roll Product Recommendations into the Ecommerce Plan #XXX.
-* Prevent deletion of new round of managed plugins (Product Recommendations, AutomateWoo, MailPoet Free) #xxx.
+* Roll Product Recommendations into the Ecommerce Plan #910.
+* Prevent deletion of new round of managed plugins (Product Recommendations, AutomateWoo, MailPoet Free) #912.
 
 = 1.9.16 =
 * Hide Customers menu item when analytics are disabled #914.

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 1.9.16
+ * Version: 1.9.17
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -37,7 +37,7 @@ if ( file_exists( WP_PLUGIN_DIR . '/wc-calypso-bridge/wc-calypso-bridge.php' ) )
 }
 
 define( 'WC_CALYSPO_BRIDGE_PLUGIN_FILE', __FILE__ );
-define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.9.16' );
+define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '1.9.17' );
 define( 'WC_MIN_VERSION', '3.0.0' );
 
 if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_plan' ) ) {


### PR DESCRIPTION
This PR bumps the version to 1.9.17 to release

- https://github.com/Automattic/wc-calypso-bridge/pull/910
- https://github.com/Automattic/wc-calypso-bridge/pull/912

```
= 1.9.17 =
* Roll Product Recommendations into the Ecommerce Plan #910.
* Prevent deletion of new round of managed plugins (Product Recommendations, AutomateWoo, MailPoet Free) #912.
```