### PR TITLE
Ensure that Calypso Plugins menu item is not added for eCommerce trials

### DIFF
--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -95,6 +95,20 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 	}
 
 	/**
+	 * Override the base implementation of add_plugins_menu() to avoid
+	 * adding the Plugins menu for eCommerce trials.
+	 *
+	 * @return void
+	 */
+	public function add_plugins_menu() {
+		if ( wc_calypso_bridge_is_ecommerce_trial_plan() ) {
+			return;
+		}
+
+		return parent::add_plugins_menu();
+	}
+
+	/**
 	 * Groups WooCommerce items.
 	 */
 	public static function menu_order( $menu_order ) {

--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -4,7 +4,7 @@
  * Class Ecommerce_Atomic_Admin_Menu.
  *
  * @since   1.9.8
- * @version 2.0.6
+ * @version x.x.x
  *
  * The admin menu controller for Ecommerce WoA sites.
  */
@@ -98,6 +98,9 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 	 * Override the base implementation of add_plugins_menu() to avoid
 	 * adding the Plugins menu for eCommerce trials.
 	 *
+	 * @since   x.x.x
+	 * @version x.x.x
+	 *
 	 * @return void
 	 */
 	public function add_plugins_menu() {
@@ -181,7 +184,7 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 	}
 
 	/**
-	 * Fixes the menu highligting based on the changes of the self::add_woocommerce_menu.
+	 * Fixes the menu highlighting based on the changes of the self::add_woocommerce_menu.
 	 *
 	 * @param  string  $submenu_file
 	 * @return string

--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -4,7 +4,7 @@
  * Class Ecommerce_Atomic_Admin_Menu.
  *
  * @since   1.9.8
- * @version x.x.x
+ * @version 2.0.8
  *
  * The admin menu controller for Ecommerce WoA sites.
  */
@@ -98,8 +98,8 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 	 * Override the base implementation of add_plugins_menu() to avoid
 	 * adding the Plugins menu for eCommerce trials.
 	 *
-	 * @since   x.x.x
-	 * @version x.x.x
+	 * @since   2.0.8
+	 * @version 2.0.8
 	 *
 	 * @return void
 	 */

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 2.0.5
+Stable tag: 2.0.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,7 +22,7 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
-= unreleased =
+= 2.0.8 =
 * Free trial: Avoid adding the Plugins menu for eCommerce trials #1027.
 
 = 2.0.7 =

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= unreleased =
+* Free trial: Avoid adding the Plugins menu for eCommerce trials #1027.
+
 = 2.0.7 =
 * Free trial: Update notice messages and other copies #1022.
 * Add free trial plan picker banner #917


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This change ensures that we don't add the _Plugins_ menu item when users are on the eCommerce trial. We do that by overriding the inherited function, and only invoking the parent's logic when we're not in the free trial.

Related to Automattic/wp-calypso#73753.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Ensure that you have a WoA development site -- you can follow these instructions if you don't have one yet: peapX7-1D4-p2
2. Apply this change to the relevant files on your site -- this file should be in `wp-content/mu-plugins/wpcomsh/vendor/automattic/wc-calypso-bridge/includes/` (and there may be a leading `htdocs` folder if you're using SSH; it's not there if you're using SFTP)
3. Navigate to a Calypso page for your site, e.g. `/plans/:siteSlug`
4. Verify that no _Plugins_ menu is visible
5. Navigate to a wp-admin page, like _My Home_.
6. Verify that the _Plugins_ menu is not present.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.