### PR TITLE
Customize new/edit product form for free trial

### DIFF
--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-product-form-changes.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-product-form-changes.php
@@ -1,0 +1,64 @@
+<?php
+
+class WC_Calypso_Bridge_Free_Trial_Product_Form_Changes {
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var object
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return object Instance.
+	 */
+	final public static function get_instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	public function __construct() {
+		// Remove pinterest tab.
+		add_filter( 'woocommerce_product_data_tabs', [ $this, 'remove_pinterest' ], 99);
+
+		// remove "Sharing" meta box.
+		add_filter( 'sharing_meta_box_show', '__return_false' );
+
+		// Customize Channel visibility meta box.
+		add_action( 'admin_enqueue_scripts', [ $this, 'add_scripts_for_google_listing_ads' ], 10, 10);
+	}
+
+	public function remove_pinterest( $tabs ) {
+		if ( isset( $tabs[ 'pinterest_attributes' ] ) ) {
+			unset( $tabs[ 'pinterest_attributes' ] );
+		}
+		return $tabs;
+	}
+
+	public function add_scripts_for_google_listing_ads( $hook ) {
+	    global $post;
+		if ( $hook === 'post-new.php' || $hook == 'post.php' ) {
+			if ( $post->post_type === 'product' ) {
+				add_action('admin_print_footer_scripts', function() {
+					$status       = new \Automattic\Jetpack\Status();
+					$site_suffix  = $status->get_site_suffix();
+					$signup_link = "https://wordpress.com/plans/" . $site_suffix;
+					$signup_text = __( 'Sign up for a plan', 'wc-calypso-bridge' );
+					$description = __( 'To sync your products directly to Google, manage your product feed, and create Google Ad campaigns, all you need to do is sign up for a plan.', 'wc-calypso-bridge' );
+					?>
+						<script>
+                            jQuery('.gla-channel-visibility-box a').text('<?=$signup_text?>').attr('href', '<?=$signup_link?>');
+                            jQuery(jQuery('.gla-channel-visibility-box p')[1]).text('<?=$description?>');
+						</script>
+					<?php
+				});
+			}
+		}
+	}
+}
+
+WC_Calypso_Bridge_Free_Trial_Product_Form_Changes::get_instance();

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -127,4 +127,5 @@ require_once dirname( __FILE__ ) . '/includes/class-wc-calypso-bridge-woocommerc
  */
 if ( ! wc_calypso_bridge_can_install_plugins() ) {
 	require_once dirname(__FILE__) . '/class-wc-calypso-bridge-frontend-free-trial.php';
+	require_once dirname(__FILE__) . '/includes/free-trial/class-wc-calypso-bridge-free-trial-product-form-changes.php';
 }


### PR DESCRIPTION
Closes #934 

### Changes in this PR

- Remove pinterest tab
- Hide sharing meta box from Jetpack
- Customize Channel visibility meta box from google listing ads plugin

### Test instructions

*Checkout this branch only after step 8, please.*

1. Make sure to copy over the latest changes in [woocmmerce-calypso-bridge-helper.php](https://gist.github.com/moon0326/cac46c70a2cee81b61faef517fef7178) and the plugin is activated.
4. Change [this line](https://gist.github.com/moon0326/cac46c70a2cee81b61faef517fef7178#file-a-woocommerce-calypso-bridge-helper-php-L33) to false in your local env. This forces your env to have free trial.
5. Install Pinterest, Jetpack, and Google Listing ads plugins.
6. Navigate to `http://your-dev-url/wp-admin/admin.php?page=jetpack_modules` and activate `Sharing`.
7. Navigate to `Products -> Add New`
8. Confirm you have `Pinterest` attribute tab, Sharing and Channel visibility meta boxes.
9. Checkout this branch.
10. Navigate back to `Products -> Add New`
11. Confirm `Pinterest` tab and Sharing meta box are hidden.
12. Confirm `Channel visibility` copy changes.
13. Confirm `Channel visibility` button URL.


