### PR TITLE
Free trial: Use theme color for completed task strikethrough

### DIFF
--- a/assets/css/ecommerce.css
+++ b/assets/css/ecommerce.css
@@ -204,3 +204,9 @@ body.woocommerce_page_wc-addons-landing-page #screen-meta-links {
 	}
 }
 
+.woocommerce-task-list__setup
+	.woocommerce-experimental-list
+	.woocommerce-experimental-list__item.complete {
+	color: var( --wp-admin-theme-color );
+}
+

--- a/assets/css/free-trial-admin.css
+++ b/assets/css/free-trial-admin.css
@@ -11,3 +11,9 @@
 .wc-calypso-notice a {
 	color: inherit;
 }
+
+.woocommerce-task-list__setup
+	.woocommerce-experimental-list
+	.woocommerce-experimental-list__item.complete {
+	color: var( --wp-admin-theme-color );
+}

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleased =
+* Use the theme color for completed task strikethrough #1006
+
 = 2.0.4 =
 * Free Trial: Hide Tools > Marketing, Tools > Earn - Move Feedback under Jetpack #979.
 * Free Trial: Introduce payment restrictions #930.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1000 .

This PR uses the current theme color for completed task strikethrough.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Checkout this branch and build the asset.
2. Navigate to `WooCommerce -> Home`
3. Complete a task.
4. Confirm the strikethrough color is the same as the current theme color.

<!-- End testing instructions -->

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
