### PR TITLE
Implement wp-admin redirects for expired eCommerce trials

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -120,6 +120,7 @@ class WC_Calypso_Bridge {
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-plugins.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-addons.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-free-trial-payment-restrictions.php';
+		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/free-trial/class-wc-calypso-bridge-free-trial-expired-plan-redirects.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/free-trial/class-wc-calypso-bridge-free-trial-hide-tasklist-tasks.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-free-trial-payment-task.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-changes.php';

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v2.0.11",
+  "version": "v2.0.12",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-expired-plan-redirects.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-expired-plan-redirects.php
@@ -76,7 +76,9 @@ class WC_Calypso_Bridge_Free_Trial_Expired_Plan_Redirects
 			}
 		);
 
-		// TODO: if we don't have a trial plan purchase, should we still redirect?
+		// If we don't have a trial plan purchase, we either have no purchase,
+		// or we have some other eCommerce plan.
+		// We want to bail either way.
 		if ( empty( $trial_plan_purchases ) ) {
 			return;
 		}

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-expired-plan-redirects.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-expired-plan-redirects.php
@@ -72,7 +72,7 @@ class WC_Calypso_Bridge_Free_Trial_Expired_Plan_Redirects
 		$trial_plan_purchases = array_filter(
 			$site_purchases,
 			function ( $site_purchase ) {
-				return 'ecommerce-trial-bundle-monthly' === ( $site_purchase['product_slug'] ?? null );
+				return 'ecommerce-trial-bundle-monthly' === $site_purchase->product_slug;
 			}
 		);
 
@@ -89,8 +89,8 @@ class WC_Calypso_Bridge_Free_Trial_Expired_Plan_Redirects
 
 		if (
 			$trial_plan_purchase
-			&& ! empty( $trial_plan_purchase['expiry_time'] )
-			&& $trial_plan_purchase['expiry_time'] < $current_timestamp
+			&& ! empty( $trial_plan_purchase->expiry_date )
+			&& $trial_plan_purchase->expiry_date < $current_timestamp
 		) {
 			$expired_trial_url = 'https://wordpress.com/plans/my-plan/trial-expired/' . WC_Calypso_Bridge_Instance()->get_site_slug();
 

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-expired-plan-redirects.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-expired-plan-redirects.php
@@ -3,8 +3,8 @@
 /**
  * Class WC_Calypso_Bridge_Free_Trial_Expired_Plan_Redirects.
  *
- * @since   2.0.9
- * @version 2.0.9
+ * @since   2.0.12
+ * @version 2.0.12
  *
  * Detects when we have an expired eCommerce trial plan, and redirects to Calypso for that case.
  */
@@ -14,14 +14,14 @@ class WC_Calypso_Bridge_Free_Trial_Expired_Plan_Redirects
 	/**
 	 * The single instance of the class.
 	 *
-	 * @var object
+	 * @var WC_Calypso_Bridge_Free_Trial_Expired_Plan_Redirects
 	 */
 	protected static $instance = null;
 
 	/**
 	 * Get class instance.
 	 *
-	 * @return object Instance.
+	 * @return WC_Calypso_Bridge_Free_Trial_Expired_Plan_Redirects Instance.
 	 */
 	final public static function get_instance() {
 		if ( is_null( self::$instance ) ) {

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-expired-plan-redirects.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-expired-plan-redirects.php
@@ -63,6 +63,10 @@ class WC_Calypso_Bridge_Free_Trial_Expired_Plan_Redirects
 			return;
 		}
 
+		if ( ! function_exists( 'wpcom_get_site_purchases' ) || ! function_exists( 'wpcom_datetime_to_iso8601' ) ) {
+			return;
+		}
+
 		$site_purchases = wpcom_get_site_purchases();
 
 		$trial_plan_purchases = array_filter(

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-expired-plan-redirects.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-expired-plan-redirects.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Class WC_Calypso_Bridge_Free_Trial_Expired_Plan_Redirects.
+ *
+ * @since   2.0.9
+ * @version 2.0.9
+ *
+ * Detects when we have an expired eCommerce trial plan, and redirects to Calypso for that case.
+ */
+class WC_Calypso_Bridge_Free_Trial_Expired_Plan_Redirects
+
+{
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var object
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return object Instance.
+	 */
+	final public static function get_instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	public function __construct() {
+		if ( ! wc_calypso_bridge_is_ecommerce_trial_plan() ) {
+			return;
+		}
+
+		add_action( 'admin_init', array( $this, 'maybe_redirect_wp_admin_to_expired_plan_page' ) );
+	}
+
+	/**
+	 * When we are handling an incoming WP Admin UI request
+	 * AND the site has an expired eCommerce trial,
+	 * redirect to the expired trial page in Calypso.
+	 *
+	 * @return void
+	 */
+	public function maybe_redirect_wp_admin_to_expired_plan_page() {
+		if ( ! wc_calypso_bridge_is_ecommerce_trial_plan() ) {
+			return;
+		}
+
+		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+			return;
+		}
+
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+			return;
+		}
+
+		if ( defined( 'REST_API_REQUEST' ) && REST_API_REQUEST ) {
+			return;
+		}
+
+		$site_purchases = wpcom_get_site_purchases();
+
+		$trial_plan_purchases = array_filter(
+			$site_purchases,
+			function ( $site_purchase ) {
+				return 'ecommerce-trial-bundle-monthly' === ( $site_purchase['product_slug'] ?? null );
+			}
+		);
+
+		// TODO: if we don't have a trial plan purchase, should we still redirect?
+		if ( empty( $trial_plan_purchases ) ) {
+			return;
+		}
+
+		$trial_plan_purchase = array_shift( $trial_plan_purchases );
+
+		$current_timestamp = wpcom_datetime_to_iso8601( 'now' );
+
+		if (
+			$trial_plan_purchase
+			&& isset( $trial_plan_purchase['expiry_time'] )
+			&& $trial_plan_purchase['expiry_time'] < $current_timestamp
+		) {
+			$expired_trial_url = 'https://wordpress.com/plans/my-plan/trial-expired/' . WC_Calypso_Bridge_Instance()->get_site_slug();
+
+			wp_redirect( $expired_trial_url );
+			exit;
+		}
+	}
+}
+
+WC_Calypso_Bridge_Free_Trial_Expired_Plan_Redirects::get_instance();

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-expired-plan-redirects.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-expired-plan-redirects.php
@@ -87,7 +87,7 @@ class WC_Calypso_Bridge_Free_Trial_Expired_Plan_Redirects
 
 		if (
 			$trial_plan_purchase
-			&& isset( $trial_plan_purchase['expiry_time'] )
+			&& ! empty( $trial_plan_purchase['expiry_time'] )
 			&& $trial_plan_purchase['expiry_time'] < $current_timestamp
 		) {
 			$expired_trial_url = 'https://wordpress.com/plans/my-plan/trial-expired/' . WC_Calypso_Bridge_Instance()->get_site_slug();

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 2.0.11
+Stable tag: 2.0.12
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ This section describes how to install the plugin and get it working.
 1. Activate the plugin through the 'Plugins' screen in WordPress
 
 == Changelog ==
+
+= 2.0.12 =
+* Redirect admin pages to the Calypso upgrade page for free trials #1055.
 
 = 2.0.11 =
 * Fix css conflict for snackbar #1041


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR ensures that when users have an expired free eCommerce trial and visit a page in wp-admin, we will correctly redirect them to the expired trial page in Calypso.

Closes:
* #1005

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

* Set up a WoA dev site that has a _valid_ free eCommerce trial plan - you can do this by following the instructions here: peapX7-1D4-p2
* Upload the changes from this PR to your site -- the code is under `wp-content/mu-plugins/wpcomsh/vendor/automattic/wc-calypso-bridge/`
* Navigate to various pages in the UI, especially in wp-admin, and verify that you don't get any errors, and see the pages you are trying to access
* Use Store Admin to modify the expiration date of your free trial plan to be a date in the past (ideally 1-3 days in the past)
* Wait a few moments, and then try to visit various pages in wp-admin for your site e.g. `/wp-admin/`, `/wp-admin/edit.php`, `/wp-admin/admin.php?page=wc-admin`
* Verify that you are redirected to the expired trial page in Calypso for any `/wp-admin/` page you try to visit
* Now upgrade the plan for your site
 - Note that the post-purchase code may redirect you back to the expired trial site - see Automattic/calypso#74785
* Repeat the tests for various wp-admin pages in your site
* Verify that you can access them all again

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.