### PR TITLE
add: homescreen free trial banner

### DIFF
--- a/src/homescreen-banner/index.js
+++ b/src/homescreen-banner/index.js
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import { Fill, Card, Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { useSelect, useDispatch } from '@wordpress/data';
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+export const WC_CALYPSO_BRIDGE_HOMESCREEN_BANNER_HIDDEN =
+	'wc_calypso_bridge_homescreen_banner_hidden';
+
+export const CalypsoBridgeHomescreenBanner = () => {
+	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { isModalHidden } = useSelect( ( select ) => {
+		const { getOption, hasFinishedResolution } =
+			select( OPTIONS_STORE_NAME );
+
+		return {
+			isModalHidden:
+				getOption( WC_CALYPSO_BRIDGE_HOMESCREEN_BANNER_HIDDEN ) ===
+					'yes' ||
+				! hasFinishedResolution( 'getOption', [
+					WC_CALYPSO_BRIDGE_HOMESCREEN_BANNER_HIDDEN,
+				] ),
+		};
+	} );
+
+	const dismissModal = () => {
+		updateOptions( {
+			[ WC_CALYPSO_BRIDGE_HOMESCREEN_BANNER_HIDDEN ]: 'yes',
+		} );
+	};
+
+	return (
+		! isModalHidden && (
+			<Fill name="woocommerce_homescreen_experimental_header_banner_item">
+				<Card>
+					<div className="wc-calypso-bridge-woocommerce-admin-homescreen-banner">
+						<p className="wc-calypso-bridge-woocommerce-admin-homescreen-banner__text">
+							{ __(
+								'This is your free trial test store where you can start exploring what\'s available! To find out more about the free trial, click "Learn more".',
+								'wc-calypso-bridge'
+							) }
+						</p>
+						<a
+							href={ `https://wordpress.com/plans/${ window.wcCalypsoBridge.siteSlug }` }
+							className="wc-calypso-bridge-woocommerce-admin-homescreen-banner__learn-more-button components-button is-secondary"
+						>
+							{ __( 'Learn more', 'wc-calypso-bridge' ) }
+						</a>
+						<Button
+							className="wc-calypso-bridge-woocommerce-admin-homescreen-banner__dismiss-button"
+							label={ __(
+								'Dismiss this free trial informational banner.'
+							) }
+							icon={
+								<span className="dashicons dashicons-no-alt"></span>
+							}
+							onClick={ dismissModal }
+						></Button>
+					</div>
+				</Card>
+			</Fill>
+		)
+	);
+};

--- a/src/homescreen-banner/style.scss
+++ b/src/homescreen-banner/style.scss
@@ -1,0 +1,23 @@
+.wc-calypso-bridge-woocommerce-admin-homescreen-banner {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    min-height: 65px;
+}
+
+.wc-calypso-bridge-woocommerce-admin-homescreen-banner__text {
+    margin-left: 20px;
+    margin-right: 64px;
+}
+
+.wc-calypso-bridge-woocommerce-admin-homescreen-banner__learn-more-button {
+    margin-left: auto;
+}
+
+.woocommerce-homescreen__header.woocommerce-homescreen:not(.woocommerce-homescreen-column) {
+    margin-bottom: 32px;
+}
+
+button.wc-calypso-bridge-woocommerce-admin-homescreen-banner__dismiss-button {
+    margin: 16px;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ import { PaymentGatewaySuggestions } from './payment-gateway-suggestions';
 import { Tax } from './free-trial/tax';
 import { TaskListCompletedHeaderFill } from './task-completion/fill.tsx';
 import './index.scss';
+import { CalypsoBridgeHomescreenBanner } from './homescreen-banner';
 
 wcNavFilterRootUrl();
 
@@ -97,10 +98,13 @@ if ( !! window.wcCalypsoBridge.isEcommercePlanTrial ) {
 		),
 	} );
 
+	registerPlugin( 'wc-calypso-bridge-homescreen-slotfill-banner', {
+		render: CalypsoBridgeHomescreenBanner,
+		scope: 'woocommerce-admin',
+	} );
 }
 
 if ( !! window.wcCalypsoBridge.isEcommercePlan ) {
-
 	// Filter wc admin pages.
 	addFilter( 'woocommerce_admin_pages_list', 'wc-calypso-bridge', ( pages ) => {
 


### PR DESCRIPTION
Fixes #927

### Changes
- Added the free trial informational banner in the homescreen header slotfill
- "Learn More" link is populated using ` window.wcCalypsoBridge.siteSlug `, not sure if this is the most appropriate way?
- Dismissal history is stored in options

### Testing Instructions

1. Make sure to copy over the latest changes in [woocmmerce-calypso-bridge-helper.php](https://gist.github.com/moon0326/cac46c70a2cee81b61faef517fef7178) and the plugin is activated.
2. Clone this branch
3. Navigate to the frontend of your local env. Confirm the banner is rendered.
4. Check that "Learn More" button correctly brings you to wordpress.com plan selection
5. Check that dismissal works and is persisted

https://user-images.githubusercontent.com/27843274/216316747-667bf96b-d96c-4627-8b71-ba0e88a72b6a.mp4

