### PR TITLE
Prevent deletion of managed plugins (Avatax)

### DIFF
--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 2.0.2
+ * @version 2.0.5
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -47,6 +47,7 @@ class WC_Calypso_Bridge_Plugins {
 		'woocommerce-product-recommendations/woocommerce-product-recommendations.php',
 		'automatewoo/automatewoo.php',
 		'woocommerce-shipping-fedex/woocommerce-shipping-fedex.php',
+		'woocommerce-avatax/woocommerce-avatax.php',
 	);
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 2.0.5 =
+* Prevent deletion of managed plugins (Avatax) #xxx.
+
 = 2.0.4 =
 * Free Trial: Hide Tools > Marketing, Tools > Earn - Move Feedback under Jetpack #979.
 * Free Trial: Introduce payment restrictions #930.

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,7 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 = 2.0.5 =
-* Prevent deletion of managed plugins (Avatax) #xxx.
+* Prevent deletion of managed plugins (Avatax) #1012.
 
 = 2.0.4 =
 * Free Trial: Hide Tools > Marketing, Tools > Earn - Move Feedback under Jetpack #979.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Avatax has been introduced as managed - We should prevent deletion in wp-admin.

Closes #1011  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

1. Visit `wp-admin/plugins.php`
2. Deactivate Avatax
3. No Delete link is available
4. The plugin can be deleted through wp cli (if needed)

<!-- End testing instructions -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
