### PR TITLE
Remove homepage step from Personalize task for Tsubaki theme

### DIFF
--- a/includes/class-wc-calypso-bridge-setup-tasks.php
+++ b/includes/class-wc-calypso-bridge-setup-tasks.php
@@ -125,9 +125,15 @@ class WC_Calypso_Bridge_Setup_Tasks {
 	public function replace_tasks( $lists ) {
 		if ( isset( $lists['setup'] ) ) {
 			foreach ($lists['setup']->tasks as $index => $task) {
-				if ( $task->get_id() === 'products' ) {
-					require_once __DIR__ . '/tasks/class-wc-calypso-task-headstart-products.php';
-					$lists['setup']->tasks[$index] = new \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\HeadstartProducts( $lists['setup'] );
+				switch ( $task->get_id() ) {
+					case 'products':
+						require_once __DIR__ . '/tasks/class-wc-calypso-task-headstart-products.php';
+						$lists['setup']->tasks[$index] = new \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\HeadstartProducts( $lists['setup'] );
+							break;
+					case 'appearance':
+						require_once __DIR__ . '/tasks/class-wc-calypso-task-appearance.php';
+						$lists['setup']->tasks[$index] = new \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\WCBridgeAppearance( $lists['setup'] );
+							break;
 				}
 			}
 		}

--- a/includes/tasks/class-wc-calypso-task-appearance.php
+++ b/includes/tasks/class-wc-calypso-task-appearance.php
@@ -29,6 +29,7 @@ class WCBridgeAppearance extends Appearance {
 	 * Check if the site has a homepage set up.
 	 */
 	public static function has_homepage() {
+		// Temporary hotfix, we should implement a better solution in Core.
 		$themes_no_need_homepage = array(
 			'Tsubaki',
 		);

--- a/includes/tasks/class-wc-calypso-task-appearance.php
+++ b/includes/tasks/class-wc-calypso-task-appearance.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks;
+
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Appearance;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\HeadstartProducts;
+
+/**
+ * WCBridgeAppearance Task
+ *
+ * @since   2.0.11
+ * @version 2.0.11
+ */
+class WCBridgeAppearance extends Appearance {
+	/**
+	 * Addtional data.
+	 *
+	 * @return array
+	 */
+	public function get_additional_data() {
+		return array(
+			'has_homepage' => self::has_homepage(),
+			'has_products' => HeadstartProducts::has_products(),
+			'stylesheet'   => get_option( 'stylesheet' ),
+			'theme_mods'   => get_theme_mods(),
+		);
+	}
+	/**
+	 * Check if the site has a homepage set up.
+	 */
+	public static function has_homepage() {
+		$themes_no_need_homepage = array(
+			'Tsubaki',
+		);
+		if ( in_array( wp_get_theme()->get( 'Name' ), $themes_no_need_homepage, true ) ) {
+			return true;
+		}
+
+		return Appearance::has_homepage();
+	}
+}

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,7 @@ This section describes how to install the plugin and get it working.
 
 = Unreleased =
 * Fixed css conflict for snackbar
+* Remove homepage step from Personalize task for Tsubaki theme #1054.
 
 = 2.0.10 =
 * Create navigation menus with new slugs #1039.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/Automattic/wc-calypso-bridge/issues/1028.

This PR removes the homepage step from Personalize task for Tsubaki theme.


<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Set up a free trial site
2. Go to WooCommerce > Home > Personalize task
3. Observe that the home page step is not shown.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
