### PR TITLE
Create navigation menus with new slugs

### DIFF
--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 2.0.5
+ * @version 2.0.10
  */
 
 use Automattic\WooCommerce\Admin\WCAdminHelper;
@@ -287,8 +287,17 @@ class WC_Calypso_Bridge_Setup {
 				WC_Install::create_pages();
 
 				// Get navigation menu page and set up the menu.
-				$menu_page_post = get_page_by_path( 'primary', OBJECT, 'wp_navigation' );
-				if ( is_a( $menu_page_post, 'WP_Post' ) ) {
+				$menu_page_slugs = array(
+					'primary',
+					'header-navigation',
+				);
+
+				foreach ( $menu_page_slugs as $menu_page_slug ) {
+					$menu_page_post = get_page_by_path( $menu_page_slug, OBJECT, 'wp_navigation' );
+
+					if ( ! is_a( $menu_page_post, 'WP_Post' ) ) {
+						continue;
+					}
 
 					$menu_pages = array(
 						'shop'       => get_post( get_option( 'woocommerce_shop_page_id' ) ),
@@ -319,7 +328,9 @@ class WC_Calypso_Bridge_Setup {
 						'post_content' => $menu_content,
 					) );
 
+
 				}
+
 
 				$wpdb->query(
 					$wpdb->prepare( "

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -328,9 +328,7 @@ class WC_Calypso_Bridge_Setup {
 						'post_content' => $menu_content,
 					) );
 
-
 				}
-
 
 				$wpdb->query(
 					$wpdb->prepare( "

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 2.0.10 =
+* Create navigation menus with new slugs #xxx.
+
 = 2.0.9 =
 * Fix an issue with the WC Tracker #1034.
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Menu items were created in this PR 
- #999 

At that time, the `wp_nagivation` post's title was `primary` - We noticed that new sites are created with `header-navigation` .

So, I've created an array of slugs, to cover both cases and be prepared for any future changes.

Closes #1038  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:


You can find testing instructions in PR #999 


<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
