### PR TITLE
Prepare to release 2.0.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v2.1.0",
+  "version": "v2.0.11",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v2.0.10",
+  "version": "v2.1.0",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 2.1.0
+Stable tag: 2.0.11
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,7 +22,7 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
-= 2.1.0 =
+= 2.0.11 =
 * Fix css conflict for snackbar #1041
 * Add avalara plugin to Tax task #1032
 * Remove default store notice #1053

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 2.0.8
+Stable tag: 2.1.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,8 +22,8 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
-= Unreleased =
-* Fixed css conflict for snackbar #1041
+= 2.1.0 =
+* Fix css conflict for snackbar #1041
 * Add avalara plugin to Tax task #1032
 * Remove default store notice #1053
 * Remove homepage step from Personalize task for Tsubaki theme #1054.

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancements for users of Store on WordPress.com.
- * Version: 2.1.0
+ * Version: 2.0.11
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -47,7 +47,7 @@ if ( ! defined( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH' ) ) {
 	define( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH', dirname( __FILE__ ) );
 }
 if ( ! defined( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION' ) ) {
-	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.1.0' );
+	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.0.11' );
 }
 if ( ! defined( 'WC_MIN_VERSION' ) ) {
 	define( 'WC_MIN_VERSION', '7.3' );
@@ -56,9 +56,12 @@ if ( ! defined( 'WC_MIN_VERSION' ) ) {
 /**
  * Always make the tracks setting be yes. Users can opt via WordPress.com privacy settings.
  */
-add_filter( 'pre_option_woocommerce_allow_tracking', function() {
-	return 'yes';
-} );
+add_filter(
+	'pre_option_woocommerce_allow_tracking',
+	function() {
+		return 'yes';
+	}
+);
 
 // The Bridge Main Controller.
 require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/class-wc-calypso-bridge-dotcom-features.php';

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancements for users of Store on WordPress.com.
- * Version: 2.0.10
+ * Version: 2.1.0
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -47,7 +47,7 @@ if ( ! defined( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH' ) ) {
 	define( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH', dirname( __FILE__ ) );
 }
 if ( ! defined( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION' ) ) {
-	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.0.10' );
+	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.1.0' );
 }
 if ( ! defined( 'WC_MIN_VERSION' ) ) {
 	define( 'WC_MIN_VERSION', '7.3' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR is to release 2.0.11.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).
   * All testing should have been performed in the original PRs

## Related PRs
* #1041
* #1032
* #1053
* #1054.
* #1050.

## Changelog
```
= 2.0.11 =
* Fix css conflict for snackbar #1041
* Add avalara plugin to Tax task #1032
* Remove default store notice #1053
* Remove homepage step from Personalize task for Tsubaki theme #1054.
* Increase WC Tracker frequency to run on a daily basis for the first 3 months #1050.
```
