### PR TITLE
Add tracking on various free trial CTAs

### DIFF
--- a/assets/scripts/free-trial-wc-payments.js
+++ b/assets/scripts/free-trial-wc-payments.js
@@ -27,9 +27,19 @@
 		} );
 	};
 
+	// Prefer wc.tracks.recordEvent since it supports debugging.
+	let recordEvent = null;
+	if ( window.wc && window.wc.tracks && window.wc.tracks.recordEvent ) {
+		recordEvent = window.wc.tracks.recordEvent;
+	} else if ( window.wcTracks && window.wcTracks.recordEvent ) {
+		recordEvent = window.wcTracks.recordEvent;
+	} else {
+		recordEvent = function () {};
+	}
+
 	const getNotice = ( copySelector ) => {
 		const defaultCopy = __(
-			"Only Administrators and Store Managers can place orders during the free trial. If you are ready to accept payments from customers, <a href='%s'>upgrade to a paid plan</a>.",
+			"Only Administrators and Store Managers can place orders during the free trial. If you are ready to accept payments from customers, <a href='%s' id='upgrade_now_button'>upgrade to a paid plan</a>.",
 			'wc-calypso-bridge'
 		);
 
@@ -37,7 +47,7 @@
 			default: defaultCopy,
 			transactions: defaultCopy,
 			deposits: __(
-				"Deposits are not available during the trial period. To start processing real transactions and receive payments and payouts, <a href='%s'>upgrade to a pain plan</a>.",
+				"Deposits are not available during the trial period. To start processing real transactions and receive payments and payouts, <a href='%s' id='upgrade_now_button'>upgrade to a pain plan</a>.",
 				'wc-calypso-bridge'
 			),
 		};
@@ -50,6 +60,13 @@
 		const upgradeNotice = document.createElement( 'div' );
 		upgradeNotice.className = 'wc-calypso-notice';
 		upgradeNotice.innerHTML = upgradeNoticeText;
+		upgradeNotice.addEventListener( 'click', ( e ) => {
+			if ( e.target?.attributes?.id?.value === 'upgrade_now_button' ) {
+				recordEvent( 'free_trial_upgrade_now', {
+					source: 'wcpay_landing',
+				} );
+			}
+		} );
 
 		return upgradeNotice;
 	};

--- a/assets/scripts/frontend-banner-tracks.js
+++ b/assets/scripts/frontend-banner-tracks.js
@@ -1,0 +1,20 @@
+document.addEventListener( 'DOMContentLoaded', function () {
+	// Prefer wc.tracks.recordEvent since it supports debugging.
+	let recordEvent = null;
+	if ( window.wc && window.wc.tracks && window.wc.tracks.recordEvent ) {
+		recordEvent = window.wc.tracks.recordEvent;
+	} else if ( window.wcTracks && window.wcTracks.recordEvent ) {
+		recordEvent = window.wcTracks.recordEvent;
+	} else {
+		recordEvent = function () {};
+	}
+
+	const el = document.getElementById( 'banner_button' );
+	if ( el ) {
+		el.addEventListener( 'click', function () {
+			recordEvent( 'free_trial_upgrade_now', {
+				source: 'frontend_banner',
+			} );
+		} );
+	}
+} );

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-notice.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-notice.php
@@ -46,10 +46,30 @@ class WC_Calypso_Bridge_Free_Trial_Orders_Notice  {
                         </p>
                     </div>
 					<div class="upgrade-action">
-						<a href="<?php echo $this->get_action_url()?>" class="button is-primary"><?php echo __('Upgrade now', 'wc-calypso-bridge'); ?></a>
+						<a href="<?php echo $this->get_action_url()?>" class="button is-primary" id="upgrade_now_button"><?php echo __('Upgrade now', 'wc-calypso-bridge'); ?></a>
 					</div>
 
 				</div>
+				<script>
+					document.addEventListener( 'DOMContentLoaded', function() {
+						let recordEvent = null;
+						if ( window.wc && window.wc.tracks && window.wc.tracks.recordEvent ) {
+							recordEvent = window.wc.tracks.recordEvent;
+						} else if ( window.wcTracks && window.wcTracks.recordEvent ) {
+							recordEvent = window.wcTracks.recordEvent;
+						} else {
+							recordEvent = function() {};
+						}
+						const el = document.getElementById( 'upgrade_now_button' );
+						if ( el ) {
+							el.addEventListener( 'click', function() {
+								recordEvent( 'free_trial_upgrade_now', {
+									source: 'orders_page',
+								} );
+							} );
+						}
+					} );
+				</script>
 				<?php
 			}
 		});

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-notice.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-notice.php
@@ -4,7 +4,7 @@
  * Class WC_Calypso_Bridge_Free_Trial_Orders_Notice.
  *
  * @since   2.0.5
- * @version 2.0.8
+ * @version 2.0.15
  *
  * Renders an admin notice on Orders page.
  */

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-notice.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-notice.php
@@ -4,7 +4,7 @@
  * Class WC_Calypso_Bridge_Free_Trial_Orders_Notice.
  *
  * @since   2.0.5
- * @version 2.0.15
+ * @version 2.0.16
  *
  * Renders an admin notice on Orders page.
  */

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-plan-picker-banner.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-plan-picker-banner.php
@@ -4,7 +4,7 @@
  * Class WC_Calypso_Bridge_Free_Trial_Plan_Picker_Banner.
  *
  * @since   2.0.5
- * @version 2.0.14
+ * @version 2.0.15
  *
  * Handles Free Trial Plan Picker Banner.
  */
@@ -28,7 +28,7 @@ class WC_Calypso_Bridge_Free_Trial_Plan_Picker_Banner {
 
 		return self::$instance;
 	}
-	
+
 	public function __construct() {
 		if ( ! wc_calypso_bridge_is_ecommerce_trial_plan() ) {
 			return;
@@ -43,10 +43,22 @@ class WC_Calypso_Bridge_Free_Trial_Plan_Picker_Banner {
 					}
 					return $classes;
 				});
-				add_action( 'wp_enqueue_scripts', array( $this, 'add_styles' ) );
+				if ( ! class_exists( 'WC_Site_Tracking' ) ) {
+					include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks.php';
+					include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-event.php';
+					include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';
+					include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-footer-pixel.php';
+					include_once WC_ABSPATH . 'includes/tracks/class-wc-site-tracking.php';
+				}
+
+				add_action( 'wp_footer', array( $this, 'append_tracking_script' ) );
+				add_action( 'wp_enqueue_scripts', array( $this, 'add_styles_and_scripts' ) );
 			}
 		});
+	}
 
+	public function append_tracking_script() {
+		WC_Site_Tracking::add_tracking_function();
 	}
 
 	/**
@@ -58,13 +70,15 @@ class WC_Calypso_Bridge_Free_Trial_Plan_Picker_Banner {
 		$link = sprintf( "https://wordpress.com/plans/%s", $site_suffix );
 
 		$text = sprintf( __("
-			At the moment you are the only one who can see your store. To make your store available to everyone, please&nbsp;<a href='%s'>upgrade to a paid plan</a>.
+			At the moment you are the only one who can see your store. To make your store available to everyone, please&nbsp;<a href='%s' id='banner_button'>upgrade to a paid plan</a>.
 		", 'wc-calypso-bridge' ), $link );
 		echo "<div id='free-trial-plan-picker-banner'>$text</div>";
 	}
 
-	public function add_styles() {
+	public function add_styles_and_scripts() {
 		wp_enqueue_style( 'wp-calypso-bridge-ecommerce-free-trial-plan-picker-banner', WC_Calypso_Bridge_Instance()->get_asset_path() . 'assets/css/free-trial-plan-picker-banner.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
+		wp_enqueue_script( 'wp-calypso-bridge-ecommerce-free-trial-plan-picker-banner', WC_Calypso_Bridge_Instance()->get_asset_path() . 'assets/scripts/frontend-banner-tracks.js', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
+		wp_enqueue_script( 'woo-tracks', 'https://stats.wp.com/w.js', array( 'wp-hooks' ), gmdate( 'YW' ), false );
 	}
 }
 

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-plan-picker-banner.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-plan-picker-banner.php
@@ -4,7 +4,7 @@
  * Class WC_Calypso_Bridge_Free_Trial_Plan_Picker_Banner.
  *
  * @since   2.0.5
- * @version 2.0.15
+ * @version 2.0.16
  *
  * Handles Free Trial Plan Picker Banner.
  */

--- a/includes/templates/html-admin-page-addons-landing-page.php
+++ b/includes/templates/html-admin-page-addons-landing-page.php
@@ -4,7 +4,7 @@
 *
 * @package WC_Calypso_Bridge/Templates
 * @since   2.0.4
-* @version 2.0.15
+* @version 2.0.16
 *
 * @uses $upgrade_url
 */

--- a/includes/templates/html-admin-page-addons-landing-page.php
+++ b/includes/templates/html-admin-page-addons-landing-page.php
@@ -4,7 +4,7 @@
 *
 * @package WC_Calypso_Bridge/Templates
 * @since   2.0.4
-* @version 2.0.4
+* @version 2.0.15
 *
 * @uses $upgrade_url
 */
@@ -24,10 +24,10 @@
 	</p>
 
 	<div class="wc-addons-landing-page__button-container">
-		<a href="<?php echo esc_url( $upgrade_url ); ?>" class="button button-primary">
+		<a href="<?php echo esc_url( $upgrade_url ); ?>" class="button button-primary" id="upgrade_now_button">
 			<?php esc_html_e( 'Upgrade now', 'wc-calypso-bridge' ); ?>
 		</a>
-		<a href="https://woocommerce.com/product-category/woocommerce-extensions/?categoryIds=1021&collections=product&page=1" target="_blank" class="button button-secondary">
+		<a href="https://woocommerce.com/product-category/woocommerce-extensions/?categoryIds=1021&collections=product&page=1" target="_blank" class="button button-secondary" id="browse_extension_button">
 			<?php esc_html_e( 'Browse extensions', 'wc-calypso-bridge' ); ?>
 		</a>
 	</div>
@@ -56,7 +56,7 @@
 			<p>
 				<?php esc_html_e( 'Add extra features and functionality, or integrate with other platforms and tools.', 'wc-calypso-bridge' ); ?>
 			</p>
-			<a href="https://woocommerce.com/product-category/woocommerce-extensions/?categoryIds=1021&collections=product&page=1" target="_blank"><?php esc_html_e( 'Browse extensions', 'wc-calypso-bridge' ); ?></a>
+			<a href="https://woocommerce.com/product-category/woocommerce-extensions/?categoryIds=1021&collections=product&page=1" target="_blank" id="browse_extension_button_2"><?php esc_html_e( 'Browse extensions', 'wc-calypso-bridge' ); ?></a>
 		</div>
 
 		<div class="wc-addons-landing-page__features-grid__item">
@@ -70,7 +70,7 @@
 			<p>
 				<?php esc_html_e( 'Quickly get started with our curated extension collections.', 'wc-calypso-bridge' ); ?>
 			</p>
-			<a href="https://woocommerce.com/collections" target="_blank"><?php esc_html_e( 'Discover collections', 'wc-calypso-bridge' ); ?></a>
+			<a href="https://woocommerce.com/collections" target="_blank" id="discover_collections_button"><?php esc_html_e( 'Discover collections', 'wc-calypso-bridge' ); ?></a>
 		</div>
 
 		<div class="wc-addons-landing-page__features-grid__item">
@@ -84,9 +84,40 @@
 			<p>
 				<?php esc_html_e( 'Tips, tricks, and ecommerce inspiration from our blog.', 'wc-calypso-bridge' ); ?>
 			</p>
-			<a href="https://woocommerce.com/blog" target="_blank"><?php esc_html_e( 'Get inspired', 'wc-calypso-bridge' ); ?></a>
+			<a href="https://woocommerce.com/blog" target="_blank" id="get_inspired_button"><?php esc_html_e( 'Get inspired', 'wc-calypso-bridge' ); ?></a>
 		</div>
 
 	</div>
 
 </div>
+
+<script>
+document.addEventListener( 'DOMContentLoaded', function() {
+	// Prefer wc.tracks.recordEvent since it supports debugging.
+	let recordEvent = null;
+	if ( window.wc && window.wc.tracks && window.wc.tracks.recordEvent ) {
+		recordEvent = window.wc.tracks.recordEvent;
+	} else if ( window.wcTracks && window.wcTracks.recordEvent ) {
+		recordEvent = window.wcTracks.recordEvent;
+	} else {
+		recordEvent = function() {};
+	}
+
+	const recordButtonEvent = function( buttonId, eventName ) {
+		const el = document.getElementById( buttonId );
+		if ( el ) {
+			el.addEventListener( 'click', function() {
+				recordEvent( eventName, {
+					source: 'extensions',
+				} );
+			} );
+		}
+	};
+
+	recordButtonEvent( 'upgrade_now_button', 'free_trial_upgrade_now' );
+	recordButtonEvent( 'browse_extension_button', 'free_trial_browse_extensions' );
+	recordButtonEvent( 'browse_extension_button_2', 'free_trial_browse_extensions' );
+	recordButtonEvent( 'discover_collections_button', 'free_trial_discover_collections' );
+	recordButtonEvent( 'get_inspired_button', 'free_trial_get_inspired' );
+} );
+</script>

--- a/readme.txt
+++ b/readme.txt
@@ -22,7 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
-* Mark Store_Details task as complete for free trial #1061 
+= Unreleased =
+* Mark Store_Details task as complete for free trial #1061
+* Add tracking on various free trial CTAs #1074
 
 = 2.0.14 =
 * Make the free trial banner responsive #1066

--- a/src/free-trial/tax/index.tsx
+++ b/src/free-trial/tax/index.tsx
@@ -52,6 +52,12 @@ export type TaxProps = {
 	task: TaskType;
 };
 
+const trackUpgradeClick = () => {
+	recordEvent( 'free_trial_upgrade_now', {
+		source: 'tax_task',
+	} );
+};
+
 const UpgradeNotice = () => (
 	<div
 		className="woocommerce-task-notice-container"
@@ -70,6 +76,7 @@ const UpgradeNotice = () => (
 							href={ getUpgradePlanLink() }
 							type="external"
 							target="_blank"
+							onClick={ trackUpgradeClick }
 						>
 							<></>
 						</Link>
@@ -298,15 +305,18 @@ export const Tax: React.FC< TaxProps > = ( { onComplete, query, task } ) => {
 	}
 
 	return (
-		<Partners { ...childProps }>
-			{ partners.map(
-				( partner ) =>
-					partner.card &&
-					createElement( partner.card, {
-						key: partner.id,
-						...childProps,
-					} )
-			) }
-		</Partners>
+		<>
+			<UpgradeNotice />
+			<Partners { ...childProps }>
+				{ partners.map(
+					( partner ) =>
+						partner.card &&
+						createElement( partner.card, {
+							key: partner.id,
+							...childProps,
+						} )
+				) }
+			</Partners>
+		</>
 	);
 };

--- a/src/marketing/index.tsx
+++ b/src/marketing/index.tsx
@@ -121,6 +121,11 @@ export const Marketing = () => {
 						<Button
 							href="/wp-admin/admin.php?page=automatewoo-dashboard"
 							variant="secondary"
+							onClick={ () => {
+								recordEvent( 'free_trial_try_automatewoo', {
+									source: 'marketing',
+								} );
+							} }
 						>
 							{ __( 'Try AutomateWoo', 'wc-calypso-bridge' ) }
 						</Button>
@@ -165,6 +170,14 @@ export const Marketing = () => {
 						<Button
 							href={ '/wp-admin/admin.php?page=gc_giftcards' }
 							variant="secondary"
+							onClick={ () => {
+								recordEvent(
+									'free_trial_create_digital_giftcards',
+									{
+										source: 'marketing',
+									}
+								);
+							} }
 						>
 							{ __(
 								'Create digital gift cards',

--- a/src/payment-gateway-suggestions/index.js
+++ b/src/payment-gateway-suggestions/index.js
@@ -272,6 +272,12 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 
 	const upgradeUrl = `https://wordpress.com/plans/${ window.wcCalypsoBridge.siteSlug }`;
 
+	const trackUpgradeClick = () => {
+		recordEvent( 'free_trial_upgrade_now', {
+			source: 'payments_task',
+		} );
+	};
+
 	return (
 		<div className="woocommerce-task-payments">
 			<Notice
@@ -287,6 +293,7 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 								href={ upgradeUrl }
 								type="external"
 								target="_blank"
+								onClick={ trackUpgradeClick }
 							>
 								<></>
 							</Link>

--- a/src/task-completion/index.tsx
+++ b/src/task-completion/index.tsx
@@ -190,6 +190,7 @@ export const TaskListCompletedHeader: React.FC<
 									'wc-calypso-bridge'
 								) }
 							</Button>
+							
 							<div className="woocommerce-task-card__header-menu">
 								{ /* @ts-expect-error: type def. is not up to date. Ignoring for now. */ }
 								<EllipsisMenu


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1003.

- Adds free trial notice in Tax task (it was missing before)
- Adds most if not all tracking requirements on bridge for free trial peapX7-1PC-p2
  - Marketing screen
  - Extensions screen
  - Frontend banner
  - Orders screen
  - Payments task
  - Tax task
  - WCPay landing screen

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### Pre-requisite

- You'll need a free trial site
- Open developer console
- Run `localStorage.setItem( 'debug', 'wc-admin:tracks' );`
- Optional tip: Open all CTAs in a new tab to make your life easier

#### Marketing screen

1. Go to Marketing > Overview
2. Click on `Try AutomateWoo`
3. Observe `wcadmin_free_trial_try_automatewoo` track with props `source: 'marketing'`
1. Click on `Create digital gift cards`
3. Observe `wcadmin_free_trial_create_digital_giftcards` track with props `source: 'marketing'`

#### Extensions screen

1. Go to Extensions > Discover
2. Click on `Upgrade now`
3. Observe `wcadmin_free_trial_upgrade_now` track with props `source: 'extensions'`
1. Click on `Browse extensions`
3. Observe `wcadmin_free_trial_browse_extensions` track with props `source: 'extensions'`
1. Click on `Browse extensions` at bottom of the screen
3. Observe `wcadmin_free_trial_browse_extensions` track with props `source: 'extensions'`
1. Click on `Discover collections`
3. Observe `wcadmin_free_trial_discover_collections` track with props `source: 'extensions'`
1. Click on `Get inspired`
3. Observe `wcadmin_free_trial_get_inspired` track with props `source: 'extensions'`

#### Frontend banner

1. Go to your site's frontend
2. In your developer's console, open up networks tab
3. Clear the console
4. Click on `upgrade to a paid plan` at the top banner
5. Observe `https://pixel.wp.com/t.gif` request with parameters `_en: wcadmin_free_trial_upgrade_now` and `source: frontend_banner`

#### Orders screen

1. Go to Orders
2. Click on `Upgrade now`
3. Observe `wcadmin_free_trial_upgrade_now` track with props `source: 'orders_page'`

#### Payments task

1. Go to `/wp-admin/admin.php?page=wc-admin&task=payments`
4. Click on `upgrade to a paid plan` at the top notice
3. Observe `wcadmin_free_trial_upgrade_now` track with props `source: 'payments_task'`

#### Tax task

1. Go to `/wp-admin/admin.php?page=wc-admin&task=tax`
2. Observe the notice now appears on the first screen (screenshot below)
5. Click on `upgrade now` at the top notice
3. Observe `wcadmin_free_trial_upgrade_now` track with props `source: 'tax_task'`

<img width="500" alt="image" src="https://user-images.githubusercontent.com/3747241/231802047-666db674-9fea-4b82-80ce-d3f5dde7bbfa.png">

#### WCPay landing screen

1. Go to Payments
4. Click on `upgrade to a paid plan` at the top notice
3. Observe `wcadmin_free_trial_upgrade_now` track with props `source: 'wcpay_landing'`

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.