### PR TITLE
Customize Store_Details task for free trial

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -127,6 +127,7 @@ class WC_Calypso_Bridge {
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/free-trial/class-wc-calypso-bridge-free-trial-wc-payments.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/free-trial/class-wc-calypso-bridge-free-trial-plan-picker-banner.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-notice.php';
+		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-free-trial-store-details-task.php';
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-free-trial-store-details-task.php
+++ b/includes/class-wc-calypso-bridge-free-trial-store-details-task.php
@@ -4,7 +4,7 @@
 /**
  * Class WC_Calypso_Bridge_Free_Trial_Store_Details_Task.
  *
- * @since   2.0.14
+ * @since   2.0.15
  * @version 2.0.15
  *
  */

--- a/includes/class-wc-calypso-bridge-free-trial-store-details-task.php
+++ b/includes/class-wc-calypso-bridge-free-trial-store-details-task.php
@@ -1,0 +1,54 @@
+<?php
+
+
+/**
+ * Class WC_Calypso_Bridge_Free_Trial_Store_Details_Task.
+ *
+ * @since   2.0.12
+ * @version 2.0.12
+ *
+ */
+class WC_Calypso_Bridge_Free_Trial_Store_Details_Task
+{
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var object
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return object Instance.
+	 */
+	final public static function get_instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	public function __construct() {
+		if ( ! wc_calypso_bridge_is_ecommerce_trial_plan() ) {
+			return;
+		}
+
+		add_filter( 'woocommerce_admin_experimental_onboarding_tasklists', [ $this, 'replace_store_details_task' ] );
+	}
+
+	public function replace_store_details_task( $lists ) {
+		if ( isset( $lists['setup'] ) ) {
+			foreach ($lists['setup']->tasks as $index => $task) {
+				if ( $task->get_id() === 'store_details' ) {
+					require_once __DIR__ . '/tasks/class-wc-calypso-task-free-trial-store-details.php';
+					$lists['setup']->tasks[$index] = new \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\TrialStoreDetails( $lists['setup'] );
+				}
+			}
+		}
+		return $lists;
+	}
+}
+
+WC_Calypso_Bridge_Free_Trial_Store_Details_Task::get_instance();

--- a/includes/class-wc-calypso-bridge-free-trial-store-details-task.php
+++ b/includes/class-wc-calypso-bridge-free-trial-store-details-task.php
@@ -5,7 +5,7 @@
  * Class WC_Calypso_Bridge_Free_Trial_Store_Details_Task.
  *
  * @since   2.0.14
- * @version 2.0.14
+ * @version 2.0.15
  *
  */
 class WC_Calypso_Bridge_Free_Trial_Store_Details_Task

--- a/includes/class-wc-calypso-bridge-free-trial-store-details-task.php
+++ b/includes/class-wc-calypso-bridge-free-trial-store-details-task.php
@@ -35,6 +35,12 @@ class WC_Calypso_Bridge_Free_Trial_Store_Details_Task
 			return;
 		}
 
+		add_filter( 'option_woocommerce_onboarding_profile', static function ( $option_value ) {
+			$value = $option_value ?? array();
+			$value['skipped'] = true;
+			return $value;
+		}, 100 );
+
 		add_filter( 'woocommerce_admin_experimental_onboarding_tasklists', [ $this, 'replace_store_details_task' ] );
 	}
 

--- a/includes/class-wc-calypso-bridge-free-trial-store-details-task.php
+++ b/includes/class-wc-calypso-bridge-free-trial-store-details-task.php
@@ -4,8 +4,8 @@
 /**
  * Class WC_Calypso_Bridge_Free_Trial_Store_Details_Task.
  *
- * @since   2.0.12
- * @version 2.0.12
+ * @since   2.0.14
+ * @version 2.0.14
  *
  */
 class WC_Calypso_Bridge_Free_Trial_Store_Details_Task

--- a/includes/class-wc-calypso-bridge-free-trial-store-details-task.php
+++ b/includes/class-wc-calypso-bridge-free-trial-store-details-task.php
@@ -35,12 +35,6 @@ class WC_Calypso_Bridge_Free_Trial_Store_Details_Task
 			return;
 		}
 
-		add_filter( 'option_woocommerce_onboarding_profile', static function ( $option_value ) {
-			$value = $option_value ?? array();
-			$value['skipped'] = true;
-			return $value;
-		}, 100 );
-
 		add_filter( 'woocommerce_admin_experimental_onboarding_tasklists', [ $this, 'replace_store_details_task' ] );
 	}
 

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -77,7 +77,9 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 		 * @return array
 		 */
 		add_filter( 'pre_option_woocommerce_onboarding_profile', static function ( $option_value ) {
-			return array( 'skipped' => true );
+			$value = $option_value ?? array();
+			$value['skipped'] = true;
+			return $value;
 		}, 100 );
 
 		/**

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -76,7 +76,7 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 		 * @param  mixed  $value
 		 * @return array
 		 */
-		add_filter( 'pre_option_woocommerce_onboarding_profile', static function ( $option_value ) {
+		add_filter( 'option_woocommerce_onboarding_profile', static function ( $option_value ) {
 			$value = $option_value ?? array();
 			$value['skipped'] = true;
 			return $value;

--- a/includes/tasks/class-wc-calypso-task-free-trial-store-details.php
+++ b/includes/tasks/class-wc-calypso-task-free-trial-store-details.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks;
+
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\StoreDetails;
+
+/**
+ * TrialStoreDetails Task
+ * 
+ * @since   2.0.12
+ * @version 2.0.12
+ */
+class TrialStoreDetails extends StoreDetails {
+	/**
+	 * Task completion.
+	 *
+	 * @return bool
+	 */
+	public function is_complete() {
+		return get_option( 'woocommerce_default_country', '' ) !== '';
+	}	
+}

--- a/includes/tasks/class-wc-calypso-task-free-trial-store-details.php
+++ b/includes/tasks/class-wc-calypso-task-free-trial-store-details.php
@@ -7,8 +7,8 @@ use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\StoreDetails;
 /**
  * TrialStoreDetails Task
  * 
- * @since   2.0.14
- * @version 2.0.14
+ * @since   2.0.15
+ * @version 2.0.15
  */
 class TrialStoreDetails extends StoreDetails {
 	/**

--- a/includes/tasks/class-wc-calypso-task-free-trial-store-details.php
+++ b/includes/tasks/class-wc-calypso-task-free-trial-store-details.php
@@ -7,8 +7,8 @@ use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\StoreDetails;
 /**
  * TrialStoreDetails Task
  * 
- * @since   2.0.12
- * @version 2.0.12
+ * @since   2.0.14
+ * @version 2.0.14
  */
 class TrialStoreDetails extends StoreDetails {
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -29,7 +29,6 @@ This section describes how to install the plugin and get it working.
 * Remove the onboarding purchase task #1060.
 * Add WooCommerce task list options to Jetpack Sync #1009.
 
-
 = 2.0.12 =
 * Redirect admin pages to the Calypso upgrade page for free trials #1055.
 

--- a/readme.txt
+++ b/readme.txt
@@ -23,6 +23,7 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 * Remove the onboarding purchase task #1060
+* Mark Store_Details task as complete for free trial #1061 
 
 = 2.0.12 =
 * Redirect admin pages to the Calypso upgrade page for free trials #1055.

--- a/readme.txt
+++ b/readme.txt
@@ -27,7 +27,6 @@ This section describes how to install the plugin and get it working.
 = 2.0.14 =
 * Make the free trial banner responsive #1066
 
-
 = 2.0.13 =
 * Remove the onboarding purchase task #1060.
 * Add WooCommerce task list options to Jetpack Sync #1009.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR overrides Store_Details to mark the task as complete for free trial sites. 

Closes #997  .


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Delete `woocommerce_store_address`, `woocommerce_store_city`, and `woocommerce_store_postcode` options. These three are used to [determine](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/StoreDetails.php#L71) task completion. 

2. Navigate to `WooCommerce -> Home` and confirm  `Add store details` task is not marked complete. 
3. Make sure `woocommerce_default_country` option is set.
4. Checkout this branch
5. Navigate to `WooCommerce -> Home` and confirm the Store_Details task is marked complete.



