### PR TITLE
fix: added !important to snackbar positioning so that it's not overriden

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleased =
+* Fixed css conflict for snackbar
+
 = 2.0.10 =
 * Create navigation menus with new slugs #1039.
 

--- a/src/task-completion/style.scss
+++ b/src/task-completion/style.scss
@@ -33,3 +33,8 @@ $ces-feedback-height: 64px;
 	padding-top: 32px;
 	padding-bottom: 8px;
 }
+
+.woocommerce-transient-notices {
+	// there's an ordering conflict which causes this to be overriden by the styles from .components-snackbar-list
+	position: fixed !important; 
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The positioning rule from .components-snackbar-list is causing the snackbar to be located at the bottom of the page, so it is not visible if you haven't scrolled to the bottom of the content.

Add !important to the positioning of the snackbar so that it's not overriden by styles for .components-snackbar-list

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Setup your test site with this change on it
2. Run `wp.data.dispatch('core/notices').createErrorNotice("test snackbar")` in the browser console to trigger a notice
3. Should be able to see the snackbar notice even if you haven't scrolled to the bottom of the page content

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
