### PR TITLE
Fix conflict between woocommerce navigation and nav unification

### DIFF
--- a/assets/css/nav-unification.css
+++ b/assets/css/nav-unification.css
@@ -32,6 +32,10 @@
 		width: calc( 100% - 272px );
 	}
 
+	.jetpack-connected.is-nav-unification.has-woocommerce-navigation .woocommerce-layout__header {
+		width: 100%;
+	}
+
 	body.jetpack-connected.folded .woocommerce-layout__header {
 		width: calc( 100% - 36px );
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleased =
+* Fix conflict between woocommerce navigation and nav unification #952.
+
 = 2.0.0 =
 * Refactor and introduce plan detection controller #926.
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/65522

This PR adds a CSS that fixes empty column when WooCommerce navigation is enabled.

### Testing instructions

- In an ecom or business plan site, go to `wp-admin/options` and set `woocommerce_navigation_enabled` to `yes`
- Go to WooCommerce > Home
- Set browser size to at least 1024px
- Observe there's no empty column on the right hand side

<img width="1720" alt="image" src="https://user-images.githubusercontent.com/3747241/219256708-359f11f3-5edc-40b0-b1c9-19973eadc7db.png">
