### PR TITLE
Patch for product import issue

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -128,6 +128,7 @@ class WC_Calypso_Bridge {
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/free-trial/class-wc-calypso-bridge-free-trial-plan-picker-banner.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-notice.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-free-trial-store-details-task.php';
+		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-product-import-fix.php';
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-product-import-fix.php
+++ b/includes/class-wc-calypso-bridge-product-import-fix.php
@@ -53,10 +53,10 @@ class WC_Calypso_Bridge_Product_Import_Fix {
 	 * Replace CSV importer args.
 	 */
 	public function replace_csv_importer_args( $args ) {
-			// The defining symptom is that the product type key has a value 'Type' instead of 'type'.
-			if ( isset( $args['mapping']['Type'] ) && 'Type' === $args['mapping']['Type'] ) {
-				$args['mapping'] = $this->get_header_mappings( array_keys( $args['mapping'] ) );
-			}
+		// The defining symptom is that the product type key has a value 'Type' instead of 'type'.
+		if ( isset( $args['mapping']['Type'] ) && 'Type' === $args['mapping']['Type'] ) {
+			$args['mapping'] = $this->get_header_mappings( array_keys( $args['mapping'] ) );
+		}
 		return $args;
 	}
 

--- a/includes/class-wc-calypso-bridge-product-import-fix.php
+++ b/includes/class-wc-calypso-bridge-product-import-fix.php
@@ -40,23 +40,23 @@ class WC_Calypso_Bridge_Product_Import_Fix {
 	}
 
 	/**
-	 * Importer fix via filter.
-	 */
-	public function init() {
-		add_filter( 'woocommerce_product_csv_importer_args', array( $this, 'replace_csv_importer_args' ) );
-	}
-
-	/**
 	 * Patch for sample product import issue with WooCommerce < 7.8.0.
 	 * Issue: https://github.com/woocommerce/woocommerce/issues/38069
 	 */
-	public function replace_csv_importer_args( $args ) {
+	public function init() {
 		if ( defined( 'WC_VERSION' ) &&	version_compare( WC_VERSION, '7.8.0', '<' ) ) {
+			add_filter( 'woocommerce_product_csv_importer_args', array( $this, 'replace_csv_importer_args' ) );
+		}
+	}
+
+	/**
+	 * Replace CSV importer args.
+	 */
+	public function replace_csv_importer_args( $args ) {
 			// The defining symptom is that the product type key has a value 'Type' instead of 'type'.
 			if ( isset( $args['mapping']['Type'] ) && 'Type' === $args['mapping']['Type'] ) {
 				$args['mapping'] = $this->get_header_mappings( array_keys( $args['mapping'] ) );
 			}
-		}
 		return $args;
 	}
 

--- a/includes/class-wc-calypso-bridge-product-import-fix.php
+++ b/includes/class-wc-calypso-bridge-product-import-fix.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Product CSV import fix.
+ *
+ * @package WC_Calypso_Bridge/Classes
+ * @since   2.1.2
+ * @version 2.1.2
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Calypso_Bridge_Notes Class.
+ */
+class WC_Calypso_Bridge_Product_Import_Fix {
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var object
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return object Instance.
+	 */
+	final public static function get_instance() {
+		if ( null === static::$instance ) {
+			static::$instance = new static();
+		}
+		return static::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->init();
+	}
+
+	/**
+	 * Importer fix via filter.
+	 */
+	public function init() {
+		add_filter( 'woocommerce_product_csv_importer_args', array( $this, 'replace_csv_importer_args' ) );
+	}
+
+	/**
+	 * Patch for sample product import issue with WooCommerce < 7.8.0.
+	 * Issue: https://github.com/woocommerce/woocommerce/issues/38069
+	 */
+	public function replace_csv_importer_args( $args ) {
+		if ( defined( 'WC_VERSION' ) &&	version_compare( WC_VERSION, '7.8.0', '<' ) ) {
+			// The defining symptom is that the product type key has a value 'Type' instead of 'type'.
+			if ( isset( $args['mapping']['Type'] ) && 'Type' === $args['mapping']['Type'] ) {
+				$args['mapping'] = $this->get_header_mappings( array_keys( $args['mapping'] ) );
+			}
+		}
+		return $args;
+	}
+
+	/**
+	 * Get fixed CSV header columns.
+	 *
+	 * @internal
+	 * @param array $raw_headers column keys from imported CSV
+	 * @return array Mapped headers.
+	 */
+	public function get_header_mappings( $raw_headers ) {
+		$default_columns = $this->get_default_english_mappings();
+		$special_columns = $this->get_default_english_special_mappings();
+
+		$headers = array();
+		foreach ( $raw_headers as $key => $field ) {
+			$index             = $field;
+			$headers[ $index ] = $field;
+
+			if ( isset( $default_columns[ $field ] ) ) {
+				$headers[ $index ] = $default_columns[ $field ];
+			} else {
+				foreach ( $special_columns as $regex => $special_key ) {
+					if ( preg_match( self::sanitize_special_column_name_regex( $regex ), $field, $matches ) ) {
+						$headers[ $index ] = $special_key . $matches[1];
+						break;
+					}
+				}
+			}
+		}
+
+		return $headers;
+	}
+
+	/**
+	 * Sanitize special column name regex.
+	 *
+	 * @internal
+	 * @param  string $value Raw special column name.
+	 * @return string
+	 */
+	public static function sanitize_special_column_name_regex( $value ) {
+		return '/' . str_replace( array( '%d', '%s' ), '(.*)', trim( quotemeta( $value ) ) ) . '/';
+	}
+
+
+	/**
+	 * Copied from default mapping.
+	 * https://github.com/woocommerce/woocommerce/blob/0a45cbfc83177c6f870c4eaf508919567b3d516e/plugins/woocommerce/includes/admin/importers/mappings/default.php#L1
+	 */
+	public function get_default_english_mappings() {
+		$weight_unit    = get_option( 'woocommerce_weight_unit' );
+		$dimension_unit = get_option( 'woocommerce_dimension_unit' );
+		return array(
+		'ID'                                      => 'id',
+		'Type'                                    => 'type',
+		'SKU'                                     => 'sku',
+		'Name'                                    => 'name',
+		'Published'                               => 'published',
+		'Is featured?'                            => 'featured',
+		'Visibility in catalog'                   => 'catalog_visibility',
+		'Short description'                       => 'short_description',
+		'Description'                             => 'description',
+		'Date sale price starts'                  => 'date_on_sale_from',
+		'Date sale price ends'                    => 'date_on_sale_to',
+		'Tax status'                              => 'tax_status',
+		'Tax class'                               => 'tax_class',
+		'In stock?'                               => 'stock_status',
+		'Stock'                                   => 'stock_quantity',
+		'Backorders allowed?'                     => 'backorders',
+		'Low stock amount'                        => 'low_stock_amount',
+		'Sold individually?'                      => 'sold_individually',
+		sprintf( 'Weight (%s)', $weight_unit )    => 'weight',
+		sprintf( 'Length (%s)', $dimension_unit ) => 'length',
+		sprintf( 'Width (%s)', $dimension_unit )  => 'width',
+		sprintf( 'Height (%s)', $dimension_unit ) => 'height',
+		'Allow customer reviews?'                 => 'reviews_allowed',
+		'Purchase note'                           => 'purchase_note',
+		'Sale price'                              => 'sale_price',
+		'Regular price'                           => 'regular_price',
+		'Categories'                              => 'category_ids',
+		'Tags'                                    => 'tag_ids',
+		'Shipping class'                          => 'shipping_class_id',
+		'Images'                                  => 'images',
+		'Download limit'                          => 'download_limit',
+		'Download expiry days'                    => 'download_expiry',
+		'Parent'                                  => 'parent_id',
+		'Upsells'                                 => 'upsell_ids',
+		'Cross-sells'                             => 'cross_sell_ids',
+		'Grouped products'                        => 'grouped_products',
+		'External URL'                            => 'product_url',
+		'Button text'                             => 'button_text',
+		'Position'                                => 'menu_order',
+		);
+	}
+
+	/**
+	 * Copied from default mapping.
+	 * https://github.com/woocommerce/woocommerce/blob/0a45cbfc83177c6f870c4eaf508919567b3d516e/plugins/woocommerce/includes/admin/importers/mappings/default.php#L1
+	 */
+	public function get_default_english_special_mappings() {
+		return array(
+		'Attribute %d name'     => 'attributes:name',
+		'Attribute %d value(s)' => 'attributes:value',
+		'Attribute %d visible'  => 'attributes:visible',
+		'Attribute %d global'   => 'attributes:taxonomy',
+		'Attribute %d default'  => 'attributes:default',
+		'Download %d ID'        => 'downloads:id',
+		'Download %d name'      => 'downloads:name',
+		'Download %d URL'       => 'downloads:url',
+		'Meta: %s'              => 'meta:',
+		);
+	}
+}
+
+WC_Calypso_Bridge_Product_Import_Fix::get_instance();

--- a/readme.txt
+++ b/readme.txt
@@ -25,6 +25,7 @@ This section describes how to install the plugin and get it working.
 * Fix JS lint errors #1105.
 * Update Appearance task has_products logic #1107
 * Update product task to detect modified products #1106.
+* Patch for product import issue #1119.
 
 = 2.1.1 =
 * Allow expired trial sites to access the Export tool #1104.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR addresses the issue https://github.com/woocommerce/woocommerce/issues/38069 to resolve the issue in WPCOM sites immediately.

### How to test the changes in this Pull Request:

#### Testing product type
1. Go to WooCommerce > Home
6. Click on "Add Products" task
7. Click on "Variable product"
8. Observe the product is created as a "variable product" and the product image is shown

#### Testing sample import
1. Go to WooCommerce > Home
6. Click on "Add Products" task
7. Click on "View more product types"
8. Click on "Load Sample Products"
9. Observe 9 sample products are loaded and product image is shown for the newly imported products

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
