### PR TITLE
Free trial: Override orders empty state screen CTA button class

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -119,6 +119,7 @@ class WC_Calypso_Bridge {
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-hide-alerts.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-plugins.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-addons.php';
+		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-changes.php';
 	}
 
 	/**

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-changes.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-changes.php
@@ -31,16 +31,20 @@ class WC_Calypso_Bridge_Free_Trial_Orders_Changes {
 	}
 
 	public function override_empty_state_cta_button_class() {
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return;
+		}
+
 		$screen = get_current_screen();
 	
 		if ( $screen->id === 'edit-shop_order' ) {
-				?>
-				<script>
-					jQuery('.woocommerce-BlankState-cta.button')
-						.addClass('button-secondary')
-						.removeClass('button-primary');
-				</script>
-				<?php
+			?>
+			<script>
+				jQuery('.woocommerce-BlankState-cta.button')
+					.addClass('button-secondary')
+					.removeClass('button-primary');
+			</script>
+			<?php
 		}
 	}
 }

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-changes.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-changes.php
@@ -2,6 +2,9 @@
 /**
  * Contains the logic for override WooCommerce > orders screen
  *
+ * @package WC_Calypso_Bridge/Classes
+ * @since   2.0.1
+ * @version 2.0.1
  */
 
 class WC_Calypso_Bridge_Free_Trial_Orders_Changes {
@@ -43,7 +46,7 @@ class WC_Calypso_Bridge_Free_Trial_Orders_Changes {
 		}
 
 		$screen = get_current_screen();
-	
+
 		if ( $screen->id === 'edit-shop_order' ) {
 			?>
 			<script>

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-changes.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-changes.php
@@ -30,6 +30,10 @@ class WC_Calypso_Bridge_Free_Trial_Orders_Changes {
 		add_action('admin_print_footer_scripts', array($this, 'override_empty_state_cta_button_class') );
 	}
 
+	/**
+	 * Change the class of the button on the empty state of the orders screen.
+	 *
+	 */
 	public function override_empty_state_cta_button_class() {
 		if ( ! function_exists( 'get_current_screen' ) ) {
 			return;

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-changes.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-changes.php
@@ -4,7 +4,6 @@
  *
  */
 
-
 class WC_Calypso_Bridge_Free_Trial_Orders_Changes {
 	/**
 	 * The single instance of the class.

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-changes.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-changes.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Contains the logic for override WooCommerce > orders screen
+ *
+ */
+
+
+class WC_Calypso_Bridge_Free_Trial_Orders_Changes {
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var object
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return object Instance.
+	 */
+	final public static function get_instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	public function __construct() {
+		add_action('admin_print_footer_scripts', array($this, 'override_empty_state_cta_button_class') );
+	}
+
+	public function override_empty_state_cta_button_class() {
+		$screen = get_current_screen();
+	
+		if ( $screen->id === 'edit-shop_order' ) {
+				?>
+				<script>
+					jQuery('.woocommerce-BlankState-cta.button')
+						.addClass('button-secondary')
+						.removeClass('button-primary');
+				</script>
+				<?php
+		}
+	}
+}
+
+WC_Calypso_Bridge_Free_Trial_Orders_Changes::get_instance();

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-changes.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-changes.php
@@ -27,6 +27,10 @@ class WC_Calypso_Bridge_Free_Trial_Orders_Changes {
 	}
 
 	public function __construct() {
+		if ( ! wc_calypso_bridge_is_ecommerce_trial_plan() ) {
+			return;
+		}
+
 		add_action('admin_print_footer_scripts', array($this, 'override_empty_state_cta_button_class') );
 	}
 

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-changes.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-changes.php
@@ -47,9 +47,9 @@ class WC_Calypso_Bridge_Free_Trial_Orders_Changes {
 		if ( $screen->id === 'edit-shop_order' ) {
 			?>
 			<script>
-				jQuery('.woocommerce-BlankState-cta.button')
-					.addClass('button-secondary')
-					.removeClass('button-primary');
+				const woocommerceBlankStateButton = document.querySelector('.woocommerce-BlankState-cta.button');
+				woocommerceBlankStateButton.classList.add('button-secondary');
+				woocommerceBlankStateButton.classList.remove('button-primary');
 			</script>
 			<?php
 		}


### PR DESCRIPTION
Fixes #935 

### Changes in this PR

In orders empty state screen, change the button's class from button-primary to button-secondary

### Test instructions

1. Make sure to copy over the latest changes in [woocmmerce-calypso-bridge-helper.php](https://gist.github.com/moon0326/cac46c70a2cee81b61faef517fef7178) and the plugin is activated.
2. Change [this line](https://gist.github.com/moon0326/cac46c70a2cee81b61faef517fef7178#file-a-woocommerce-calypso-bridge-helper-php-L33) to false in your local env. This forces your env to have free trial.
3. Navigate to WooCommerce > Orders
4. Confirm CTA button class is `button-secondary`.

Before:

![Screenshot 2023-02-15 at 12 34 30](https://user-images.githubusercontent.com/4344253/218931521-12919117-a69f-44a9-8437-4e8b60417bb5.png)


After:

https://user-images.githubusercontent.com/4344253/218931061-e536e979-a21b-45e6-ae95-1304e9c7981c.mov

