### PR TITLE
Fix store name not rendering special characters

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,8 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+* Fix store name not rendering special characters #1070.
+
 = 2.0.14 =
 * Make the free trial banner responsive #1066
 

--- a/src/homescreen-progress-header/progress-title.tsx
+++ b/src/homescreen-progress-header/progress-title.tsx
@@ -7,6 +7,11 @@ import { useSelect } from '@wordpress/data';
 import { getVisibleTasks, ONBOARDING_STORE_NAME } from '@woocommerce/data';
 import { getSetting } from '@woocommerce/settings';
 
+/**
+ * Internal dependencies
+ */
+import { sanitizeHTML } from '../payment-gateway-suggestions/utils';
+
 export type ProgressTitleProps = {
 	taskListId: string;
 };
@@ -82,6 +87,10 @@ export const ProgressTitle: React.FC< ProgressTitleProps > = ( {
 	}
 
 	return (
-		<h1 id="woocommerce-task-progress-header__title" className="woocommerce-task-progress-header__title">{ title }</h1>
+		<h1
+			id="woocommerce-task-progress-header__title"
+			className="woocommerce-task-progress-header__title"
+			dangerouslySetInnerHTML={ sanitizeHTML( title ) }
+		/>
 	);
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1064 

Update task progress header title to render special characters correctly.


- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Use free trial site
2. Go to Settings > General (/wp-admin/options-general.php)
3. Change Site Title to `Mike's Essential Store`
4. Go to `WooCommerce > Home`
5. Observe that the home screen title renders `Mike's Essential Store`

![Screenshot 2023-04-12 at 11 07 31](https://user-images.githubusercontent.com/4344253/231341506-36363edd-5d64-465d-9d51-bf500fe6b0fa.png)


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.