### PR TITLE
Arrange menu order for Mailpoet and Automatewoo

### DIFF
--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -4,7 +4,7 @@
  * Class Ecommerce_Atomic_Admin_Menu.
  *
  * @since   1.9.8
- * @version 1.9.17
+ * @version 1.9.18
  *
  * The admin menu controller for Ecommerce WoA sites.
  */

--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -46,11 +46,10 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 	 * Groups WooCommerce items.
 	 */
 	public static function menu_order( $menu_order ) {
-
 		// Initialize our custom order array.
 		$woocommerce_menu_order = array();
 
-		// Get the index of our managed pages.
+		// Get the index of our managed pages for core.
 		$orders_index              = array_search( 'edit.php?post_type=shop_order', $menu_order, true );
 		$customers_index           = array_search( 'admin.php?page=wc-admin&path=/customers', $menu_order, true );
 		$products_index            = array_search( 'edit.php?post_type=product', $menu_order, true );
@@ -59,8 +58,12 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 		$extensions_index          = array_search( 'woocommerce', $menu_order, true );
 		$woocommerce_sep_index     = array_search( 'separator-woocommerce', $menu_order, true );
 		$woocommerce_sep_top_index = array_search( 'wc-calypso-bridge-separator-top', $menu_order, true );
+
+		// Get the index of our managed pages for integrations.
 		$payments_connect_index    = array_search( 'wc-admin&path=/payments/connect', $menu_order, true );
 		$payments_overview_index   = array_search( 'wc-admin&path=/payments/overview', $menu_order, true );
+		$automatewoo_index         = array_search( 'automatewoo', $menu_order, true );
+		$mailpoet_index            = array_search( 'mailpoet-newsletters', $menu_order, true );
 
 		// Loop through menu order and do some rearranging.
 		foreach ( $menu_order as $index => $item ) {
@@ -80,6 +83,7 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 
 				$woocommerce_menu_order[] = 'wc-admin&path=/analytics/overview'; // Analytics.
 				$woocommerce_menu_order[] = 'woocommerce-marketing'; // Marketing.
+				$woocommerce_menu_order[] = 'automatewoo'; // AutomateWoo.
 				$woocommerce_menu_order[] = 'woocommerce'; // Extensions.
 				$woocommerce_menu_order[] = 'separator-woocommerce'; // Separator WC.
 				$woocommerce_menu_order[] = $item; // Posts.
@@ -113,8 +117,22 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 				} elseif ( false !== $payments_overview_index ) {
 					unset( $menu_order[ $payments_overview_index ] );
 				}
+				if ( false !== $automatewoo_index ) {
+					unset( $menu_order[ $automatewoo_index ] );
+				}
+
+
+			// Move "Mailpoet" below the "Jetpack" menu item.
+			} elseif ( 'jetpack' === $item ) {
+				$woocommerce_menu_order[] = $item; // Jetpack.
+				$woocommerce_menu_order[] = 'mailpoet-newsletters'; // Mailpoet.
+				if ( false !== $mailpoet_index ) {
+					unset( $menu_order[ $mailpoet_index ] );
+				}
 
 			} elseif ( ! in_array( $item, array(
+				'mailpoet-newsletters',
+				'automatewoo',
 				'wc-admin&path=/payments/connect',
 				'wc-admin&path=/payments/overview',
 				'wc-calypso-bridge-separator-top',

--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -47,13 +47,13 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 	 */
 	public static function menu_order( $menu_order ) {
 		// Initialize our custom order array.
-		$woocommerce_menu_order = array();
+		$woocommerce_menu_order   = array();
 
 		// Get the index of our managed pages for integrations.
-		$payments_connect_index    = array_search( 'wc-admin&path=/payments/connect', $menu_order, true );
-		$payments_overview_index   = array_search( 'wc-admin&path=/payments/overview', $menu_order, true );
-		$automatewoo_index         = array_search( 'automatewoo', $menu_order, true );
-		$mailpoet_index            = array_search( 'mailpoet-newsletters', $menu_order, true );
+		$payments_connect_exists  = in_array( 'wc-admin&path=/payments/connect', $menu_order );
+		$payments_overview_exists = in_array( 'wc-admin&path=/payments/overview', $menu_order );
+		$automatewoo_exists       = in_array( 'automatewoo', $menu_order );
+		$mailpoet_exists          = in_array( 'mailpoet-newsletters', $menu_order );
 
 		// Loop through menu order and do some rearranging.
 		foreach ( $menu_order as $index => $item ) {
@@ -65,15 +65,15 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 				$woocommerce_menu_order[] = 'edit.php?post_type=shop_order'; // Orders.
 				$woocommerce_menu_order[] = 'edit.php?post_type=product'; // Products.
 				$woocommerce_menu_order[] = 'admin.php?page=wc-admin&path=/customers'; // Customers.
-				if ( false !== $payments_connect_index ) {
+				if ( false !== $payments_connect_exists ) {
 					$woocommerce_menu_order[] = 'wc-admin&path=/payments/connect'; // Payments.
-				} elseif ( false !== $payments_overview_index ) {
+				} elseif ( false !== $payments_overview_exists ) {
 					$woocommerce_menu_order[] = 'wc-admin&path=/payments/overview'; // Payments.
 				}
 
 				$woocommerce_menu_order[] = 'wc-admin&path=/analytics/overview'; // Analytics.
 				$woocommerce_menu_order[] = 'woocommerce-marketing'; // Marketing.
-				if ( false !== $automatewoo_index ) {
+				if ( false !== $automatewoo_exists ) {
 					$woocommerce_menu_order[] = 'automatewoo'; // AutomateWoo.
 				}
 				$woocommerce_menu_order[] = 'woocommerce'; // Extensions.
@@ -81,7 +81,7 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 				$woocommerce_menu_order[] = $item; // Posts.
 
 			// Move "Mailpoet" below the "Jetpack" menu item.
-			} elseif ( false !== $mailpoet_index && 'jetpack' === $item ) {
+			} elseif ( false !== $mailpoet_exists && 'jetpack' === $item ) {
 				$woocommerce_menu_order[] = $item; // Jetpack.
 				$woocommerce_menu_order[] = 'mailpoet-newsletters'; // Mailpoet.
 

--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -49,16 +49,6 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 		// Initialize our custom order array.
 		$woocommerce_menu_order = array();
 
-		// Get the index of our managed pages for core.
-		$orders_index              = array_search( 'edit.php?post_type=shop_order', $menu_order, true );
-		$customers_index           = array_search( 'admin.php?page=wc-admin&path=/customers', $menu_order, true );
-		$products_index            = array_search( 'edit.php?post_type=product', $menu_order, true );
-		$analytics_index           = array_search( 'wc-admin&path=/analytics/overview', $menu_order, true );
-		$marketing_index           = array_search( 'woocommerce-marketing', $menu_order, true );
-		$extensions_index          = array_search( 'woocommerce', $menu_order, true );
-		$woocommerce_sep_index     = array_search( 'separator-woocommerce', $menu_order, true );
-		$woocommerce_sep_top_index = array_search( 'wc-calypso-bridge-separator-top', $menu_order, true );
-
 		// Get the index of our managed pages for integrations.
 		$payments_connect_index    = array_search( 'wc-admin&path=/payments/connect', $menu_order, true );
 		$payments_overview_index   = array_search( 'wc-admin&path=/payments/overview', $menu_order, true );

--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -83,52 +83,17 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 
 				$woocommerce_menu_order[] = 'wc-admin&path=/analytics/overview'; // Analytics.
 				$woocommerce_menu_order[] = 'woocommerce-marketing'; // Marketing.
-				$woocommerce_menu_order[] = 'automatewoo'; // AutomateWoo.
+				if ( false !== $automatewoo_index ) {
+					$woocommerce_menu_order[] = 'automatewoo'; // AutomateWoo.
+				}
 				$woocommerce_menu_order[] = 'woocommerce'; // Extensions.
 				$woocommerce_menu_order[] = 'separator-woocommerce'; // Separator WC.
 				$woocommerce_menu_order[] = $item; // Posts.
 
-				if ( false !== $orders_index ) {
-					unset( $menu_order[ $orders_index ] );
-				}
-				if ( false !== $customers_index ) {
-					unset( $menu_order[ $customers_index ] );
-				}
-				if ( false !== $products_index ) {
-					unset( $menu_order[ $products_index ] );
-				}
-				if ( false !== $analytics_index ) {
-					unset( $menu_order[ $analytics_index ] );
-				}
-				if ( false !== $marketing_index ) {
-					unset( $menu_order[ $marketing_index ] );
-				}
-				if ( false !== $extensions_index ) {
-					unset( $menu_order[ $extensions_index ] );
-				}
-				if ( false !== $woocommerce_sep_index ) {
-					unset( $menu_order[ $woocommerce_sep_index ] );
-				}
-				if ( false !== $woocommerce_sep_top_index ) {
-					unset( $menu_order[ $woocommerce_sep_top_index ] );
-				}
-				if ( false !== $payments_connect_index ) {
-					unset( $menu_order[ $payments_connect_index ] );
-				} elseif ( false !== $payments_overview_index ) {
-					unset( $menu_order[ $payments_overview_index ] );
-				}
-				if ( false !== $automatewoo_index ) {
-					unset( $menu_order[ $automatewoo_index ] );
-				}
-
-
 			// Move "Mailpoet" below the "Jetpack" menu item.
-			} elseif ( 'jetpack' === $item ) {
+			} elseif ( false !== $mailpoet_index && 'jetpack' === $item ) {
 				$woocommerce_menu_order[] = $item; // Jetpack.
 				$woocommerce_menu_order[] = 'mailpoet-newsletters'; // Mailpoet.
-				if ( false !== $mailpoet_index ) {
-					unset( $menu_order[ $mailpoet_index ] );
-				}
 
 			} elseif ( ! in_array( $item, array(
 				'mailpoet-newsletters',

--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -4,7 +4,7 @@
  * Class Ecommerce_Atomic_Admin_Menu.
  *
  * @since   1.9.8
- * @version 1.9.16
+ * @version 1.9.17
  *
  * The admin menu controller for Ecommerce WoA sites.
  */

--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -44,7 +44,6 @@ class WC_Calypso_Bridge_Plugins {
 		'woocommerce-shipment-tracking/woocommerce-shipment-tracking.php',
 		'crowdsignal-forms/crowdsignal-forms.php',
 		'polldaddy/polldaddy.php',
-		'automatewoo/automatewoo.php',
 		'woocommerce-product-recommendations/woocommerce-product-recommendations.php',
 	);
 

--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -44,7 +44,6 @@ class WC_Calypso_Bridge_Plugins {
 		'woocommerce-shipment-tracking/woocommerce-shipment-tracking.php',
 		'crowdsignal-forms/crowdsignal-forms.php',
 		'polldaddy/polldaddy.php',
-		'mailpoet/mailpoet.php',
 		'automatewoo/automatewoo.php',
 		'woocommerce-product-recommendations/woocommerce-product-recommendations.php',
 	);

--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 1.9.17
+ * @version 1.9.18
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/readme.txt
+++ b/readme.txt
@@ -24,7 +24,7 @@ This section describes how to install the plugin and get it working.
 
 = 1.9.18 =
 * Arrange menu order for the menu items of Mailpoet and AutomateWoo #921.
-* Remove Mailpoet Free from the managed plugins #921.
+* Remove Mailpoet Free and AutomateWoo from the managed plugins #921.
 
 = 1.9.17 =
 * Roll Product Recommendations into the Ecommerce Plan #910.

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,10 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 1.9.18 =
+* Arrange menu order for the menu items of Mailpoet and AutomateWoo #921.
+* Remove Mailpoet Free from the managed plugins #921.
+
 = 1.9.17 =
 * Roll Product Recommendations into the Ecommerce Plan #910.
 * Prevent deletion of new round of managed plugins (Product Recommendations, AutomateWoo, MailPoet Free) #912.


### PR DESCRIPTION
### Specification

This PR removes MailPoet from the list of managed plugins and arranges the new Mailpoet and AutomateWoo menu items into the Woo Navigation.