### PR TITLE
Override the `wc.experimental.useSlot` hook 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import { render } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import './use-slot-patch';
 import wcNavFilterRootUrl from './wc-navigation-root-url';
 import LaunchStorePage from './launch-store';
 import WelcomeModal from './welcome-modal';
@@ -114,21 +115,36 @@ if ( !! window.wcCalypsoBridge.isEcommercePlanTrial ) {
 
 if ( !! window.wcCalypsoBridge.isEcommercePlan ) {
 	// Filter wc admin pages.
-	addFilter( 'woocommerce_admin_pages_list', 'wc-calypso-bridge', ( pages ) => {
+	addFilter(
+		'woocommerce_admin_pages_list',
+		'wc-calypso-bridge',
+		( pages ) => {
+			if ( !! window.wcCalypsoBridge.isWooNavigationEnabled ) {
+				/**
+				 * Ensure that WooCommerce Home page will not highlight the WooCommerce parent menu item.
+				 */
+				pages = pages.map( ( page ) =>
+					page.path === '/'
+						? { ...page, wpOpenMenu: 'menu-dashboard' }
+						: page
+				);
+				pages = pages.map( ( page ) =>
+					page.path === '/customers'
+						? { ...page, wpOpenMenu: '' }
+						: page
+				);
+			}
 
-		if ( !! window.wcCalypsoBridge.isWooNavigationEnabled ) {
-			/**
-			 * Ensure that WooCommerce Home page will not highlight the WooCommerce parent menu item.
-			 */
-			pages = pages.map( page => page.path === '/' ? {...page, wpOpenMenu: 'menu-dashboard' } : page );
-			pages = pages.map( page => page.path === '/customers' ? {...page, wpOpenMenu: ''} : page );
+			return pages;
 		}
-
-		return pages;
-	} );
+	);
 
 	// Embed code on woo pages.
-	if ( !! window.wcCalypsoBridge.isWooNavigationEnabled && !! window.wcCalypsoBridge.showEcommerceNavigationModal && !! window.wcCalypsoBridge.isWooPage ) {
+	if (
+		!! window.wcCalypsoBridge.isWooNavigationEnabled &&
+		!! window.wcCalypsoBridge.showEcommerceNavigationModal &&
+		!! window.wcCalypsoBridge.isWooPage
+	) {
 		const wpBody = document.getElementById( 'wpbody-content' );
 		const wrap =
 			wpBody.querySelector( '.wrap.woocommerce' ) ||

--- a/src/use-slot-patch.js
+++ b/src/use-slot-patch.js
@@ -1,0 +1,29 @@
+'use strict';
+/* This file is a patch to override the useSlot hook in the @woocommerce/experimental package.
+ * This is a temporary fix until the WooCommerce updated to 7.5.0.
+ */
+
+const wpUseSlotFills = window.wp.components.__experimentalUseSlotFills;
+const wpUseSlot = window.wp.components.__experimentalUseSlot;
+
+// Override the useSlot hook only if the experimental useSlotFills hook is available (Gutenberg 14.3+).
+if ( typeof wpUseSlotFills === 'function' ) {
+	// We need to re-assign the useSlot hook to the experimental object because it doesn't allow us to redefine property directly.
+	window.wc.experimental = {
+		...window.wc.experimental,
+		useSlot: ( name ) => {
+			const slot = wpUseSlot( name );
+			const fills = wpUseSlotFills( name );
+			return {
+				...slot,
+				fills,
+			};
+		},
+	};
+
+	// Make the useSlot hook non-configurable and non-writable.
+	Object.defineProperty( window.wc.experimental, 'useSlot', {
+		configurable: false,
+		writable: false,
+	} );
+}

--- a/src/use-slot-patch.js
+++ b/src/use-slot-patch.js
@@ -1,6 +1,6 @@
 'use strict';
-/* This file is a patch to override the useSlot hook in the @woocommerce/experimental package.
- * This is a temporary fix until the WooCommerce updated to 7.5.0.
+/*
+ * This is a temporary fix to override the useSlot hook in the @woocommerce/experimental package until the WooCommerce updated to 7.5.0.
  */
 
 const wpUseSlotFills = window.wp.components.__experimentalUseSlotFills;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Override the `wc.experimental.useSlot` hook  to fix the slotfill issue when using Gutenberg 14.3+.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Installed and activate Gutenberg 14.3+ (if needed)
2. Go to WooCommerce > Home
3. Confirm homescreen free trial banner and task accordion slotfills are rendered.

![Screenshot 2023-02-23 at 11 38 28](https://user-images.githubusercontent.com/4344253/220817581-d7207e6b-d7b1-4543-83ba-1d71c950dd33.png)


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
