### PR TITLE
Fix woocommerce payments task

### DIFF
--- a/src/free-trial/fills/index.ts
+++ b/src/free-trial/fills/index.ts
@@ -1,2 +1,3 @@
 export * from './task-headers/payments';
 export * from './task-headers/woocommerce-payments';
+export * from './woocommerce-payments';

--- a/src/free-trial/fills/woocommerce-payments.js
+++ b/src/free-trial/fills/woocommerce-payments.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import React, { useEffect } from 'react';
+import { WooOnboardingTask } from '@woocommerce/onboarding';
+import { useDispatch } from '@wordpress/data';
+import { Spinner } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import { connectWcpay } from '../../payment-gateway-suggestions/components/WCPay/utils';
+
+const ReadyWcPay = () => {
+	const { createNotice } = useDispatch( 'core/notices' );
+
+	useEffect( () => {
+		// Attempt to connect. Catch is not provided since notice is handled in the util.
+		connectWcpay( createNotice, () => {} );
+	}, [ createNotice ] );
+
+	return (
+		<div
+			style={ {
+				height: '70vh',
+				display: 'flex',
+				flexDirection: 'column',
+				justifyContent: 'center',
+				alignItems: 'center',
+			} }
+		>
+			<Spinner />
+			<div style={ { marginTop: '1rem' } }>
+				Preparing payment settings...
+			</div>
+		</div>
+	);
+};
+
+// shows up at http://host/wp-admin/admin.php?page=wc-admin&task=woocommerce-payments which is the default url for woocommerce-payments task
+export const WoocommercePaymentsTaskPage = () => (
+	<WooOnboardingTask id="woocommerce-payments">
+		<ReadyWcPay />
+	</WooOnboardingTask>
+);

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ import WelcomeModal from './welcome-modal';
 import { DisabledTasksFill } from './disabled-tasks';
 import { PaymentGatewaySuggestions } from './payment-gateway-suggestions';
 import { Tax } from './free-trial/tax';
+import { WoocommercePaymentsTaskPage } from './free-trial/fills/woocommerce-payments';
 import { TaskListCompletedHeaderFill } from './task-completion/fill.tsx';
 import './index.scss';
 import { CalypsoBridgeHomescreenBanner } from './homescreen-banner';
@@ -56,6 +57,8 @@ if ( !! window.wcCalypsoBridge.isEcommercePlanTrial ) {
 	// Otherwise we'll have both the original and new fills rendered.
 	const oldTaskNames = [
 		'wc-admin-onboarding-task-payments',
+		'woocommerce-admin-task-wcpay', // WCPay task item which handles direct click on the task. (Not needed in free trial)
+		'woocommerce-admin-task-wcpay-page', // WCPay task page which handles URL navigation to the task.
 		'wc-admin-onboarding-task-tax',
 	];
 	addAction(
@@ -96,6 +99,11 @@ if ( !! window.wcCalypsoBridge.isEcommercePlanTrial ) {
 				) }
 			</WooOnboardingTask>
 		),
+	} );
+
+	registerPlugin( 'wc-calypso-bridge-task-woocommerce-payments-page', {
+		scope: 'woocommerce-tasks',
+		render: WoocommercePaymentsTaskPage,
 	} );
 
 	registerPlugin( 'wc-calypso-bridge-homescreen-slotfill-banner', {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes WooCommerce payments task attempting to install WCPay plugin

### How to test the changes in this Pull Request:

1. Go to WooCommerce homescreen
2. Click on `Set up WooCommerce Payments`
3. Observe that you're redirected to WCPay set up site

