### PR TITLE
WooExpress: Hide the Launch task for sites on eCommerce trial

### DIFF
--- a/includes/tasks/class-wc-calypso-task-launch-site.php
+++ b/includes/tasks/class-wc-calypso-task-launch-site.php
@@ -88,4 +88,15 @@ class LaunchSite extends Task {
 	public function is_complete() {
 		return 'launched' === get_option( 'launch-status' );
 	}
+
+	/**
+	 * Checks if the task is active. The task should not be active
+	 * if the site is on the eCommerce trial.
+	 * 
+	 * @return bool
+	 */
+	public function can_view() {
+		$ecommerce_trial_purchase = wp_list_filter( wpcom_get_site_purchases(), array( 'billing_product_slug' => 'wp-bundle-ecommerce-trial' ) );
+		return empty( $ecommerce_trial_purchase );
+	}
 }

--- a/includes/tasks/class-wc-calypso-task-launch-site.php
+++ b/includes/tasks/class-wc-calypso-task-launch-site.php
@@ -95,7 +95,6 @@ class LaunchSite extends Task {
 	 * @return bool
 	 */
 	public function can_view() {
-		$ecommerce_trial_purchase = wp_list_filter( wpcom_get_site_purchases(), array( 'billing_product_slug' => 'wp-bundle-ecommerce-trial' ) );
-		return empty( $ecommerce_trial_purchase );
+		return ! wc_calypso_bridge_is_ecommerce_trial_plan();
 	}
 }

--- a/includes/tasks/class-wc-calypso-task-launch-site.php
+++ b/includes/tasks/class-wc-calypso-task-launch-site.php
@@ -90,8 +90,7 @@ class LaunchSite extends Task {
 	}
 
 	/**
-	 * Checks if the task is active. The task should not be active
-	 * if the site is on the eCommerce trial.
+	 * The task should not be displayed if the site is on the eCommerce trial.
 	 * 
 	 * @return bool
 	 */


### PR DESCRIPTION
The users on the eCommerce trial should not be allowed to launch the site. This PR hides the Launch task for users on the trial plan.

The back-end changes are being handled here: D100473-code

### Testing Instructions

* Sandbox the public-api.
* Sandbox the store
* Create a site with a business plan
* Use the WoA Developer Blog Manager to convert your site to a WoA dev site.
* Transfer your site to atomic.
* Navigate to `https://wordpress.com/hosting-config/{your-site}`, activate the hosting configurations, and create the ssh access.
* Use the credentials shown to access your site's VM.
* Disable the store in your sandbox so your site can be considered free.
* Navigate to the developer console
* Make a POST request to `WP.COM API v1.1 /sites/:siteSlug/ecommerce-trial/add/ecommerce-trial-bundle-monthly` to add the eCommerce Trial plan to your site.
* Add the changes in `includes/tasks/class-wc-calypso-task-launch-site.php` to your WoA VM -> `/wp-content/mu-plugins/wpcomsh/vendor/automattic/wc-calypso-bridge/includes/tasks/class-wc-calypso-task-launch-site.php` (I manually copied the changes and applied on the VM file)
* Navigate to: https://{YOUR_DOMAIN}/wp-admin/admin.php?page=wc-admin
* You should not see the Launch task anymore

Depends on https://github.com/Automattic/wc-calypso-bridge/pull/926
Related to https://github.com/Automattic/wp-calypso/issues/73015