### PR TITLE
Prevent double footer when using Storefront in Ecommerce plan

### DIFF
--- a/includes/class-wc-calypso-bridge-themes-setup.php
+++ b/includes/class-wc-calypso-bridge-themes-setup.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 2.0.0
+ * @version 2.0.2
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -41,8 +41,7 @@ class WC_Calypso_Bridge_Themes_Setup {
 			return;
 		}
 
-		remove_action( 'storefront_footer', 'storefront_credit', 20 );
-		add_action( 'storefront_footer', array( $this, 'wpcom_ecommerce_plan_storefront_credit' ), 20 );
+		add_action( 'init', array( $this, 'setup_storefront' ) );
 
 		if ( ! is_admin() && ! defined( 'DOING_CRON' ) ) {
 			return;
@@ -50,6 +49,18 @@ class WC_Calypso_Bridge_Themes_Setup {
 
 		add_action( 'init', array( $this, 'set_theme_default_values' ) );
 		add_action( 'customize_save_after', array( $this, 'mark_import_as_completed' ) );
+	}
+
+	/**
+	 * Setup Storefront theme for dotCom.
+	 *
+	 * @since 2.0.2
+	 *
+	 * @return void
+	 */
+	public function setup_storefront() {
+		remove_action( 'storefront_footer', 'storefront_credit', 20 );
+		add_action( 'storefront_footer', array( $this, 'wpcom_ecommerce_plan_storefront_credit' ), 20 );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 2.0.2 =
+* Prevented a double footer issue when using Storefront in Ecommerce plan #970.
+
 = 2.0.1 =
 * Make plugin_asset_path a static prop #959.
 * Fix conflict between woocommerce navigation and nav unification #952.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes a timing issue that was introduced in #926 and produced a double footer in the storefront theme.

Closes https://github.com/woocommerce/storefront/issues/2091

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Activate the _Storefront_ theme in an Ecommerce site.
2. View a front-end page and notice the double footer.
3. Apply this fix, and ensure that you are only showing one footer that links to wordpress.com

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
