### PR TITLE
Add filter to synchronize task list options to WPCOM via Jetpack

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v2.0.12",
+  "version": "v2.0.13",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/includes/class-wc-calypso-bridge-filters.php
+++ b/includes/class-wc-calypso-bridge-filters.php
@@ -49,6 +49,7 @@ class WC_Calypso_Bridge_Filters {
 	 */
 	public function init() {
 		add_filter( 'admin_footer', array( $this, 'add_documentation_js_filter' ) );
+		add_filter( 'jetpack_sync_options_whitelist', array( $this, 'add_woocommerce_task_list_options_to_jetpack_sync' ), 10, 1 );
 
 		/**
 		 * Disable email based notifications.
@@ -82,6 +83,31 @@ class WC_Calypso_Bridge_Filters {
 			}
 		</script>
 		<?php
+	}
+
+	/**
+	 * Function to hook into the `jetpack_sync_options_whitelist` filter
+	 * and adds options related to the WooCommerce task list to the list of
+	 * options Jetpack will synchronize to WordPress.com.
+	 *
+	 * @param array $allowed_options
+	 * @return array
+	 */
+	public function add_woocommerce_task_list_options_to_jetpack_sync( $allowed_options ) {
+		if ( ! is_array( $allowed_options ) ) {
+			return $allowed_options;
+		}
+
+		$woocommerce_task_list_options = array(
+			'woocommerce_task_list_complete',
+			'woocommerce_task_list_completed_lists',
+			'woocommerce_task_list_dismissed_tasks',
+			'woocommerce_task_list_hidden_lists',
+			'woocommerce_task_list_keep_completed',
+			'woocommerce_task_list_tracked_completed_tasks',
+		);
+
+		return array_merge( $allowed_options, $woocommerce_task_list_options );
 	}
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 2.0.12
+Stable tag: 2.0.13
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,7 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
-* Remove the onboarding purchase task #1060
+= 2.0.13 =
+* Remove the onboarding purchase task #1060.
+* Add WooCommerce task list options to Jetpack Sync #1009.
 
 = 2.0.12 =
 * Redirect admin pages to the Calypso upgrade page for free trials #1055.

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancements for users of Store on WordPress.com.
- * Version: 2.0.11
+ * Version: 2.0.13
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -47,7 +47,7 @@ if ( ! defined( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH' ) ) {
 	define( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH', dirname( __FILE__ ) );
 }
 if ( ! defined( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION' ) ) {
-	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.0.11' );
+	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.0.13' );
 }
 if ( ! defined( 'WC_MIN_VERSION' ) ) {
 	define( 'WC_MIN_VERSION', '7.3' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR ensures that the following options relating to the WooCommerce task list are synchronized to WordPress.com from eCommerce sites:
* `woocommerce_task_list_complete`
* `woocommerce_task_list_completed_lists`
* `woocommerce_task_list_dismissed_tasks`
* `woocommerce_task_list_hidden_lists`
* `woocommerce_task_list_keep_completed`
* `woocommerce_task_list_tracked_completed_tasks`

These options will be used to drive email campaigns based on task completion, as per this discussion: pcUrMV-1TL-p2

_Note: this PR depends on D106275-code, which adds these options to the Jetpack sync allow-list._ That change has now been deployed to WordPress.com.
<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

2. Ensure that you have a WoA developer site configured with an eCommerce, eCommerce trial, or Woo Express plan.
3. Apply this patch to `wc-calypso-bridge` on your site. You can do this by modifying the file directly using a text editor, or by using SFTP. 
  - If you're modifying the file via SSH or SCP, the file is in `~/htdocs/wp-content/mu-plugins/wpcomsh/vendor/automattic/wc-calypso-bridge/includes/class-wc-calypso-bridge-filters.php`
  - If you're pushing up the files via SFTP, the file is in `wp-content/mu-plugins/wpcomsh/vendor/automattic/wc-calypso-bridge/includes/class-wc-calypso-bridge-filters.php`
4. Open up an SSH session to your WoA dev site with the patch applied.
5. Run the following commands to delete and then re-add the relevant options:
  a. `wp option delete woocommerce_task_list_complete woocommerce_task_list_completed_lists woocommerce_task_list_dismissed_tasks woocommerce_task_list_hidden_lists woocommerce_task_list_keep_completed woocommerce_task_list_tracked_completed_tasks`
     - Note that some of these options may not exist, so the delete operation may show some warnings
   b. `wp option add woocommerce_task_list_complete 'no'`
   c. `wp option add woocommerce_task_list_completed_lists --format=json '["secret_tasklist"]'`
   d. `wp option add woocommerce_task_list_dismissed_tasks --format=json '["test_task"]'`
   e. `wp option add woocommerce_task_list_hidden_lists --format=json '["test_list"]'`
   f. `wp option add woocommerce_task_list_keep_completed 'no'`
   g. `wp option add woocommerce_task_list_tracked_completed_tasks --format=json '["purchase","woocommerce-payments","launch_site","products","shipping-recommendation","store_details"]'`
6. Now, find the WPCOM blog ID for your test Atomic site - I tend to find it by checking the network tab of my browser when viewing Calypso
7. Open up `wpsh` on your WPCOM sandbox, and run the following code after at least some time has elapsed (you can use the _Incremental sync_ subsection of the [Jetpack debugger](https://jptools.wordpress.com/debug/) to confirm whether your site has been synched):
```
> $dev_blog_id = 123456; // replace with your WoA site's blog_id
> switch_to_blog( $dev_blog_id );
> $replica_store = Jetpack_Sync_WPCOM_Shadow_Replicastore::getInstance();
> $woo_options = [ 'woocommerce_task_list_complete', 'woocommerce_task_list_completed_lists', 'woocommerce_task_list_dismissed_tasks', 'woocommerce_task_list_hidden_lists', 'woocommerce_task_list_keep_completed', 'woocommerce_task_list_tracked_completed_tasks' ];
> foreach ( $woo_options as $woo_option ) { echo "\n$woo_option: " . var_export( $replica_store->get_option( $woo_option ), true ); }
```
8. Verify that you get the following data written out:
```
woocommerce_task_list_complete: 'no'
woocommerce_task_list_completed_lists: array (
  0 => 'secret_tasklist',
)
woocommerce_task_list_dismissed_tasks: array (
  0 => 'test_task',
)
woocommerce_task_list_hidden_lists: array (
  0 => 'test_list',
)
woocommerce_task_list_keep_completed: 'no'
woocommerce_task_list_tracked_completed_tasks: array (
  0 => 'purchase',
  1 => 'woocommerce-payments',
  2 => 'launch_site',
  3 => 'products',
  4 => 'shipping-recommendation',
  5 => 'store_details',
)
```
9. Rerun the option deletion on your WoA dev site:
  - `wp option delete woocommerce_task_list_complete woocommerce_task_list_completed_lists woocommerce_task_list_dismissed_tasks woocommerce_task_list_hidden_lists woocommerce_task_list_keep_completed woocommerce_task_list_tracked_completed_tasks`
10. Wait for the data to be synched and then run the following code in your existing `wpsh` session on your WPCOM sandbox:
```
> foreach ( $woo_options as $woo_option ) { echo "\n$woo_option: " . var_export( $replica_store->get_option( $woo_option ), true ); }
```
11. Verify that you get the following output with false for all option values:
```
woocommerce_task_list_complete: false
woocommerce_task_list_completed_lists: false
woocommerce_task_list_dismissed_tasks: false
woocommerce_task_list_hidden_lists: false
woocommerce_task_list_keep_completed: false
woocommerce_task_list_tracked_completed_tasks: false
```

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.