### PR TITLE
Prepare to release 2.0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v2.0.3",
+  "version": "v2.0.4",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-wc-payments.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-wc-payments.php
@@ -4,7 +4,7 @@
  * Class WC_Calypso_Bridge_Free_Trial_WC_Payments.
  *
  * @since   2.0.2
- * @version 2.0.2
+ * @version 2.0.4
  *
  * Includes JS on the WC Payments page to customize the look.
  */

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 2.0.3
+Stable tag: 2.0.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,16 +22,14 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
-= Unreleased =
-* Fixed wcpay customisation script error #989
-* Customize homescreen title and progress header #987.
-
 = 2.0.4 =
 * Free Trial: Hide Tools > Marketing, Tools > Earn - Move Feedback under Jetpack #979.
 * Free Trial: Introduce payment restrictions #930.
 * Free trial: Replace Marketing page #984.
 * Free trial: Introduce Extensions landing page - Hide Extensions > Manage #965.
 * Update webpack config to import scss variables and mixins as a global import #988.
+* Customize homescreen title and progress header #987.
+* Fixed wcpay customisation script error #989
 * Customize homescreen title and progress header #987.
 
 = 2.0.3 =

--- a/readme.txt
+++ b/readme.txt
@@ -26,9 +26,8 @@ This section describes how to install the plugin and get it working.
 * Free Trial: Hide Tools > Marketing, Tools > Earn - Move Feedback under Jetpack #979.
 * Free Trial: Introduce payment restrictions #930.
 * Free trial: Replace Marketing page #984.
-* Free trial: Introduce Extensions landing page - Hide Extensions > Manage #965.
+* Free trial: Introduce Extensions landing page - Hide Extensions > Manage #990.
 * Update webpack config to import scss variables and mixins as a global import #988.
-* Customize homescreen title and progress header #987.
 * Fixed wcpay customisation script error #989
 * Customize homescreen title and progress header #987.
 

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancments for users of Store on WordPress.com.
- * Version: 2.0.3
+ * Version: 2.0.4
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -47,7 +47,7 @@ if ( ! defined( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH' ) ) {
 	define( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH', dirname( __FILE__ ) );
 }
 if ( ! defined( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION' ) ) {
-	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.0.3' );
+	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.0.4' );
 }
 if ( ! defined( 'WC_MIN_VERSION' ) ) {
 	define( 'WC_MIN_VERSION', '7.3' );


### PR DESCRIPTION
This PR bumps the version to 2.0.4 to release

- https://github.com/Automattic/wc-calypso-bridge/pull/979
- https://github.com/Automattic/wc-calypso-bridge/pull/930
- https://github.com/Automattic/wc-calypso-bridge/pull/984
- https://github.com/Automattic/wc-calypso-bridge/pull/990
- https://github.com/Automattic/wc-calypso-bridge/pull/988
- https://github.com/Automattic/wc-calypso-bridge/pull/989
- https://github.com/Automattic/wc-calypso-bridge/pull/987

```
= 2.0.4 =
* Free Trial: Hide Tools > Marketing, Tools > Earn - Move Feedback under Jetpack #979.
* Free Trial: Introduce payment restrictions #930.
* Free trial: Replace Marketing page #984.
* Free trial: Introduce Extensions landing page - Hide Extensions > Manage #990.
* Update webpack config to import scss variables and mixins as a global import #988.
* Fixed wcpay customisation script error #989
* Customize homescreen title and progress header #987.
```