### PR TITLE
Free trial: WC Payments customizations

### DIFF
--- a/assets/css/free-trial-admin.css
+++ b/assets/css/free-trial-admin.css
@@ -1,0 +1,13 @@
+.wc-calypso-notice {
+	background: #fff;
+	border: 1px solid #c3c4c7;
+	border-left-width: 4px;
+	box-shadow: 0 1px 1px rgb( 0 0 0 / 4% );
+	border-left-color: var( --wp-admin-theme-color );
+	padding: 12px 16px;
+	margin: 0 0 24px 0;
+}
+
+.wc-calypso-notice a {
+	color: inherit;
+}

--- a/assets/scripts/free-trial-wc-payments.js
+++ b/assets/scripts/free-trial-wc-payments.js
@@ -1,0 +1,2 @@
+(function($) {
+})(jQuery);

--- a/assets/scripts/free-trial-wc-payments.js
+++ b/assets/scripts/free-trial-wc-payments.js
@@ -25,12 +25,23 @@
 		} );
 	};
 
-	const getNotice = () => {
-		const upgradeNoticeText = wp.i18n.sprintf(
-			__(
-				"During the trial period you can only make test payments. To process real transactions, <a href='%s'>upgrade now.</a>",
+	const getNotice = ( copySelector ) => {
+		const defaultCopy = __(
+			"During the trial period you can only make test payments. To process real transactions, <a href='%s'>upgrade now.</a>",
+			'wc-calypso-bridge'
+		);
+
+		const copies = {
+			default: defaultCopy,
+			transactions: defaultCopy,
+			deposits: __(
+				"During the trial period you’ll not be able to get deposits. To receive payments and payouts, <a href='%s'>upgrade now.</a>",
 				'wc-calypso-bridge'
 			),
+		};
+
+		const upgradeNoticeText = wp.i18n.sprintf(
+			copies[ copySelector ],
 			'https://wordpress.com/plans/' + window.wcCalypsoBridge.siteSlug
 		);
 
@@ -43,26 +54,34 @@
 
 	const customizeConnectPage = () => {
 		waitForElm( '.connect-account' ).then( function ( element ) {
-			element.prepend( getNotice() );
-			window.test = element;
+			element.prepend( getNotice( 'default' ) );
+			const h2s = element.querySelectorAll( 'h2' );
+			if ( h2s.lengths === 2 ) {
+				h2s[ 1 ].innerText = __(
+					'You’re only steps away from getting ready to be paid',
+					'wc-calypso-bridge'
+				);
+			}
 
-			element.querySelectorAll( 'h2' )[ 1 ].innerText = __(
-				'You’re only steps away from getting ready to be paid',
-				'wc-calypso-bridge'
+			const stepItems = element.querySelectorAll(
+				'.connect-page-onboarding-steps-item'
 			);
 
-			element
-				.querySelectorAll( '.connect-page-onboarding-steps-item' )[ 2 ]
-				.querySelector( 'p' ).innerText = __(
-				'You’re ready to start testing the features and benefits of WooCommerce Payments',
-				'wc-calypso-bridge'
-			);
+			if ( stepItems.length === 3 ) {
+				const p = stepItems.querySelector( 'p' );
+				if ( p ) {
+					p.innerText = __(
+						'You’re ready to start testing the features and benefits of WooCommerce Payments',
+						'wc-calypso-bridge'
+					);
+				}
+			}
 		} );
 	};
 
-	const addNotice = ( selector ) => {
+	const addNotice = ( selector, notice ) => {
 		waitForElm( selector ).then( function ( element ) {
-			element.prepend( getNotice() );
+			element.prepend( notice );
 		} );
 	};
 
@@ -72,11 +91,19 @@
 				customizeConnectPage();
 				break;
 			case '/payments/overview':
-				addNotice( '.wcpay-overview' );
+				addNotice( '.wcpay-overview', getNotice( 'default' ) );
 				break;
 			case '/payments/transactions':
+				addNotice(
+					'.woocommerce-payments-page',
+					getNotice( 'transactions' )
+				);
+				break;
 			case '/payments/deposits':
-				addNotice( '.woocommerce-payments-page' );
+				addNotice(
+					'.woocommerce-payments-page',
+					getNotice( 'deposits' )
+				);
 				break;
 		}
 	};

--- a/assets/scripts/free-trial-wc-payments.js
+++ b/assets/scripts/free-trial-wc-payments.js
@@ -1,4 +1,4 @@
-( function ( $ ) {
+( function () {
 	const __ = wp.i18n.__;
 	/**
 	 * Wait for an element.
@@ -34,41 +34,35 @@
 			'https://wordpress.com/plans/' + window.wcCalypsoBridge.siteSlug
 		);
 
-		const upgradeNotice = $(
-			"<div class='wc-calypso-notice'>" + upgradeNoticeText + '</div>'
-		);
+		const upgradeNotice = document.createElement( 'div' );
+		upgradeNotice.className = 'wc-calypso-notice';
+		upgradeNotice.innerHTML = upgradeNoticeText;
+
 		return upgradeNotice;
 	};
 
 	const customizeConnectPage = () => {
 		waitForElm( '.connect-account' ).then( function ( element ) {
-			var connectAccount = $( element );
-			connectAccount.prepend( getNotice() );
-			connectAccount
-				.find( 'h2' )
-				.last()
-				.text(
-					__(
-						'You’re only steps away from getting ready to be paid',
-						'wc-calypso-bridge'
-					)
-				);
-			connectAccount
-				.find( '.connect-page-onboarding-steps-item' )
-				.last()
-				.find( 'p' )
-				.text(
-					__(
-						'You’re ready to start testing the features and benefits of WooCommerce Payments',
-						'wc-calypso-bridge'
-					)
-				);
+			element.prepend( getNotice() );
+			window.test = element;
+
+			element.querySelectorAll( 'h2' )[ 1 ].innerText = __(
+				'You’re only steps away from getting ready to be paid',
+				'wc-calypso-bridge'
+			);
+
+			element
+				.querySelectorAll( '.connect-page-onboarding-steps-item' )[ 2 ]
+				.querySelector( 'p' ).innerText = __(
+				'You’re ready to start testing the features and benefits of WooCommerce Payments',
+				'wc-calypso-bridge'
+			);
 		} );
 	};
 
 	const addNotice = ( selector ) => {
 		waitForElm( selector ).then( function ( element ) {
-			$( element ).prepend( getNotice() );
+			element.prepend( getNotice() );
 		} );
 	};
 
@@ -105,4 +99,4 @@
 	);
 
 	detectPageAndRunCustomization();
-} )( jQuery );
+} )();

--- a/assets/scripts/free-trial-wc-payments.js
+++ b/assets/scripts/free-trial-wc-payments.js
@@ -82,7 +82,7 @@
 	};
 
 	/**
-	 * Detect when page changes via React Router and run one of the customziations again.
+	 * Detect when page changes via React Router and run one of the customizations again.
 	 */
 	let url = location.href;
 	document.body.addEventListener(

--- a/assets/scripts/free-trial-wc-payments.js
+++ b/assets/scripts/free-trial-wc-payments.js
@@ -1,2 +1,108 @@
-(function($) {
-})(jQuery);
+( function ( $ ) {
+	const __ = wp.i18n.__;
+	/**
+	 * Wait for an element.
+	 * This is required as there's no official way of waiting for an React component to finish.
+	 *
+	 * Source: https://stackoverflow.com/questions/5525071/how-to-wait-until-an-element-exists
+	 */
+	const waitForElm = ( selector ) => {
+		return new Promise( ( resolve ) => {
+			if ( document.querySelector( selector ) ) {
+				return resolve( document.querySelector( selector ) );
+			}
+			const observer = new MutationObserver( ( mutations ) => {
+				if ( document.querySelector( selector ) ) {
+					resolve( document.querySelector( selector ) );
+					observer.disconnect();
+				}
+			} );
+
+			observer.observe( document.body, {
+				childList: true,
+				subtree: true,
+			} );
+		} );
+	};
+
+	const getNotice = () => {
+		const upgradeNoticeText = wp.i18n.sprintf(
+			__(
+				"During the trial period you can only make test payments. To process real transactions, <a href='%s'>upgrade now.</a>",
+				'wc-calypso-bridge'
+			),
+			'https://wordpress.com/plans/' + window.wcCalypsoBridge.siteSlug
+		);
+
+		const upgradeNotice = $(
+			"<div class='wc-calypso-notice'>" + upgradeNoticeText + '</div>'
+		);
+		return upgradeNotice;
+	};
+
+	const customizeConnectPage = () => {
+		waitForElm( '.connect-account' ).then( function ( element ) {
+			var connectAccount = $( element );
+			connectAccount.prepend( getNotice() );
+			connectAccount
+				.find( 'h2' )
+				.last()
+				.text(
+					__(
+						'You’re only steps away from getting ready to be paid',
+						'wc-calypso-bridge'
+					)
+				);
+			connectAccount
+				.find( '.connect-page-onboarding-steps-item' )
+				.last()
+				.find( 'p' )
+				.text(
+					__(
+						'You’re ready to start testing the features and benefits of WooCommerce Payments',
+						'wc-calypso-bridge'
+					)
+				);
+		} );
+	};
+
+	const addNotice = ( selector ) => {
+		waitForElm( selector ).then( function ( element ) {
+			$( element ).prepend( getNotice() );
+		} );
+	};
+
+	const detectPageAndRunCustomization = () => {
+		switch ( new URLSearchParams( window.location.search ).get( 'path' ) ) {
+			case '/payments/connect':
+				customizeConnectPage();
+				break;
+			case '/payments/overview':
+				addNotice( '.wcpay-overview' );
+				break;
+			case '/payments/transactions':
+			case '/payments/deposits':
+				addNotice( '.woocommerce-payments-page' );
+				break;
+		}
+	};
+
+	/**
+	 * Detect when page changes via React Router and run one of the customziations again.
+	 */
+	let url = location.href;
+	document.body.addEventListener(
+		'click',
+		() => {
+			requestAnimationFrame( () => {
+				if ( url !== location.href ) {
+					url = location.href;
+					detectPageAndRunCustomization();
+				}
+			} );
+		},
+		true
+	);
+
+	detectPageAndRunCustomization();
+} )( jQuery );

--- a/class-wc-calypso-bridge-shared.php
+++ b/class-wc-calypso-bridge-shared.php
@@ -60,6 +60,13 @@ class WC_Calypso_Bridge_Shared {
 		if ( wc_calypso_bridge_has_ecommerce_features() ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'add_ecommerce_plan_styles' ) );
 		}
+
+		/**
+		 * Load Ecommerce trial styles.
+		 */
+		if ( wc_calypso_bridge_is_ecommerce_trial_plan() ) {
+			add_action( 'admin_enqueue_scripts', array( $this, 'add_ecommerce_trial_plan_styles' ) );
+		}
 	}
 
 	/**
@@ -145,6 +152,13 @@ class WC_Calypso_Bridge_Shared {
 			wp_enqueue_style( 'wp-calypso-bridge-ecommerce-navigation', WC_Calypso_Bridge_Instance()->get_asset_path() . 'assets/css/ecommerce-navigation.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
 		}
 	}
+
+	/**
+	 * Add styles for ecommerce plan trial.
+	 */
+	public function add_ecommerce_trial_plan_styles() {
+		wp_enqueue_style( 'wp-calypso-bridge-ecommerce-trial', WC_Calypso_Bridge_Instance()->get_asset_path() . 'assets/css/free-trial-admin.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
+	}	
 }
 
 WC_Calypso_Bridge_Shared::instance();

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -120,6 +120,7 @@ class WC_Calypso_Bridge {
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-plugins.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-addons.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-changes.php';
+		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/free-trial/class-wc-calypso-bridge-free-trial-wc-payments.php';
 	}
 
 	/**

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-wc-payments.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-wc-payments.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Class WC_Calypso_Bridge_Free_Trial_WC_Payments.
+ *
+ * @since   1.9.16
+ * @version 1.9.16
+ *
+ * Includes JS on the WC Payments page to customize the look.
+ */
+class WC_Calypso_Bridge_Free_Trial_WC_Payments  {
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var object
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return object Instance.
+	 */
+	final public static function get_instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	public function __construct(){
+		if ( ! wc_calypso_bridge_is_ecommerce_trial_plan() ) {
+			return;
+		}
+
+		if ( ! class_exists( 'Automattic\WooCommerce\Admin\PageController' ) ) {
+			return;
+		}
+
+		add_action('current_screen', function() {
+			$current_page = \Automattic\WooCommerce\Admin\PageController::get_instance()->get_current_page();
+			if ( isset( $current_page['id'] ) && $current_page['id'] === 'wc-payments' ) {
+				add_action('admin_enqueue_scripts', function() {
+					wp_enqueue_script( 'wp-calypso-bridge-free-trial-wc-payments', WC_Calypso_Bridge_Instance()->get_asset_path() . 'assets/scripts/free-trial-wc-payments.js', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
+				});
+			}
+		});
+
+	}
+}
+
+WC_Calypso_Bridge_Free_Trial_WC_Payments::get_instance();

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-wc-payments.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-wc-payments.php
@@ -42,7 +42,7 @@ class WC_Calypso_Bridge_Free_Trial_WC_Payments  {
 			$current_page = \Automattic\WooCommerce\Admin\PageController::get_instance()->get_current_page();
 			if ( isset( $current_page['id'] ) && $current_page['id'] === 'wc-payments' ) {
 				add_action('admin_enqueue_scripts', function() {
-					wp_enqueue_script( 'wp-calypso-bridge-free-trial-wc-payments', WC_Calypso_Bridge_Instance()->get_asset_path() . 'assets/scripts/free-trial-wc-payments.js', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
+					wp_enqueue_script( 'wp-calypso-bridge-free-trial-wc-payments', WC_Calypso_Bridge_Instance()->get_asset_path() . 'assets/scripts/free-trial-wc-payments.js', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION, true );
 				});
 			}
 		});

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-wc-payments.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-wc-payments.php
@@ -3,8 +3,8 @@
 /**
  * Class WC_Calypso_Bridge_Free_Trial_WC_Payments.
  *
- * @since   1.9.16
- * @version 1.9.16
+ * @since   2.0.2
+ * @version 2.0.2
  *
  * Includes JS on the WC Payments page to customize the look.
  */

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-wc-payments.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-wc-payments.php
@@ -40,7 +40,7 @@ class WC_Calypso_Bridge_Free_Trial_WC_Payments  {
 
 		add_action('current_screen', function() {
 			$current_page = \Automattic\WooCommerce\Admin\PageController::get_instance()->get_current_page();
-			if ( isset( $current_page['id'] ) && $current_page['id'] === 'wc-payments' ) {
+			if ( isset( $current_page['id'] ) && strpos($current_page['id'], 'wc-payments') === 0 ) {
 				add_action('admin_enqueue_scripts', function() {
 					wp_enqueue_script( 'wp-calypso-bridge-free-trial-wc-payments', WC_Calypso_Bridge_Instance()->get_asset_path() . 'assets/scripts/free-trial-wc-payments.js', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION, true );
 				});


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #943 

This PR uses vanilla JS to customize WC Payments pages.

### How to test the changes in this Pull Request:

For both test cases, make sure you're in trial plan.

**Testing connect page**

1. Start with a fresh install.
2. Install WooCommerce Payments
3. Click WooCommerce Payments menu.
4. You should see a notice and copy changes described on https://github.com/Automattic/wc-calypso-bridge/issues/943

**Testing notice on overview, transactions, and deposits pages**
1. cd to `/wp-content/plugins/woocommerce-payments` and open `includes/admin/class-wc-payments-admin.php`
2. return `false` from `maybe_redirect_to_onboarding` method.
3. Set `$should_render_full_menu` variable to true in `add_payments_menu` method.
4. Refresh your admin page and you should see the full menu under WooCommerce Payment menu.
5. Click overview, transactions, and deposits pages.
6. Confirm the notice.


<!-- End testing instructions -->

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
