### PR TITLE
Make the free trial banner responsive

### DIFF
--- a/assets/css/free-trial-plan-picker-banner.css
+++ b/assets/css/free-trial-plan-picker-banner.css
@@ -28,6 +28,12 @@ body.has-free-trial-plan-picker .woocommerce-store-notice {
 	}
 }
 
+@media screen and (max-width: 480px) {
+	#free-trial-plan-picker-banner {
+		position: inherit;
+	}
+}
+
 body.hide-free-trial-plan-picker #free-trial-plan-picker-banner {
 	display: none;
 }

--- a/assets/css/free-trial-plan-picker-banner.css
+++ b/assets/css/free-trial-plan-picker-banner.css
@@ -4,7 +4,6 @@
 	font-size: 0.8125em;
 	position: sticky;
 	z-index: 99999;
-	width: 100%;
 	padding: 5px;
 	text-align: center;
 	top: calc( var( --wp-admin--admin-bar--height, 0px ) ) !important;

--- a/assets/css/free-trial-plan-picker-banner.css
+++ b/assets/css/free-trial-plan-picker-banner.css
@@ -3,7 +3,7 @@
 	color: #ffffff;
 	font-size: 0.8125em;
 	position: sticky;
-	z-index: 9999;
+	z-index: 99999;
 	width: 100%;
 	padding: 5px;
 	text-align: center;

--- a/assets/css/free-trial-plan-picker-banner.css
+++ b/assets/css/free-trial-plan-picker-banner.css
@@ -2,13 +2,11 @@
 	background-color: #c9356e;
 	color: #ffffff;
 	font-size: 0.8125em;
-	position: fixed;
+	position: sticky;
 	z-index: 9999;
 	width: 100%;
-	height: 40px;
-	display: flex;
-	justify-content: center;
-	align-items: center;
+	padding: 5px;
+	text-align: center;
 	top: calc( var( --wp-admin--admin-bar--height, 0px ) ) !important;
 }
 
@@ -17,14 +15,20 @@
 	text-decoration: underline;
 }
 
-body.has-free-trial-plan-picker {
-	margin-top: 40px;
-}
-
 /**
 * Store notice can be at the top or bottom depending on the activated theme.
 * Force it to be at the bottom all the time to place the free trial banner at the top.
 */
 body.has-free-trial-plan-picker .woocommerce-store-notice {
 	top: auto !important;
+}
+
+@media screen and (max-width: 782px) {
+	html {
+		--wp-admin--admin-bar--height: 46px !important;
+	}
+}
+
+body.hide-free-trial-plan-picker #free-trial-plan-picker-banner {
+	display: none;
 }

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-plan-picker-banner.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-plan-picker-banner.php
@@ -4,7 +4,7 @@
  * Class WC_Calypso_Bridge_Free_Trial_Plan_Picker_Banner.
  *
  * @since   2.0.5
- * @version 2.0.5
+ * @version 2.0.14
  *
  * Handles Free Trial Plan Picker Banner.
  */

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-plan-picker-banner.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-plan-picker-banner.php
@@ -36,9 +36,11 @@ class WC_Calypso_Bridge_Free_Trial_Plan_Picker_Banner {
 
 		add_action('init', function() {
 			if ( current_user_can( 'manage_woocommerce' ) ) {
-				add_action( 'wp_footer', array( $this, 'add_plan_picker_banner' ), 10 );
+				add_action( 'wp_head', array( $this, 'add_plan_picker_banner' ), -2000 );
 				add_filter( 'body_class', function ( $classes ) {
-					$classes[] = 'has-free-trial-plan-picker';
+					if ( !in_array('admin-bar', $classes )) {
+						$classes[] = 'hide-free-trial-plan-picker';
+					}
 					return $classes;
 				});
 				add_action( 'wp_enqueue_scripts', array( $this, 'add_styles' ) );

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,8 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+* Make the free trial banner responsive #1066
+
 = 2.0.13 =
 * Remove the onboarding purchase task #1060.
 * Add WooCommerce task list options to Jetpack Sync #1009.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1065

This PR makes the free trial notice banner responsive and fixes a few minor glitches. 

1. Render the banner right after the `body` tag so that we don't have to calculate body tag `margin-top` manually.
2. Add media query and set the `--wp-admin--admin-bar--height` manually. As described in #1065, `admin-bar` mu-plugin manually sets `-wp-admin--admin-bar--height`, which makes the browser ignore the media query from the core. Setting `-wp-admin--admin-bar--height` with `!important` is a temporary solution. I'll submit an issue to `admin-bar` mu-plugin to fix the root cause.
3. Hide the free trial banner on a preview screen (screenshot below)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Since one of the problems came from `admin-bar` mu-plugin, it is better to test this PR on a real trial site with `admin-bar` mu-plugin. Please set up a free trial site, convert it to a dev blog, and copy changes in this PR before testing.

1. Go to /view/:your-site-slug
2. Make sure the banner is not rendered (screenshot 1)
3. Go to the frontend
4. Make sure the banner is rendered right after the admin bar
5. Change your browser width to various sizes and make sure the free trial banner works without breaking words.
6. Make sure the free trial banner works with a few different themes.


### Screenshots
![Screen Shot 2023-04-05 at 10 37 41 AM](https://user-images.githubusercontent.com/4723145/230164177-4831cc77-5abd-46a2-9e16-12a086ae2e27.jpg)




### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
