### PR TITLE
Prepare to release 2.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v2.0.1",
+  "version": "v2.0.2",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 2.0.1
+Stable tag: 2.0.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,7 +23,7 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 = 2.0.2 =
-* Prevent deletion of managed plugins (AutomateWoo, FedEx Shipping) #xxx.
+* Prevent deletion of managed plugins (AutomateWoo, FedEx Shipping) #969.
 * Prevent a double footer issue when using Storefront in Ecommerce plan #970.
 
 = 2.0.1 =

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 2.0.1
+ * Version: 2.0.2
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -47,7 +47,7 @@ if ( ! defined( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH' ) ) {
 	define( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH', dirname( __FILE__ ) );
 }
 if ( ! defined( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION' ) ) {
-	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.0.1' );
+	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.0.2' );
 }
 if ( ! defined( 'WC_MIN_VERSION' ) ) {
 	define( 'WC_MIN_VERSION', '7.3' );


### PR DESCRIPTION
This PR bumps the version to 2.0.2 to release

- https://github.com/Automattic/wc-calypso-bridge/pull/970
- https://github.com/Automattic/wc-calypso-bridge/pull/969

```
= 2.0.2 =
* Prevent deletion of managed plugins (AutomateWoo, FedEx Shipping) #969.
* Prevent a double footer issue when using Storefront in Ecommerce plan #970.
```