### PR TITLE
Treat missing launch status as launched

### DIFF
--- a/includes/tasks/class-wc-calypso-task-launch-site.php
+++ b/includes/tasks/class-wc-calypso-task-launch-site.php
@@ -86,7 +86,12 @@ class LaunchSite extends Task {
 		$launch_status = get_option( 'launch-status' );
 
 		// The site is launched when the launch status is 'launched' or missing.
-		return 'launched' === $launch_status || '' === $launch_status;
+		$launched_values = array(
+			'launched',
+			'',
+			false,
+		);
+		return in_array( $launch_status, $launched_values, true );
 	}
 
 	/**

--- a/includes/tasks/class-wc-calypso-task-launch-site.php
+++ b/includes/tasks/class-wc-calypso-task-launch-site.php
@@ -83,7 +83,10 @@ class LaunchSite extends Task {
 	 * @return bool
 	 */
 	public function is_complete() {
-		return 'launched' === get_option( 'launch-status' );
+		$launch_status = get_option( 'launch-status' );
+
+		// The site is launched when the launch status is 'launched' or missing.
+		return 'launched' === $launch_status || '' === $launch_status;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -22,7 +22,8 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
-* Mark Store_Details task as complete for free trial #1061 
+* Mark Store_Details task as complete for free trial #1061
+* Fix site launch checks #1073.
 
 = 2.0.14 =
 * Make the free trial banner responsive #1066


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR is intended to handle the case where sites don't have the `launch-status` option defined, which seems to be the root cause of some issues on sites created from the mobile apps, as discussed in p1681200289275869-slack-CNA89KY6M.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

* Ensure you have an Atomic development site.
* Ensure that site has the eCommerce plan or a Woo Express plan
* Navigate to the WooCommerce home page via _Home_ in the left nav
* Scroll down and verify whether the "Launch your site" task is visible and incomplete
  - If you are seeing the "You've already launched your store" text struck out, you will have an extra step later on
* Open up an SSH session to your site -- this should be via `ssh yoursubdomain.wordpress.com@sftp.wp.com`
* Run the following command to remove the `launch-status` option: `wp option delete launch-status`
* If you saw the completed task above, you will also need to run `wp option delete woocommerce_task_list_tracked_completed_tasks` - these values get re-initialised when the home page is loaded
* Reload the WooCommerce Home page
* Verify that the "Launch your store" task is visible and incomplete
* Now apply the changes in this patch to your system - you can upload the file or edit the file inline - it is in `~/htdocs/wp-content/mu-plugins/wpcomsh/vendor/automattic/wc-calypso-bridge/includes/tasks/class-wc-calypso-task-launch-site.php`
* Reload the WooCommerce home page
* Verify that the "Launch your store" task is not visible, and you see the "You've already launched your store" text with struck out formatting

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.