### PR TITLE
Update default progress title

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,8 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+* Update default progress title to "Welcome to your Woo Express store" #1071.
+
 = 2.0.14 =
 * Make the free trial banner responsive #1066
 

--- a/src/homescreen-progress-header/progress-title.tsx
+++ b/src/homescreen-progress-header/progress-title.tsx
@@ -53,7 +53,7 @@ export const ProgressTitle: React.FC< ProgressTitleProps > = ( {
 						__( 'Welcome to %s', 'woocommerce' ),
 						siteTitle
 				  )
-				: __( 'Welcome to your store', 'woocommerce' );
+				: __( 'Welcome to your Woo Express store', 'woocommerce' );
 		}
 		switch ( completedCount ) {
 			case 1:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/Automattic/wp-calypso/issues/74898

Update the default home screen headline for users on the free trial.
figma: lD0gTB4IqGsmSmsnjZNaP6-fi-2157_19583

![Screenshot 2023-04-12 at 11 24 53](https://user-images.githubusercontent.com/4344253/231340835-192454cc-aed1-44ed-bcac-b19abb3bdc8b.png)


<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Use free trial site
2. Go to `Settings > General` (/wp-admin/options-general.php)
3. Remove Site Title (if it exists)
4. Go to `WooCommerce > Home`
5. Observe that the home screen title renders `Welcome to your Woo Express store`



<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.