### PR TITLE
Release 2.0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v2.0.2",
+  "version": "v2.0.3",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 2.0.2
+Stable tag: 2.0.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ This section describes how to install the plugin and get it working.
 1. Activate the plugin through the 'Plugins' screen in WordPress
 
 == Changelog ==
+
+= 2.0.3 =
+* Hides the Launch task for WooExpress sites.
 
 = 2.0.2 =
 * Prevent deletion of managed plugins (AutomateWoo, FedEx Shipping) #969.

--- a/readme.txt
+++ b/readme.txt
@@ -23,8 +23,21 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 = 2.0.3 =
+* Bring Add a domain task back for free trial #985
 * Hides the Launch task for WooExpress sites.
 * Remove absolute path prefix from My Home and Customer menu URLs
+* Fix woocommerce payments task #980.
+* Fix incorrect SVG size #978.
+* WC Payments customizations #977.
+* Replace tax task to remove Avalara #975.
+* Replace product task with custom completion logic #963.
+* Customize payment tasklist header #956.
+* Hide partial tasklist and tasks #951.
+* Override orders empty state screen CTA button class #948.
+* Add disabled tasks accordion component #940.
+* Add task completion task #939.
+* Add homescreen banner #933.
+* Add payment task #919.
 
 = 2.0.2 =
 * Prevent deletion of managed plugins (AutomateWoo, FedEx Shipping) #969.

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,8 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 = 2.0.3 =
-* Bring Add a domain task back for free trial #985
+* Override the wc.experimental.useSlot hook #986.
+* Bring Add a domain task back for free trial #985.
 * Hides the Launch task for WooExpress sites.
 * Remove absolute path prefix from My Home and Customer menu URLs
 * Fix woocommerce payments task #980.

--- a/readme.txt
+++ b/readme.txt
@@ -25,8 +25,8 @@ This section describes how to install the plugin and get it working.
 = 2.0.3 =
 * Override the wc.experimental.useSlot hook #986.
 * Bring Add a domain task back for free trial #985.
-* Hides the Launch task for WooExpress sites.
-* Remove absolute path prefix from My Home and Customer menu URLs
+* Hides the Launch task for WooExpress sites #937.
+* Remove absolute path prefix from My Home and Customer menu URLs #974.
 * Fix woocommerce payments task #980.
 * Fix incorrect SVG size #978.
 * WC Payments customizations #977.

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,7 @@ This section describes how to install the plugin and get it working.
 
 = 2.0.3 =
 * Hides the Launch task for WooExpress sites.
+* Remove absolute path prefix from My Home and Customer menu URLs
 
 = 2.0.2 =
 * Prevent deletion of managed plugins (AutomateWoo, FedEx Shipping) #969.

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 2.0.2
+ * Version: 2.0.3
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -47,7 +47,7 @@ if ( ! defined( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH' ) ) {
 	define( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH', dirname( __FILE__ ) );
 }
 if ( ! defined( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION' ) ) {
-	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.0.2' );
+	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.0.3' );
 }
 if ( ! defined( 'WC_MIN_VERSION' ) ) {
 	define( 'WC_MIN_VERSION', '7.3' );


### PR DESCRIPTION
Version bump and changelog entries for releasing 2.0.3.
This release includes the following PRs:
* https://github.com/Automattic/wc-calypso-bridge/pull/986
* https://github.com/Automattic/wc-calypso-bridge/pull/985
* https://github.com/Automattic/wc-calypso-bridge/pull/980
* https://github.com/Automattic/wc-calypso-bridge/pull/978
* https://github.com/Automattic/wc-calypso-bridge/pull/977
* https://github.com/Automattic/wc-calypso-bridge/pull/975
* https://github.com/Automattic/wc-calypso-bridge/pull/974
* https://github.com/Automattic/wc-calypso-bridge/pull/963
* https://github.com/Automattic/wc-calypso-bridge/pull/956
* https://github.com/Automattic/wc-calypso-bridge/pull/951
* https://github.com/Automattic/wc-calypso-bridge/pull/948
* https://github.com/Automattic/wc-calypso-bridge/pull/940
* https://github.com/Automattic/wc-calypso-bridge/pull/939
* https://github.com/Automattic/wc-calypso-bridge/pull/937
* https://github.com/Automattic/wc-calypso-bridge/pull/933
* https://github.com/Automattic/wc-calypso-bridge/pull/919