### PR TITLE
Remove default store notice

### DIFF
--- a/includes/class-wc-calypso-bridge-themes-setup.php
+++ b/includes/class-wc-calypso-bridge-themes-setup.php
@@ -103,7 +103,6 @@ class WC_Calypso_Bridge_Themes_Setup {
 			set_theme_mod( 'sp_homepage_on_sale', false ); // Removes On Sale Products area from starter content.
 			set_theme_mod( 'sp_homepage_best_sellers', false ); // Removes Best Sellers Products area from starter content.
 			update_option( 'woocommerce_demo_store', 'yes' ); // enables demo store notice.
-			update_option( 'woocommerce_demo_store_notice', __( 'This is an example of a sitewide notice - you can change or remove this text in the Customizer under "Store Notice"', 'wc-calypso-bridge' ) ); // Default store notice message.
 			// Force Fresh Site.
 			update_option( 'fresh_site', true );
 			// Save option that says the setup has been run already.

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,9 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 = Unreleased =
-* Fixed css conflict for snackbar
+* Fixed css conflict for snackbar #1041
+* Add avalara plugin to Tax task #1032
+* Remove default store notice #1053
 
 = 2.0.10 =
 * Create navigation menus with new slugs #1039.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Partially fix https://github.com/Automattic/wc-calypso-bridge/issues/1028.

Remote store notice from Personalize your store task

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?
 
1. Delete `woocommerce_demo_store_notice`  and `wpcom_ec_plan_theme_defaults` options or use a fresh site
2. Go to `WooCommerce > Home > Personalize your store` task
3. Go to `Set a store notice` step
4. Observe that the input box is blank

![Screenshot 2023-03-16 at 12 04 23](https://user-images.githubusercontent.com/4344253/225511620-80f3786c-18c8-4ca8-8dd7-41a7623456f8.png)


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
