### PR TITLE
Add filter to hide the generic site launch banner for eCommerce trials

### DIFF
--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-plan-picker-banner.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-plan-picker-banner.php
@@ -34,6 +34,11 @@ class WC_Calypso_Bridge_Free_Trial_Plan_Picker_Banner {
 			return;
 		}
 
+		/**
+		 * Disable the generic site launch banner for eCommerce trials.
+		 */
+		add_filter( 'wpcomsh_private_site_show_logged_in_banner', '__return_false' );
+
 		add_action('init', function() {
 			if ( current_user_can( 'manage_woocommerce' ) ) {
 				add_action( 'wp_head', array( $this, 'add_plan_picker_banner' ), -2000 );

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,7 @@ This section describes how to install the plugin and get it working.
 
 * Mark Store_Details task as complete for free trial #1061
 * Fix site launch checks #1073.
+* Hide site launch banner for eCommerce trials #1062.
 
 = 2.0.14 =
 * Make the free trial banner responsive #1066


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR leverages the new `wpcomsh_private_site_show_logged_in_banner` filter implemented in Automattic/wpcomsh#1329 to hide the generic site launch banner for eCommerce trials. We are already showing a separate banner for eCommerce trials, so we want to hide the generic one when that is the case.

Related to:
* Automattic/wpcomsh#1329

Closes Automattic/wp-calypso#74338 .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### Screenshots

#### Before
<img width="1025" alt="Screenshot 2023-03-31 at 14 05 05" src="https://user-images.githubusercontent.com/3376401/229115979-20148e8d-a4e1-45d2-84ef-073bb215dda8.png">

#### After
<img width="1025" alt="Screenshot 2023-03-31 at 14 02 25" src="https://user-images.githubusercontent.com/3376401/229116015-a66f0b93-899e-4221-80b8-dce21033d7c8.png">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Ensure that you have a WoA development site that is running the eCommerce trial - these instructions document how to do this: peapX7-1D4-p2
2. Ensure that your WoA development site is running a version of `wpcomsh` that includes Automattic/wpcomsh#1329 - patch it if needed
3. Visit the home page for your site while logged in (i.e. the actual home page, not Calypso or wp-admin)
4. Verify that you see both the generic launch banner and the "upgrade to a paid plan" banner
5. Apply this patch to your site
6. Reload the home page for your site
7. Verify that you see only the "upgrade to a paid plan" banner

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.