### PR TITLE
Prepare to release 2.0.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v2.0.6",
+  "version": "v2.0.7",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -22,7 +22,7 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
-= Unreleased =
+= 2.0.7 =
 * Free trial: Update notice messages and other copies #1022.
 * Add free trial plan picker banner #917
 * Add wcadmin_free_trial_upgrade_now track for task_list and marketing sources #1023.

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancements for users of Store on WordPress.com.
- * Version: 2.0.6
+ * Version: 2.0.7
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -47,7 +47,7 @@ if ( ! defined( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH' ) ) {
 	define( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH', dirname( __FILE__ ) );
 }
 if ( ! defined( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION' ) ) {
-	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.0.6' );
+	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.0.7' );
 }
 if ( ! defined( 'WC_MIN_VERSION' ) ) {
 	define( 'WC_MIN_VERSION', '7.3' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR is to release 2.0.7.

- Please take a look at the changes: https://github.com/Automattic/wc-calypso-bridge/compare/release/2.0.6...release/2.0.7
- Please look at the version bumps


💡 Please update the list below

## Related PRs
* #1022.
* #917
* #1023.
* #1024.

## Changelog

```
= 2.0.7 =
* Free trial: Update notice messages and other copies #1022.
* Add free trial plan picker banner #917
* Add wcadmin_free_trial_upgrade_now track for task_list and marketing sources #1023.
* Add wcadmin_free_trial_learn_more track #1024.
```

