### PR TITLE
Add checks for domain purchases to domain task

### DIFF
--- a/includes/tasks/class-wc-calypso-task-add-domain.php
+++ b/includes/tasks/class-wc-calypso-task-add-domain.php
@@ -100,7 +100,25 @@ class AddDomain extends Task {
 	 * @return bool
 	 */
 	public function is_complete() {
-		// Determine if a custom domain is used by ensuring that the default atomic url wpcomstating is not part of the `siteurl` option.
-		return false === strpos( get_option( 'siteurl' ), 'wpcomstaging' );
+		// Determine if a custom domain is used by ensuring that the default atomic url .wpcomstaging.com is not part of the `siteurl` option.
+		if ( false === strpos( get_option( 'siteurl' ), '.wpcomstaging.com' ) ) {
+			return true;
+		}
+
+		if ( ! function_exists( 'wpcom_get_site_purchases' ) ) {
+			return false;
+		}
+
+		// Otherwise, check if the site has any domain purchases.
+		$site_purchases = wpcom_get_site_purchases();
+
+		$domain_purchases = array_filter(
+			$site_purchases,
+			function ( $site_purchase ) {
+				return in_array( $site_purchase->product_type, array( 'domain_map', 'domain_reg' ), true );
+			}
+		);
+
+		return ! empty( $domain_purchases );
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,8 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+* Update _Add a domain_ task to check for domain purchases in addition to the site URL #1083.
+
 = 2.0.17 =
 * Update default progress title to "Welcome to your Woo Express store" #1071.
 * Fix store name not rendering special characters #1070.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR explores a more robust mechanism for checking if the site has added a custom domain, as the current logic only checks for the site's primary address being different. In most cases, that's sufficient, but in the case where it takes a while for a domain to be registered and for the DNS details to be propagated, there can be a lengthy delay of 10-30 minutes before the site gets switched across to the new domain. (For some TLDs, that delay can be even longer.)

The implementation logic has now been updated to perform three levels of checks:
1. If the site includes `.wpcomstaging.com` in the URL, we mark the task as complete
   - It's worth noting that this is a minor refinement of the current logic, which only checks for `wpcomstaging`
2. We check if the `wpcom_get_site_purchases()` function exists. If it doesn't we mark the task as incomplete, as we can't perform the next step.
3. We call `wpcom_get_site_purchases()`, and filter the results so we're only looking at purchases where `product_type` is either `domain_map` or `domain_reg` for domain mappings (AKA connected domains) and domain registrations. If any such purchases exist, we can assume the customer has set up a domain, and we can mark the task as complete. 

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

* Set up an eCommerce site as a development site
* Connect a domain to the site, but ensure that this domain is not the primary domain, i.e. we keep the `wpcomstaging.com` URL
* Visit WooCommerce Home
* Verify the task is incomplete
* Apply this patch
* Reload WooCommerce Home
* Verify the task is marked as complete

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.