### PR TITLE
Add `wcadmin_free_trial_learn_more` track

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleased =
+Add wcadmin_free_trial_learn_more track #1024.
+
 = 2.0.6 =
 * Fix fatal error when trying to remove GC hidden menu items from Calypso menu #1018.
 

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,7 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 = Unreleased =
-Add wcadmin_free_trial_learn_more track #1024.
+* Add wcadmin_free_trial_learn_more track #1024.
 
 = 2.0.6 =
 * Fix fatal error when trying to remove GC hidden menu items from Calypso menu #1018.

--- a/src/homescreen-banner/index.js
+++ b/src/homescreen-banner/index.js
@@ -5,6 +5,8 @@ import { Fill, Card, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { recordEvent } from '@woocommerce/tracks';
+
 /**
  * Internal dependencies
  */
@@ -48,6 +50,9 @@ export const CalypsoBridgeHomescreenBanner = () => {
 						<a
 							href={ `https://wordpress.com/plans/${ window.wcCalypsoBridge.siteSlug }` }
 							className="wc-calypso-bridge-woocommerce-admin-homescreen-banner__learn-more-button components-button is-secondary"
+							onClick={ () => {
+								recordEvent( 'free_trial_learn_more' );
+							} }
 						>
 							{ __( 'Learn more', 'wc-calypso-bridge' ) }
 						</a>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/team-ghidorah/issues/173.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Go to `WooCommerce > Home`
2. Open dev console
3. Enable debug `localStorage.setItem( 'debug', 'wc-admin:*' );` and tick "preserve log" option
4. Click on "Learn more" button
5. Confirm the `wcadmin_free_trial_learn_more` track is recorded.

![Screenshot 2023-03-03 at 12 16 14](https://user-images.githubusercontent.com/4344253/222630048-853c4450-8315-40fe-b864-00a0badf1e6c.png)


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
