### PR TITLE
Deploy Automation: Automate creating and pushing a release tag

### DIFF
--- a/scripts/commands/build.js
+++ b/scripts/commands/build.js
@@ -7,12 +7,14 @@ import {
 	error,
 	success,
 	info,
+	warning,
 	getCurrentBranchName,
 	getCurrentVersion,
 	getStatus,
 	gitFactory,
 	isDevBuild,
 	promptContinue,
+	switchToBranchWithMessage,
 	verifyBuild,
 } from '../utils.js';
 
@@ -48,11 +50,12 @@ async function buildRelease() {
 	}
 
 	const git = gitFactory();
-	const version = getCurrentVersion();
 	const currentBranchName = await getCurrentBranchName();
 
 	await git.checkout( 'master' );
-	await git.pull( 'origin', 'master' );
+	await git.pull( [ 'origin', 'master', '--rebase' ] );
+
+	const version = getCurrentVersion();
 	info(
 		`Pulled latest changes from 'master'. Current version is ${ version }.`
 	);
@@ -63,10 +66,7 @@ async function buildRelease() {
 
 	if ( ! shouldContinue ) {
 		info( 'Aborting release build.' );
-		if ( currentBranchName !== 'master' ) {
-			info( `Switching back to branch '${ currentBranchName }'` );
-			await git.checkout( currentBranchName );
-		}
+		await switchToBranchWithMessage( currentBranchName );
 
 		return false;
 	}

--- a/scripts/commands/build.js
+++ b/scripts/commands/build.js
@@ -71,8 +71,13 @@ async function buildRelease() {
 		return false;
 	}
 
+	info('Creating a new release build. This make take some time...');
+	const interval = setInterval( () => process.stdout.write( '.' ), 1000 );
+
 	await execAsync( 'npm i' );
 	const { stdout, stderr } = await execAsync( 'npm run build' );
+
+	clearInterval( interval );
 
 	// Verify that the build was successful.
 	// We do this by getting the last line of the build output (which is the webpack status line) and checking it for errors.

--- a/scripts/commands/build.js
+++ b/scripts/commands/build.js
@@ -20,7 +20,7 @@ import {
 
 const execAsync = promisify( exec );
 
-async function buildRelease() {
+async function buildRelease(currentBranchName) {
 	// Ensure we're always running in the project root.
 	process.chdir( `${ __dirname }/..` );
 
@@ -50,7 +50,6 @@ async function buildRelease() {
 	}
 
 	const git = gitFactory();
-	const currentBranchName = await getCurrentBranchName();
 
 	await git.checkout( 'master' );
 	await git.pull( [ 'origin', 'master', '--rebase' ] );

--- a/scripts/commands/tag.js
+++ b/scripts/commands/tag.js
@@ -1,0 +1,82 @@
+import fs from 'fs';
+import chalk from 'chalk';
+
+import {
+	__dirname,
+	error,
+	info,
+	getCurrentVersion,
+	getCurrentBranchName,
+	gitFactory,
+	promptContinue,
+	switchToBranchWithMessage,
+	tagExists,
+	verifyBuild,
+	warning,
+} from '../utils.js';
+
+async function tagRelease() {
+	// Ensure we're always running in the project root.
+	process.chdir( `${ __dirname }/..` );
+
+	const verificationErrors = await verifyBuild();
+	if ( verificationErrors.length > 0 ) {
+		error( 'Build verification failed:' );
+		verificationErrors.map( ( err ) => error( `\t${ err }` ) );
+		return false;
+	}
+
+	if ( fs.existsSync( 'node_modules' ) ) {
+		error(
+			'A node_modules folder exists. Please remove it and try again.'
+		);
+		return false;
+	}
+
+	let res = null;
+	const git = gitFactory();
+	const currentBranchName = await getCurrentBranchName();
+	const version = getCurrentVersion();
+	const versionStr = `${ chalk.blue( version ) }`;
+
+	res = await tagExists( version );
+	if ( res ) {
+		error( `The tag ${ version } already exists. Deploy failed.` );
+		await switchToBranchWithMessage( currentBranchName );
+		return false;
+	}
+
+	await git.tag( [ version ] );
+	await git.checkout( version );
+	await git.add( [ './build', '--force' ] );
+	await git.commit( 'Adding build directory to release', null, {
+		'--no-verify': null,
+	} );
+	await git.tag( [ '-f', version ] );
+	info( `We've created a tag for release ${ versionStr }.` );
+
+	const shouldContinue = await promptContinue(
+		`Would you like to publish the release for ${ versionStr }?`
+	);
+
+	if ( ! shouldContinue ) {
+		warning(
+			`Aborting. The release for ${ versionStr } was not published!`
+		);
+		// TODO - Should we delete the tag here?
+		return false;
+	}
+
+	res = await tagExists( version );
+	if ( ! res ) {
+		error( `The tag ${ version } does not exist. Deploy failed.` );
+		await switchToBranchWithMessage( currentBranchName );
+		return false;
+	}
+
+	await git.push( [ 'origin', version ] );
+
+	return true;
+}
+
+export default tagRelease;

--- a/scripts/commands/tag.js
+++ b/scripts/commands/tag.js
@@ -59,10 +59,15 @@ async function tagRelease( currentBranchName ) {
 	);
 
 	if ( ! shouldContinue ) {
+		await switchToBranchWithMessage( currentBranchName );
+
+		// Delete the tag we just created.
+		await git.tag( [ '-d', version ] );
+
 		warning(
-			`Aborting. The release for ${ versionStr } was not published!`
+			`Aborting. The release for ${ versionStr } was not published and the new tag has been deleted!`
 		);
-		// TODO - Should we delete the tag here?
+
 		return false;
 	}
 

--- a/scripts/commands/tag.js
+++ b/scripts/commands/tag.js
@@ -15,7 +15,7 @@ import {
 	warning,
 } from '../utils.js';
 
-async function tagRelease() {
+async function tagRelease( currentBranchName ) {
 	// Ensure we're always running in the project root.
 	process.chdir( `${ __dirname }/..` );
 
@@ -35,7 +35,6 @@ async function tagRelease() {
 
 	let res = null;
 	const git = gitFactory();
-	const currentBranchName = await getCurrentBranchName();
 	const version = getCurrentVersion();
 	const versionStr = `${ chalk.blue( version ) }`;
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -9,7 +9,6 @@ import {
 	getCurrentBranchName,
 	getCurrentVersion,
 	getNvmrcVersion,
-	gitFactory,
 	promptContinue,
 	success,
 	switchToBranchWithMessage,

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -27,7 +27,7 @@ async function main() {
 	let res = null;
 	let shouldContinue = null;
 
-	res = await buildRelease();
+	res = await buildRelease( currentBranchName );
 	if ( ! res ) {
 		return;
 	}
@@ -47,14 +47,12 @@ async function main() {
 		return;
 	}
 
-	res = await tagRelease();
+	res = await tagRelease( currentBranchName );
 	if ( ! res ) {
 		return;
 	}
 
-	const git = gitFactory();
-
-	await git.checkout( 'master' );
+	await switchToBranchWithMessage( currentBranchName );
 	success( 'Release complete!' );
 }
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,13 +1,18 @@
 import chalk from 'chalk';
 
 import buildRelease from './commands/build.js';
+import tagRelease from './commands/tag.js';
 import {
 	error,
 	info,
 	isCorrectNodeVersion,
+	getCurrentBranchName,
 	getCurrentVersion,
 	getNvmrcVersion,
+	gitFactory,
 	promptContinue,
+	success,
+	switchToBranchWithMessage,
 } from './utils.js';
 
 async function main() {
@@ -18,13 +23,39 @@ async function main() {
 		return;
 	}
 
-	const version = getCurrentVersion();
+	const currentBranchName = await getCurrentBranchName();
 	let res = null;
-	const shouldContinue = null;
+	let shouldContinue = null;
 
 	res = await buildRelease();
 	if ( ! res ) {
+		return;
 	}
+
+	const version = getCurrentVersion();
+
+	shouldContinue = await promptContinue(
+		`We've built the release for ${ chalk.blue(
+			version
+		) }. Would you like to tag the release and deploy? You will be prompted one more time before the release is published.`
+	);
+
+	if ( ! shouldContinue ) {
+		info( 'Aborting release deploy.' );
+		await switchToBranchWithMessage( currentBranchName );
+
+		return;
+	}
+
+	res = await tagRelease();
+	if ( ! res ) {
+		return;
+	}
+
+	const git = gitFactory();
+
+	await git.checkout( 'master' );
+	success( 'Release complete!' );
 }
 
 main();

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -20,21 +20,10 @@ async function main() {
 
 	const version = getCurrentVersion();
 	let res = null;
-
-	const shouldContinue = await promptContinue(
-		`The current version is ${ chalk.blue(
-			version
-		) }. Would you like to create a new release?`
-	);
-
-	if ( ! shouldContinue ) {
-		info( 'Aborting release build.' );
-		return;
-	}
+	const shouldContinue = null;
 
 	res = await buildRelease();
 	if ( ! res ) {
-		return;
 	}
 }
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -24,6 +24,10 @@ export function info( message ) {
 	console.log( 'INFO: ' + chalk.blue( message ) );
 }
 
+export function gitFactory() {
+	return git;
+}
+
 export async function promptContinue( msg ) {
 	const answer = await inquirer.prompt( [
 		{
@@ -84,10 +88,9 @@ export async function getStatus() {
 	}
 }
 
-// Pull the latest master changes from origin.
-export async function pullLatestChanges() {
-	await git.checkout( 'master' );
-	await git.pull( 'origin', 'master' );
+export async function getCurrentBranchName() {
+	const currentBranch = await git.branch();
+	return currentBranch.current;
 }
 
 // Check to see if we're running a dev build.

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -67,7 +67,7 @@ export function getCurrentVersion() {
 		);
 		const { version } = JSON.parse( packageJson );
 
-		return version;
+		return version.replace( /[^\d.]/g, '' );
 	} catch ( err ) {
 		error( err );
 		return null;
@@ -88,9 +88,23 @@ export async function getStatus() {
 	}
 }
 
+export async function tagExists( tagName ) {
+	const tags = await git.tag( [ '-l', tagName.replace( /[^\d.]/g, '' ) ] );
+	const tag = tags.replace( /\n/g, '' );
+
+	return tag && tag.length > 0;
+}
+
 export async function getCurrentBranchName() {
 	const currentBranch = await git.branch();
 	return currentBranch.current;
+}
+
+export async function switchToBranchWithMessage( branchName ) {
+	if ( branchName !== 'master' ) {
+		info( `Switching back to branch '${ branchName }'` );
+		await git.checkout( branchName );
+	}
 }
 
 // Check to see if we're running a dev build.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This updates the `yarn create-release` command with a step to create a release tag and then push the tag to `origin`.

Closes #1101.
Related to #1096.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

### Cancelling tagging the release
1. In the project root, run `yarn create-release`
1. Answer 'Y' to the release build prompt.
1. Answer 'N' to the "Would you like to tag this release and deploy?" prompt.
1. Verify the script stops and you are switched back to this branch.

### The tag already exists
1. Make sure the current version in `composer.json` is one that has already been released (this will be the default scenario after checking out this branch).
1. In the project root, run `yarn create-release` and answer `Y` to all prompts.
1. Once you say yes to the "Would you like to tag this release and deploy?", you'll get an `ERROR: The tag :version already exists. Deploy failed.` error.

### Fully creating and deploying a tag
1. Checkout `master`, increment the version in `composer.json`, and commit the change. This will be a fake version bump used for testing which we'll revert when we're done.
1. Checkout this branch.
1. Run `yarn create-release` and answer `Y` to all prompts.
1. At the end, you should see a `SUCCESS: Release complete!` message.
1. You should also be able to see the new tag in the [list of tags on Github](https://github.com/Automattic/wc-calypso-bridge/tags) and locally by running `git tag`.

#### Cleaning up our fake version bump
1. Run the commands `git tag -d x.x.x` and `git push --delete origin x.x.x` where `x.x.x` is the fake version bump we created earlier.
1. Checkout `master` locally and revert the fake version bump commit by running `git reset --hard HEAD~1`

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
