### PR TITLE
Update webpack config to import scss variables and mixins as a global import

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleased =
+* Update webpack config to import scss variables and mixins as a global import #988
+
 = 2.0.3 =
 * Override the wc.experimental.useSlot hook #986.
 * Bring Add a domain task back for free trial #985.

--- a/src/free-trial/tax/components/partner-card.scss
+++ b/src/free-trial/tax/components/partner-card.scss
@@ -1,6 +1,3 @@
-@import '../../../stylesheets/variables';
-@import '../../../stylesheets/mixins';
-
 .woocommerce-tax-partner-card {
 	border: 1px solid $gray-300;
 	border-radius: 3px;

--- a/src/free-trial/tax/components/partners.scss
+++ b/src/free-trial/tax/components/partners.scss
@@ -1,6 +1,3 @@
-@import '../../../stylesheets/variables';
-@import '../../../stylesheets/mixins';
-
 .woocommerce-tax-partners__partners {
 	display: grid;
 	grid-template-columns: 1fr 1fr;

--- a/src/free-trial/tax/woocommerce-tax/setup.scss
+++ b/src/free-trial/tax/woocommerce-tax/setup.scss
@@ -1,6 +1,3 @@
-@import '../../../stylesheets/variables';
-@import '../../../stylesheets/mixins';
-
 .woocommerce-task-tax__automated-tax-control {
 	display: flex;
 	align-items: center;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,13 +1,39 @@
-const defaultConfig = require('@wordpress/scripts/config/webpack.config');
-const WooCommerceDependencyExtractionWebpackPlugin = require('@woocommerce/dependency-extraction-webpack-plugin');
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
+const WooCommerceDependencyExtractionWebpackPlugin = require( '@woocommerce/dependency-extraction-webpack-plugin' );
+const path = require( 'path' );
+
+// Import variables and mixins from the stylesheets directory so they can be used in all scss files.
+defaultConfig.module.rules.push( {
+	test: /\.(sc|sa)ss$/,
+	use: [
+		{
+			loader: 'sass-loader',
+			options: {
+				sassOptions: {
+					includePaths: [
+						path.resolve( __dirname, 'src/stylesheets' ),
+					],
+				},
+				// Prepends Sass/SCSS code before the actual entry file
+				additionalData: ( content ) => {
+					return (
+						'@import "_variables"; ' +
+						'@import "_mixins"; ' +
+						content
+					);
+				},
+			},
+		},
+	],
+} );
 
 module.exports = {
 	...defaultConfig,
 	plugins: [
 		...defaultConfig.plugins.filter(
-			(plugin) =>
+			( plugin ) =>
 				plugin.constructor.name !== 'DependencyExtractionWebpackPlugin'
 		),
 		new WooCommerceDependencyExtractionWebpackPlugin(),
-	]
+	],
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #941.

This PR updates the webpack config to import `_variables.scss` and `mixins.scss` as a global import so we don't need to import them for each required file.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Run `npm start`
2. Make sure your store is located in WCS supported country, such as US
3. Go to WooCommerce > Home > Tax task
4. Confirm the UI looks like the screenshots in https://github.com/Automattic/wc-calypso-bridge/pull/975

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
