### PR TITLE
Add blog name/site title as starter suggestion for Add a domain task

### DIFF
--- a/includes/tasks/class-wc-calypso-task-add-domain.php
+++ b/includes/tasks/class-wc-calypso-task-add-domain.php
@@ -67,8 +67,19 @@ class AddDomain extends Task {
 	public function get_action_url() {
 		$status      = new \Automattic\Jetpack\Status();
 		$site_suffix = $status->get_site_suffix();
+		$domain_path = sprintf( "https://wordpress.com/domains/add/%s", $site_suffix );
+		$home_url    = \home_url( '', 'https' );
 
-		return sprintf( "https://wordpress.com/domains/add/%s", $site_suffix );
+		if ( ! \str_starts_with( $home_url, 'https://woo-' ) && ! \str_starts_with( $home_url, 'https://wooexpress-' ) ) {
+			return $domain_path;
+		}
+
+		$blog_name = \get_option( 'blogname' );
+		if ( empty( $blog_name ) ) {
+			return $domain_path;
+		}
+
+		return sprintf( '%s?suggestion=%s', $domain_path, rawurlencode( $blog_name ) );
 	}
 
 	/**

--- a/includes/tasks/class-wc-calypso-task-add-domain.php
+++ b/includes/tasks/class-wc-calypso-task-add-domain.php
@@ -70,6 +70,10 @@ class AddDomain extends Task {
 		$domain_path = sprintf( "https://wordpress.com/domains/add/%s", $site_suffix );
 		$home_url    = \home_url( '', 'https' );
 
+		if ( ! \str_ends_with( $home_url, '.wpcomstaging.com' ) ) {
+			return $domain_path;
+		}
+
 		if ( ! \str_starts_with( $home_url, 'https://woo-' ) && ! \str_starts_with( $home_url, 'https://wooexpress-' ) ) {
 			return $domain_path;
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR ensures that when we are on a site that has a primary site address that starts with `woo-` or `wooexpress-`, the "Add a domain" task will use the site title/blog name as the seed content for domain suggestions (assuming the title is not empty).

That is achieved as follows when we're building the task's target URL:
1. We get the `home_url()` for the current site, and checking if it starts with `woo-` or `wooexpress-` _and_ ends with `.wpcomstaging.com`. If it doesn't we return the existing URL without a suggestion.
2. We then get the `blogname` option - if it's empty, we return the existing URL.
3. We now know we have a title, and we add it as the `suggestion` URL parameter in the returned data.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes Automattic/wp-calypso#73393.

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Start by setting up a free eCommerce trial site as a WoA dev site, as documented here: peapX7-1D4-p2
  - Note that the site's domain must start with `woo-` or `wooexpress-` for the new logic to work
3. Next, use SFTP to apply the changes from this patch on your dev site, where the `wc-calypso-bridge` code is located under `wp-content/mu-plugins/wpcomsh/vendor/automattic/wc-calypso-bridge/` - you can either copy up just this modified file, or you can rebuild the plugin locally and upload it as a whole. (If you do the latter, I'd recommend that you upload a zip file, `rm -r` the `wc-calypso-bridge` directory, and then `unzip` the zip file.)
4. Once the patch is applied, visit WooCommerce home for the site (`/wp-admin/admin.php?page=wc-admin`)
5. Click on the "Add a domain" task in the tasklist
6. Verify that you are taken to the domain suggestions page and the URL includes a `suggestion` URL parameter pulled from the site's blogname (which can be checked or modified via the _Site title_ setting under _Settings_ -> _General_ in the left nav.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.