### PR TITLE
Add defensive WC_Calypso_Bridge_Instance->get_site_slug() helper function

### DIFF
--- a/class-wc-calypso-bridge-shared.php
+++ b/class-wc-calypso-bridge-shared.php
@@ -106,7 +106,7 @@ class WC_Calypso_Bridge_Shared {
 			filemtime( WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/build/style-index.css' )
 		);
 
-		$site_suffix = wc_calypso_bridge_get_site_slug();
+		$site_suffix = WC_Calypso_Bridge_Instance()->get_site_slug();
 
 		$params      = array(
 			'isEcommercePlan'              => (bool) wc_calypso_bridge_has_ecommerce_features(),

--- a/class-wc-calypso-bridge-shared.php
+++ b/class-wc-calypso-bridge-shared.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 2.0.
+ * @version 2.0.8
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/class-wc-calypso-bridge-shared.php
+++ b/class-wc-calypso-bridge-shared.php
@@ -106,10 +106,9 @@ class WC_Calypso_Bridge_Shared {
 			filemtime( WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/build/style-index.css' )
 		);
 
-		$status       = new \Automattic\Jetpack\Status();
-		$site_suffix  = $status->get_site_suffix();
+		$site_suffix = wc_calypso_bridge_get_site_slug();
 
-		$params       = array(
+		$params      = array(
 			'isEcommercePlan'              => (bool) wc_calypso_bridge_has_ecommerce_features(),
 			'isEcommercePlanTrial'         => (bool) wc_calypso_bridge_is_ecommerce_trial_plan(), // This is true for ecommerce trial only.			
 			'isWooNavigationEnabled'       => (bool) apply_filters( 'ecommerce_new_woo_atomic_navigation_enabled', true ),

--- a/class-wc-calypso-bridge-shared.php
+++ b/class-wc-calypso-bridge-shared.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 2.0.0
+ * @version 2.0.
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -110,7 +110,7 @@ class WC_Calypso_Bridge_Shared {
 
 		$params      = array(
 			'isEcommercePlan'              => (bool) wc_calypso_bridge_has_ecommerce_features(),
-			'isEcommercePlanTrial'         => (bool) wc_calypso_bridge_is_ecommerce_trial_plan(), // This is true for ecommerce trial only.			
+			'isEcommercePlanTrial'         => (bool) wc_calypso_bridge_is_ecommerce_trial_plan(), // This is true for ecommerce trial only.
 			'isWooNavigationEnabled'       => (bool) apply_filters( 'ecommerce_new_woo_atomic_navigation_enabled', true ),
 			'isWooPage'                    => $is_woo_page,
 			'homeUrl'                      => esc_url( get_home_url() ),
@@ -158,7 +158,7 @@ class WC_Calypso_Bridge_Shared {
 	 */
 	public function add_ecommerce_trial_plan_styles() {
 		wp_enqueue_style( 'wp-calypso-bridge-ecommerce-trial', WC_Calypso_Bridge_Instance()->get_asset_path() . 'assets/css/free-trial-admin.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
-	}	
+	}
 }
 
 WC_Calypso_Bridge_Shared::instance();

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -228,18 +228,18 @@ class WC_Calypso_Bridge {
 		// The Jetpack class should be auto-loaded if Jetpack has been loaded,
 		// but we've seen fatals from cases where the class wasn't defined.
 		// So let's make double-sure it exists before calling it.
-		if ( class_exists( '\Automattic\Jetpack\Status' ) ) {
+		if ( false && class_exists( '\Automattic\Jetpack\Status' ) ) {
 			$jetpack_status = new \Automattic\Jetpack\Status();
 
 			return $jetpack_status->get_site_suffix();
 		}
 
-		// If the Jetpack Status class doesn't exist, fall back on home_url()
+		// If the Jetpack Status class doesn't exist, fall back on site_url()
 		// with any trailing '/' characters removed.
-		$home_url = trim( home_url( '', 'https' ), '/' );
+		$site_url = untrailingslashit( site_url( '/', 'https' ) );
 
 		// Remove the leading 'https://' and replace any remaining `/` characters with
-		return str_replace( '/', '::', substr( $home_url, 8 ) );
+		return str_replace( '/', '::', substr( $site_url, 8 ) );
 	}
 
 	/**

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -228,7 +228,7 @@ class WC_Calypso_Bridge {
 		// The Jetpack class should be auto-loaded if Jetpack has been loaded,
 		// but we've seen fatals from cases where the class wasn't defined.
 		// So let's make double-sure it exists before calling it.
-		if ( false && class_exists( '\Automattic\Jetpack\Status' ) ) {
+		if ( class_exists( '\Automattic\Jetpack\Status' ) ) {
 			$jetpack_status = new \Automattic\Jetpack\Status();
 
 			return $jetpack_status->get_site_suffix();

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -216,6 +216,32 @@ class WC_Calypso_Bridge {
 	}
 
 	/**
+	 * Defensive helper function to return the current site slug in a way that will work
+	 * when Automattic\Jetpack\Status hasn't been loaded by the Jetpack plugin.
+	 *
+	 * @since 2.0.8
+	 *
+	 * @return string
+	 */
+	public function get_site_slug() {
+		// The Jetpack class should be auto-loaded if Jetpack has been loaded,
+		// but we've seen fatals from cases where the class wasn't defined.
+		// So let's make double-sure it exists before calling it.
+		if ( class_exists( '\Automattic\Jetpack\Status' ) ) {
+			$jetpack_status = new \Automattic\Jetpack\Status();
+
+			return $jetpack_status->get_site_suffix();
+		}
+
+		// If the Jetpack Status class doesn't exist, fall back on home_url()
+		// with any trailing '/' characters removed.
+		$home_url = trim( home_url( '', 'https' ), '/' );
+
+		// Remove the leading 'https://' and replace any remaining `/` characters with
+		return str_replace( '/', '::', substr( $home_url, 8 ) );
+	}
+
+	/**
 	 * Record event using JetPack if enabled
 	 *
 	 * @param string $event_name Name of the event.

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 2.0.5
+ * @version 2.0.8
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-calypso-bridge-addons-screen.php
+++ b/includes/class-wc-calypso-bridge-addons-screen.php
@@ -52,9 +52,7 @@ class WC_Calypso_Bridge_Addons_Screen extends WC_Admin_Addons {
 
 		if ( wc_calypso_bridge_is_ecommerce_trial_plan() ) {
 
-
-			$site_suffix = (new \Automattic\Jetpack\Status())->get_site_suffix();
-			$upgrade_url = sprintf( 'https://wordpress.com/plans/%s', $site_suffix );
+			$upgrade_url = sprintf( 'https://wordpress.com/plans/%s', WC_Calypso_Bridge_Instance()->get_site_slug() );
 
 			/**
 			 * Addon page view.

--- a/includes/class-wc-calypso-bridge-addons-screen.php
+++ b/includes/class-wc-calypso-bridge-addons-screen.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.6
- * @version 2.0.4
+ * @version 2.0.8
  */
 
 /**

--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -86,8 +86,7 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 
 
 			// Hide Tools > Marketing and Tools > Earn submenus.
-			$status       = new \Automattic\Jetpack\Status();
-			$site_suffix  = $status->get_site_suffix();
+			$site_suffix  = WC_Calypso_Bridge_Instance()->get_site_slug();
 			$this->hide_submenu_page( 'tools.php', sprintf( 'https://wordpress.com/marketing/tools/%s', $site_suffix ) );
 			$this->hide_submenu_page( 'tools.php', sprintf( 'https://wordpress.com/earn/%s', $site_suffix ) );
 

--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -4,7 +4,7 @@
  * Class Ecommerce_Atomic_Admin_Menu.
  *
  * @since   1.9.8
- * @version 2.0.6
+ * @version 2.0.8
  *
  * The admin menu controller for Ecommerce WoA sites.
  */

--- a/includes/class-wc-calypso-bridge-free-trial-payment-restrictions.php
+++ b/includes/class-wc-calypso-bridge-free-trial-payment-restrictions.php
@@ -365,8 +365,7 @@ class WC_Calypso_Bridge_Free_Trial_Payment_Restrictions {
 				return;
 			}
 
-			$site_slug = ( new \Automattic\Jetpack\Status() )->get_site_suffix();
-			$plan_url  = 'https://wordpress.com/plans/' . $site_slug;
+			$plan_url  = sprintf( 'https://wordpress.com/plans/%s',  WC_Calypso_Bridge_Instance()->get_site_slug() );
 			$message   = sprintf( __( 'Only Administrators and Store Managers can place orders during the free trial. If you are ready to accept payments from customers, <a href="%s">upgrade to a paid plan</a>.', 'wc-calypso-bridge' ), $plan_url );
 
 			?>

--- a/includes/class-wc-calypso-bridge-free-trial-payment-restrictions.php
+++ b/includes/class-wc-calypso-bridge-free-trial-payment-restrictions.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   2.0.4
- * @version 2.0.4
+ * @version 2.0.8
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-notice.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-notice.php
@@ -4,7 +4,7 @@
  * Class WC_Calypso_Bridge_Free_Trial_Orders_Notice.
  *
  * @since   2.0.5
- * @version 2.0.5
+ * @version 2.0.8
  *
  * Renders an admin notice on Orders page.
  */

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-notice.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-notice.php
@@ -61,10 +61,7 @@ class WC_Calypso_Bridge_Free_Trial_Orders_Notice  {
 	 * @return string
 	 */
 	public function get_action_url() {
-		$status      = new \Automattic\Jetpack\Status();
-		$site_suffix = $status->get_site_suffix();
-
-		return sprintf( "https://wordpress.com/plans/%s", $site_suffix );
+		return sprintf( "https://wordpress.com/plans/%s", WC_Calypso_Bridge_Instance()->get_site_slug() );
 	}
 
 }

--- a/includes/tasks/class-wc-calypso-task-add-domain.php
+++ b/includes/tasks/class-wc-calypso-task-add-domain.php
@@ -8,7 +8,7 @@ use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
  * Add domain Task
  *
  * @since   1.9.12
- * @version 2.0.5
+ * @version 2.0.8
  */
 class AddDomain extends Task {
 

--- a/includes/tasks/class-wc-calypso-task-add-domain.php
+++ b/includes/tasks/class-wc-calypso-task-add-domain.php
@@ -65,7 +65,7 @@ class AddDomain extends Task {
 	 * @return string
 	 */
 	public function get_action_url() {
-		$site_suffix = wc_calypso_bridge_get_site_slug();
+		$site_suffix = WC_Calypso_Bridge_Instance()->get_site_slug();
 		$domain_path = sprintf( "https://wordpress.com/domains/add/%s", $site_suffix );
 		$home_url    = \home_url( '', 'https' );
 

--- a/includes/tasks/class-wc-calypso-task-add-domain.php
+++ b/includes/tasks/class-wc-calypso-task-add-domain.php
@@ -65,8 +65,7 @@ class AddDomain extends Task {
 	 * @return string
 	 */
 	public function get_action_url() {
-		$status      = new \Automattic\Jetpack\Status();
-		$site_suffix = $status->get_site_suffix();
+		$site_suffix = wc_calypso_bridge_get_site_slug();
 		$domain_path = sprintf( "https://wordpress.com/domains/add/%s", $site_suffix );
 		$home_url    = \home_url( '', 'https' );
 

--- a/includes/tasks/class-wc-calypso-task-launch-site.php
+++ b/includes/tasks/class-wc-calypso-task-launch-site.php
@@ -7,8 +7,8 @@ use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
 /**
  * Launch Site Task
  *
- * @since   1.9.12.
- * @version 1.9.12.
+ * @since   1.9.12
+ * @version 2.0.8
  */
 class LaunchSite extends Task {
 
@@ -88,7 +88,7 @@ class LaunchSite extends Task {
 
 	/**
 	 * The task should not be displayed if the site is on the eCommerce trial.
-	 * 
+	 *
 	 * @return bool
 	 */
 	public function can_view() {

--- a/includes/tasks/class-wc-calypso-task-launch-site.php
+++ b/includes/tasks/class-wc-calypso-task-launch-site.php
@@ -74,10 +74,7 @@ class LaunchSite extends Task {
 	 * @return string|null
 	 */
 	public function get_action_url() {
-		$status      = new \Automattic\Jetpack\Status();
-		$site_suffix = $status->get_site_suffix();
-
-		return ! $this->is_complete() ? null : sprintf( "https://wordpress.com/settings/general/%s#site-privacy-settings", $site_suffix );
+		return ! $this->is_complete() ? null : sprintf( "https://wordpress.com/settings/general/%s#site-privacy-settings", WC_Calypso_Bridge_Instance()->get_site_slug() );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 2.0.8 =
+* Introduce site slug helper function #1025.
+
 = 2.0.7 =
 * Free trial: Update notice messages and other copies #1022.
 * Add free trial plan picker banner #917

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -61,3 +61,23 @@ if ( ! wc_calypso_bridge_has_ecommerce_features() ) {
 	require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/store-on-wpcom/class-wc-calypso-bridge.php';
 	return;
 }
+
+if ( ! function_exists( 'wc_calypso_bridge_get_site_slug' ) ) {
+	/**
+	 * Defensive helper function to return the current site slug in a way that will work
+	 * when Automattic\Jetpack\Status hasn't been loaded by the Jetpack plugin.
+	 *
+	 * @return string
+	 */
+	function wc_calypso_bridge_get_site_slug() {
+		if ( class_exists( '\Automattic\Jetpack\Status' ) ) {
+			$jetpack_status = new \Automattic\Jetpack\Status();
+
+			return $jetpack_status->get_site_suffix();
+		}
+
+		$home_url = home_url( '', 'https' );
+
+		return substr( $home_url, 8 );
+	}
+}

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -61,23 +61,3 @@ if ( ! wc_calypso_bridge_has_ecommerce_features() ) {
 	require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/store-on-wpcom/class-wc-calypso-bridge.php';
 	return;
 }
-
-if ( ! function_exists( 'wc_calypso_bridge_get_site_slug' ) ) {
-	/**
-	 * Defensive helper function to return the current site slug in a way that will work
-	 * when Automattic\Jetpack\Status hasn't been loaded by the Jetpack plugin.
-	 *
-	 * @return string
-	 */
-	function wc_calypso_bridge_get_site_slug() {
-		if ( class_exists( '\Automattic\Jetpack\Status' ) ) {
-			$jetpack_status = new \Automattic\Jetpack\Status();
-
-			return $jetpack_status->get_site_suffix();
-		}
-
-		$home_url = home_url( '', 'https' );
-
-		return substr( $home_url, 8 );
-	}
-}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a defensive `get_site_slug()` helper function to `WC_Calypso_Bridge_Instance`. We've seen fatals in production due to the `Automattic\Jetpack\Status` class not existing (though it _should_ be autoloaded by Jetpack), so this PR adds a wrapper function that should still work in cases where the Jetpack class isn't present. When that class doesn't exist, we fall back on using `home_url()` to identify the primary location of the site. While this isn't foolproof, it shouldn't break as badly.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

I am honestly not sure how best to test the failing case for this effectively, as we haven't triggered the fatals on dev sites.

However, we should do the following happy path testing to verify that the changes are working when the Jetpack code is loaded:
* Apply these changes to a development site -- see peapX7-1D4-p2 for instructions on setting one up
* Verify that the following links are correct:
  - The _Add a domain_ task in the onboarding checklist
  - The site launch task (which is only visible for upgraded sites)
  - _Extensions_ -> _Discover_ - the "Upgrade now" CTA should point at `/plans/:siteSlug`
  - The Earn and Marketing Tools submenu items are _not_ visible in the Tools menu
  - _Settings_ -> _WooCommerce_ -> "Payments" tab -- verify the "upgrade to a paid plan" links to `/plans/:siteSlug` in the "Only Administrators and Store Managers can place orders..." notice
  - _Orders_ -> _Orders_ -- verify the "Upgrade now" CTA points at `/plans/:siteSlug`
  - 
<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.