### PR TITLE
Add free trial host value for tracks

### DIFF
--- a/includes/class-wc-calypso-bridge-tracks.php
+++ b/includes/class-wc-calypso-bridge-tracks.php
@@ -97,8 +97,11 @@ class WC_Calypso_Bridge_Tracks {
 		// Default value assumes business plan, inside wp-admin.
 		$host_value = 'bizplan-wp-admin';
 
-		// If an ecomm plan site, update host value.
-		if ( wc_calypso_bridge_has_ecommerce_features() ) {
+		// Update host value according to plan. Ordering could be important
+		// since some plans may have overlapping features.
+		if ( wc_calypso_bridge_is_ecommerce_trial_plan() ) {
+			$host_value = 'ecommplan-freetrial';
+		} else if ( wc_calypso_bridge_has_ecommerce_features() ) {
 			$host_value = 'ecommplan';
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleased =
+* Add free trial host value for tracks #995.
+
 = 2.0.4 =
 * Free Trial: Hide Tools > Marketing, Tools > Earn - Move Feedback under Jetpack #979.
 * Free Trial: Introduce payment restrictions #930.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #949.

This PR adds sets tracks `host` prop to `ecommplan-freetrial` when it detects free trial plan.

### How to test the changes in this Pull Request:

1. On a free trial site, go to WooCommerce homescreen
2. Right click on anywhere on screen, view page source
3. Search for the text `properties.host`
4. Observe the value is set to `ecommplan-freetrial`.
