### PR TITLE
Remove absolute path prefix from My Home and Customer menu URLs

### DIFF
--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -111,7 +111,7 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 	 * Adds My Home menu.
 	 */
 	public function add_my_home_menu() {
-		$this->update_menu( 'index.php', '/admin.php?page=wc-admin', __( 'My Home', 'jetpack' ), 'edit_posts', 'dashicons-admin-home' );
+		$this->update_menu( 'index.php', 'admin.php?page=wc-admin', __( 'My Home', 'jetpack' ), 'edit_posts', 'dashicons-admin-home' );
 	}
 
 	/**
@@ -206,7 +206,7 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 		if ( class_exists( '\Automattic\WooCommerce\Admin\Features\Features' ) && \Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'analytics' ) ) {
 			// Move Customers to root menu.
 			$this->hide_submenu_page( 'woocommerce', 'wc-admin&path=/customers' );
-			add_menu_page( __( 'Customers', 'woocommerce' ), __( 'Customers', 'woocommerce' ), 'manage_woocommerce', '/admin.php?page=wc-admin&path=/customers', null, 'dashicons-money', 100 );
+			add_menu_page( __( 'Customers', 'woocommerce' ), __( 'Customers', 'woocommerce' ), 'manage_woocommerce', 'admin.php?page=wc-admin&path=/customers', null, 'dashicons-money', 100 );
 		}
 
 		// Update WooCommerce to Extensions


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR modifies the _My Home_ and _Customers_ menu items to use URLs without a leading `/`, and to simply use `admin.php`. This should fix some situations where the _My Home_ menu item was incorrectly directing users to `/admin.php?page=wc-admin` instead of `/wp-admin/admin.php?page=wc-admin`.

Fixes Automattic/wp-calypso#73537

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Add the updated code from this patch to a free eCommerce trial site where the filesystem is writable
   - Refer to these instructions for setting up such a site: peapX7-1D4-p2
   - For upload purposes, you'd need to update the modified file (`includes/class-wc-calypso-bridge-ecommerce-admin-menu.php`) in the following directory on the server: `~/htdocs/wp-content/mu-plugins/wpcomsh/vendor/automattic/wc-calypso-bridge/includes/`
3. With that in place, navigate to `/wp-admin/admin.php?page=wc-admin` on the site.
4. Use the left nav to navigate to _Extensions_ -> _Manage_
5. Mouse over the _My Home_ item in the left nav -- confirm that the URL has the full path to `/wp-admin/admin.php?page=wc-admin`

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.