### PR TITLE
Prepare to release 2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v1.9.18",
+  "version": "v2.0.0",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 2.0.0 =
+* Refactor and introduce plan detection controller #926.
+
 = 1.9.18 =
 * Arrange menu order for the menu items of Mailpoet and AutomateWoo #921.
 * Remove Mailpoet Free and AutomateWoo from the managed plugins #921.


### PR DESCRIPTION
This PR bumps the version to 2.0.0 to release

- https://github.com/Automattic/wc-calypso-bridge/pull/926

```
= 2.0.0 =
* Refactor and introduce plan detection controller #926.
```