### PR TITLE
Fix tracking issues with business sites

### DIFF
--- a/includes/class-wc-calypso-bridge-tracks.php
+++ b/includes/class-wc-calypso-bridge-tracks.php
@@ -46,13 +46,6 @@ class WC_Calypso_Bridge_Tracks {
 	private function __construct() {
 
 		/**
-		 * Always make the tracks setting be yes. Users can opt via WordPress.com privacy settings.
-		 */
-		add_filter( 'pre_option_woocommerce_allow_tracking', static function() {
-			return 'yes';
-		} );
-
-		/**
 		 * Init tracking configuration.
 		 */
 		add_action( 'init', array( $this, 'init' ) );

--- a/includes/class-wc-calypso-bridge-tracks.php
+++ b/includes/class-wc-calypso-bridge-tracks.php
@@ -6,7 +6,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.1.6
- * @version 2.0.5
+ * @version 2.0.9
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -52,10 +52,9 @@ class WC_Calypso_Bridge_Tracks {
 			return 'yes';
 		} );
 
-		if ( ! wc_calypso_bridge_has_ecommerce_features() ) {
-			return;
-		}
-
+		/**
+		 * Init tracking configuration.
+		 */
 		add_action( 'init', array( $this, 'init' ) );
 	}
 

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -53,6 +53,13 @@ if ( ! defined( 'WC_MIN_VERSION' ) ) {
 	define( 'WC_MIN_VERSION', '7.3' );
 }
 
+/**
+ * Always make the tracks setting be yes. Users can opt via WordPress.com privacy settings.
+ */
+add_filter( 'pre_option_woocommerce_allow_tracking', function() {
+	return 'yes';
+} );
+
 // The Bridge Main Controller.
 require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/class-wc-calypso-bridge-dotcom-features.php';
 require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/class-wc-calypso-bridge.php';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1033

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Open a business, ecommerce, and a free trial ecommerce site in a wp-admin page.
2. Ensure by visiting the page's source code that near the "woocommerce_tracks_client_event_properties" _(hint: Use cmd + F)_ the values are respectively "bizplan-wp-admin", "ecommplan", and "ecommplan-freetrial". 

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
