### PR TITLE
Free trial: Update notice messages and other copies

### DIFF
--- a/assets/css/free-trial-admin.css
+++ b/assets/css/free-trial-admin.css
@@ -9,7 +9,7 @@
 }
 
 .wc-calypso-notice a {
-	color: #007cba	;
+	color: #007cba;
 }
 
 .free-trial-orders-notice {

--- a/assets/css/free-trial-admin.css
+++ b/assets/css/free-trial-admin.css
@@ -9,7 +9,7 @@
 }
 
 .wc-calypso-notice a {
-	color: inherit;
+	color: #007cba	;
 }
 
 .free-trial-orders-notice {

--- a/assets/scripts/free-trial-wc-payments.js
+++ b/assets/scripts/free-trial-wc-payments.js
@@ -6,7 +6,7 @@
 	 *
 	 * Source: https://stackoverflow.com/questions/5525071/how-to-wait-until-an-element-exists
 	 *
-	 * @param selector
+	 * @param {string} selector The selector to wait for.
 	 */
 	const waitForElm = ( selector ) => {
 		return new Promise( ( resolve ) => {

--- a/assets/scripts/free-trial-wc-payments.js
+++ b/assets/scripts/free-trial-wc-payments.js
@@ -5,6 +5,8 @@
 	 * This is required as there's no official way of waiting for an React component to finish.
 	 *
 	 * Source: https://stackoverflow.com/questions/5525071/how-to-wait-until-an-element-exists
+	 *
+	 * @param selector
 	 */
 	const waitForElm = ( selector ) => {
 		return new Promise( ( resolve ) => {
@@ -27,7 +29,7 @@
 
 	const getNotice = ( copySelector ) => {
 		const defaultCopy = __(
-			"During the trial period you can only make test payments. To process real transactions, <a href='%s'>upgrade now.</a>",
+			"Only Administrators and Store Managers can place orders during the free trial. If you are ready to accept payments from customers, <a href='%s'>upgrade to a paid plan</a>.",
 			'wc-calypso-bridge'
 		);
 
@@ -35,7 +37,7 @@
 			default: defaultCopy,
 			transactions: defaultCopy,
 			deposits: __(
-				"During the trial period you’ll not be able to get deposits. To receive payments and payouts, <a href='%s'>upgrade now.</a>",
+				"Deposits are not available during the trial period. To start processing real transactions and receive payments and payouts, <a href='%s'>upgrade to a pain plan</a>.",
 				'wc-calypso-bridge'
 			),
 		};

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleased =
+* Free trial: Update notice messages and other copies #1022.
+
 = 2.0.6 =
 * Fix fatal error when trying to remove GC hidden menu items from Calypso menu #1018.
 

--- a/src/free-trial/fills/task-headers/payments.js
+++ b/src/free-trial/fills/task-headers/payments.js
@@ -38,7 +38,7 @@ const PaymentsHeader = () => {
 							</h1>
 							<p>
 								{ __(
-									'Give your customers an easy and convenient way to pay! Set up one (or more!) of our fast and secure online or in person payment methods.',
+									'Give your customers an easy and convenient way to pay! Set up and test some of our fast and secure online or in person payment methods.',
 									'wc-calypso-bridge'
 								) }
 							</p>

--- a/src/free-trial/tax/index.tsx
+++ b/src/free-trial/tax/index.tsx
@@ -29,7 +29,7 @@ import { Card as WooCommerceTaxCard } from './woocommerce-tax/card';
 import {
 	getCountryCode,
 	createNoticesFromResponse,
-	getPlanUpgradeLink,
+	getUpgradePlanLink,
 } from '../../utils';
 import { ManualConfiguration } from './manual-configuration';
 import { WooCommerceTax } from './woocommerce-tax';
@@ -64,7 +64,7 @@ const UpgradeNotice = () => (
 					br: <br />,
 					link: (
 						<Link
-							href={ getPlanUpgradeLink() }
+							href={ getUpgradePlanLink() }
 							type="external"
 							target="_blank"
 						>

--- a/src/notice/style.scss
+++ b/src/notice/style.scss
@@ -6,7 +6,3 @@
 	font-size: 13px;
 	background-color: #ffffff;
 }
-
-.wc-calypso-bridge-notice a {
-	color: #000000;
-}

--- a/src/payment-gateway-suggestions/components/WCPay/Suggestion.js
+++ b/src/payment-gateway-suggestions/components/WCPay/Suggestion.js
@@ -33,10 +33,7 @@ const WCPayBannerText = ( { actionButton } ) => {
 				lineHeight="28px"
 				padding="0 20px 0 0"
 			>
-				{ __(
-					'Get ready to be paid and manage your business.',
-					'wc-calypso-bridge'
-				) }
+				{ __( 'Get ready to accept payments', 'wc-calypso-bridge' ) }
 			</Text>
 			<Text
 				className="woocommerce-recommended-payments__header-heading"

--- a/src/payment-gateway-suggestions/index.js
+++ b/src/payment-gateway-suggestions/index.js
@@ -277,7 +277,7 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 			<Notice
 				text={ interpolateComponents( {
 					mixedString: __(
-						'During the trial period you can only make test payments. To process real transactions, {{link}}upgrade now{{/link}}.',
+						'Only Administrators and Store Managers can place orders during the free trial. If you are ready to accept payments from customers, {{link}}upgrade to a paid plan{{/link}}.',
 						'wc-calypso-bridge'
 					),
 					components: {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -35,6 +35,6 @@ export function createNoticesFromResponse( response ) {
 	}
 }
 
-export const getPlanUpgradeLink = () => {
+export const getUpgradePlanLink = () => {
 	return `https://wordpress.com/plans/${ window.wcCalypsoBridge.siteSlug }`;
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -34,3 +34,7 @@ export function createNoticesFromResponse( response ) {
 		createNotice( response.code ? 'error' : 'success', response.message );
 	}
 }
+
+export const getPlanUpgradeLink = () => {
+	return `https://wordpress.com/plans/${ window.wcCalypsoBridge.siteSlug }`;
+};


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1019.

Update all copies from latest changes in figma

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

### Tasks

Figma: lD0gTB4IqGsmSmsnjZNaP6-fi-49%3A7986 | 1EGipzzulCg2uk4MsSf2x7-fi-14%3A5786

1. Choose a WCPay country
1. Go to `WooCommerce > Home > Payments task`
1. Observe that the free trial notice displays: `"Only Administrators and Store Managers can place orders during the free trial. If you are ready to accept payments from customers, [upgrade to a paid plan](URL)".`
1. Confirm the heading is `Get ready to accept payments` 
1. Go to WooCommerce > Home > **Tax task**
1. Observe that the free trial notice displays `"During the free trial period you can configure your sales tax settings, but not collect it. To start selling products, [upgrade now](URL)."`
1. Complete store details, add products tasks and make sure payments task is incomplete
1. Observe that payment task header description is `"Give your customers an easy and convenient way to pay! Set up and test some of our fast and secure online or in person payment methods."`

Payments task fill header

<img src="https://user-images.githubusercontent.com/3747241/222486238-c38aa821-423f-4b58-991a-9becd0fa1fdf.png" width="500">

Payments task header description

<img src="https://user-images.githubusercontent.com/3747241/222487242-4ed3a8eb-0dd8-47d9-bf08-402519c5d341.png" width="500">

Tax

<img src="https://user-images.githubusercontent.com/4344253/222633963-ebe93f72-cf9c-468f-b11e-b9b8495641f0.png" width="500">

### WCPay

Figma: 1EGipzzulCg2uk4MsSf2x7-fi-14%3A7215

1. Change your store country to US
4. Click WooCommerce Payments menu.
5. Confirm the notice shows `"Only Administrators and Store Managers can place orders during the free trial. If you are ready to accept payments from customers, [upgrade to a paid plan](url)."`
6. cd to `/wp-content/plugins/woocommerce-payments` and open `includes/admin/class-wc-payments-admin.php`
7. return false from `maybe_redirect_to_onboarding` method.
8. Set `$should_render_full_menu` variable to true in `add_payments_men` method.
9. Refresh your admin page and you should see the full menu under WooCommerce Payment menu.
10. Go to **Payments > overview screen:**
11. Confirm the notice shows `"Only Administrators and Store Managers can place orders during the free trial. If you are ready to accept payments from customers, [upgrade to a paid plan](URL)."`
12. Go to **Payments > transactions screen:**
13. Confirm the notice shows `"Only Administrators and Store Managers can place orders during the free trial. If you are ready to accept payments from customers, [upgrade to a paid plan](URL)."`
14. Go to **Payments > WCPay deposits screen:**
15. Confirm the notice shows `"Deposits are not available during the trial period. To start processing real transactions and receive payments and payouts, [upgrade to a pain plan](URL)."`

![Screenshot 2023-03-03 at 10 50 29](https://user-images.githubusercontent.com/4344253/222624205-0dfd1bda-a23b-485a-bda6-93928ad2055f.png)
![Screenshot 2023-03-03 at 10 53 30](https://user-images.githubusercontent.com/4344253/222624228-1aa9b95d-f734-47a2-84ca-2d2bd8c3514d.png)
![Screenshot 2023-03-03 at 10 53 39](https://user-images.githubusercontent.com/4344253/222624269-eaf5f0e5-a202-40ca-b524-5e5f1babe418.png)


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
