### PR TITLE
Prevent deletion of managed plugins (AutomateWoo - Fedex Shipping)

### DIFF
--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 2.0.0
+ * @version 2.0.2
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -45,6 +45,8 @@ class WC_Calypso_Bridge_Plugins {
 		'crowdsignal-forms/crowdsignal-forms.php',
 		'polldaddy/polldaddy.php',
 		'woocommerce-product-recommendations/woocommerce-product-recommendations.php',
+		'automatewoo/automatewoo.php',
+		'woocommerce-shipping-fedex/woocommerce-shipping-fedex.php',
 	);
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 2.0.2 =
+* Prevent deletion of managed plugins (AutomateWoo, FedEx Shipping) #xxx.
+
 = 2.0.1 =
 * Make plugin_asset_path a static prop #959.
 * Fix conflict between woocommerce navigation and nav unification #952.


### PR DESCRIPTION
We'll be introducing a new round of extensions in WPCOM, we need to prevent them from being deleted

- peapX7-1K1-p2
- AutomateWoo
- FedEx Shipping

closed #968 
