### PR TITLE
Free Trial: Fix error when calling wp.hooks.addFilter and gutenberg is deactivated

### DIFF
--- a/includes/class-wc-calypso-bridge-free-trial-payment-restrictions.php
+++ b/includes/class-wc-calypso-bridge-free-trial-payment-restrictions.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   2.0.4
- * @version x.x.x
+ * @version 2.0.8
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-calypso-bridge-free-trial-payment-restrictions.php
+++ b/includes/class-wc-calypso-bridge-free-trial-payment-restrictions.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   2.0.4
- * @version 2.0.4
+ * @version x.x.x
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -301,8 +301,7 @@ class WC_Calypso_Bridge_Free_Trial_Payment_Restrictions {
 					return translation;
 				}
 
-				// Adding the filter
-				wp.hooks.addFilter(
+				window.wp && window.wp.hooks && window.wp.hooks.addFilter(
 					'i18n.gettext_woocommerce',
 					'wc-calypso-bridge/override-no-payment-methods-message',
 					overrideNoPaymentMethodsMessage


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

