### PR TITLE
Update sync list override to hook into 'plugins_loaded'

### DIFF
--- a/includes/class-wc-calypso-bridge-filters.php
+++ b/includes/class-wc-calypso-bridge-filters.php
@@ -42,6 +42,10 @@ class WC_Calypso_Bridge_Filters {
 		}
 
 		add_action( 'init', array( $this, 'init' ) );
+
+		// Jetpack Sync is initialised from the 'plugins_loaded' action, so we need to do so as well.
+		// Ref: https://github.com/Automattic/jetpack/blob/db92236462824dc73e4cf4602388fc0ded99e984/projects/packages/sync/src/class-main.php#L24-L25
+		add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded' ) );
 	}
 
 	/**
@@ -49,7 +53,6 @@ class WC_Calypso_Bridge_Filters {
 	 */
 	public function init() {
 		add_filter( 'admin_footer', array( $this, 'add_documentation_js_filter' ) );
-		add_filter( 'jetpack_sync_options_whitelist', array( $this, 'add_woocommerce_task_list_options_to_jetpack_sync' ), 10, 1 );
 
 		/**
 		 * Disable email based notifications.
@@ -57,6 +60,15 @@ class WC_Calypso_Bridge_Filters {
 		add_filter( 'pre_option_woocommerce_merchant_email_notifications', static function() {
 			return 'no';
 		} );
+	}
+
+	/**
+	 * Initialization function that runs on the `plugins_loaded` action.
+	 *
+	 * @return void
+	 */
+	public function on_plugins_loaded() {
+		add_filter( 'jetpack_sync_options_whitelist', array( $this, 'add_woocommerce_task_list_options_to_jetpack_sync' ) );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -22,9 +22,10 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+* Update the hook we use to include additional task list options in Jetpack Sync #1084.
+
 = 2.0.18 =
 * Update _Add a domain_ task to check for domain purchases in addition to the site URL #1083.
-* Update the hook we use to include additional task list options in Jetpack Sync #1084.
 
 = 2.0.17 =
 * Update default progress title to "Welcome to your Woo Express store" #1071.

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,7 @@ This section describes how to install the plugin and get it working.
 
 = 2.0.18 =
 * Update _Add a domain_ task to check for domain purchases in addition to the site URL #1083.
+* Update the hook we use to include additional task list options in Jetpack Sync #1084.
 
 = 2.0.17 =
 * Update default progress title to "Welcome to your Woo Express store" #1071.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR makes a small adjustment to the logic added in #1009, as we discovered that the options weren't synching across as we expected. Upon digging deeper, I discovered that our custom function wasn't getting triggered, despite the loading and triggering happening as written. I finally realised that the issue is because Jetpack Sync is fully triggered from the `plugins_loaded` action, so has already triggered and completed any sync-related actions before we run the `init` hook that we were using for our code.

As such, this PR simply updates the logic to add the WooCommerce task list option filter via the `plugins_loaded` hook instead of the `init` hook.

Related to #1009.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

#### Set up/prep

1. Set up a WoA dev site with an eCommerce or paid Woo Express plan linked to it, and make a note of the WordPress.com blog_id
2. Ensure you only have one browser window for the site, preferably not the WooCommerce Home page
3. Open an SSH session to your WordPress.com development sandbox, and add the function from 2fe8b-pb/#php to your `0-sandbox.php` file
4. Open up an SSH session to the site using `ssh subdomain.wordpress.com@sftp.wp.com`
5. Open up the [Jetpack debugger](https://jptools.wordpress.com/debug/) in a separate browser tab, and enter your site's URL to get details
6. Run the following command to ensure that the `woocommerce_task_list_tracked_completed_tasks` option is fully removed: `wp option delete woocommerce_task_list_tracked_completed_tasks`

#### Actual testing

##### Test case: sync is not working at present

1. Navigate to the WooCommerce home page for your site
2. In your SSH session to the site, verify that the site option has been repopulated: `wp option get woocommerce_task_list_tracked_completed_tasks`
3. Refresh the Jetpack debugger details for your site
4. Verify that the Incremental Sync option shows the update having flowed through
5. On your sandbox, open up `wpsh` and run `return null === test_get_jetpack_replica_option( $your_blog_id, 'woocommerce_task_list_tracked_completed_tasks' );`
6. This should return true, as the update wasn't synced.

##### Test case: sync works with the patch

1. Apply this patch to your development site. You can use `sftp`, `rsync`, or direct editing to do so, but the file is in `~/htdocs/wp-content/mu-plugins/wpcomsh/vendor/automattic/wc-calypso-bridge/includes/` (where the `htdocs` is not exposed via `sftp`)
2. Run the following command in the SSH connection to your dev site to remove the `woocommerce_task_list_tracked_completed_tasks` option again: `wp option delete woocommerce_task_list_tracked_completed_tasks`
3. Now reload the WooCommerce home page, which should repopulate the option.
4. In your SSH session to the site, verify that the site option has been repopulated: `wp option get woocommerce_task_list_tracked_completed_tasks`
5. Refresh the Jetpack debugger details for your site
6. Verify that the Incremental Sync option shows the update having flowed through
7. On your sandbox, open up `wpsh` and run `return test_get_jetpack_replica_option( $your_blog_id, 'woocommerce_task_list_tracked_completed_tasks' );`
8. This should return an array of completed tasks.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.