### PR TITLE
Make OBW skip reliable for ecommerce and free trial plans

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -129,6 +129,7 @@ class WC_Calypso_Bridge {
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-notice.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-free-trial-store-details-task.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-product-import-fix.php';
+		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-skip-obw.php';
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-skip-obw.php
+++ b/includes/class-wc-calypso-bridge-skip-obw.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Skips OBW by overriding onboarding option.
+ *
+ * @package WC_Calypso_Bridge/Classes
+ * @since   2.1.3
+ * @version 2.1.3
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC Calypso Bridge Skip OBW
+ */
+class WC_Calypso_Bridge_Skip_OBW {
+
+	/**
+	 * Class Instance.
+	 *
+	 * @var WC_Calypso_Bridge_Skip_OBW instance
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Get class instance
+	 */
+	public static function get_instance() {
+		if ( ! static::$instance ) {
+			static::$instance = new static();
+		}
+
+		return static::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		// Only in Ecommerce or free trial.
+		if ( ! ( wc_calypso_bridge_has_ecommerce_features() || wc_calypso_bridge_is_ecommerce_trial_plan() ) ) {
+			return;
+		}
+
+		add_action( 'plugins_loaded', array( $this, 'initialize' ), 2 );
+	}
+
+	/**
+	 * Initialize.
+	 */
+	public function initialize() {
+		/**
+		 * Force skip OBW by appending to existing option `woocommerce_onboarding_profile`.
+		 *
+		 * @since 1.9.4
+		 *
+		 * @param  mixed  $value
+		 * @return array
+		 */
+		add_filter( 'option_woocommerce_onboarding_profile', array( $this, 'add_skipped_state' ) );
+
+		/**
+		 * Force skip OBW when option `woocommerce_onboarding_profile` does not exist.
+		 *
+		 * @since 2.1.3
+		 *
+		 * @param  mixed  $value
+		 * @return array
+		 */
+		add_filter( 'default_option_woocommerce_onboarding_profile', array( $this, 'add_skipped_state' ) );
+	}
+
+	/**
+	 * Skip the OBW by appending the skipped state to the option value.
+	 *
+	 * @param  mixed  $value
+	 * @return array
+	 */
+	public function add_skipped_state( $option_value ) {
+		$value = $option_value ?? array();
+		$value['skipped'] = true;
+		return $value;
+	}
+}
+
+WC_Calypso_Bridge_Skip_OBW::get_instance();

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -67,22 +67,6 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 		add_action( 'admin_footer', array( $this, 'filter_woocommerce_body_classes_js' ) );
 
 		/**
-		 * Skip the OBW.
-		 *
-		 * This callback will ensure that the `woocommerce_onboarding_profile` option value will result to skipped state, always.
-		 *
-		 * @since 1.9.4
-		 *
-		 * @param  mixed  $value
-		 * @return array
-		 */
-		add_filter( 'option_woocommerce_onboarding_profile', static function ( $option_value ) {
-			$value = $option_value ?? array();
-			$value['skipped'] = true;
-			return $value;
-		}, 100 );
-
-		/**
 		 * Disable WooCommerce Navigation.
 		 *
 		 * @since   1.9.4

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,7 @@ This section describes how to install the plugin and get it working.
 
 = Unreleased =
 * Remove useSlot monkey patch. #1117
+* Make OBW skip reliable for ecommerce and free trial plans #1125
 
 = 2.1.2 =
 * Fix JS lint errors #1105.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Addresses p1683195595191999-slack-C03Q87XT1QF

It was found that the old option did not work when `woocommerce_onboarding_profile` did not exist. This PR addresses that and moved the filter to its own class since we need it to reliably work for multiple plans, free trial and ecommerce.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### Guide
In order to observe option values, you can do either the following:

1. **Using Atomic:** In your free trial site, go to `_cli` by appending it to URL, example: `https://freetrialtestingsite5.wpcomstaging.com/_cli`.
2. **Using local:** Use `wp-cli` instead

#### Testing when the option exists

1. Go to `/wp-admin/admin.php?page=wc-admin&path=/setup-wizard`
2. Go through all profiler questions
3. Run `wp option get woocommerce_onboarding_profile`
4. Observe the value returned contains `skipped => true`, example:
```
array (
  'skipped' => true,
  'is_agree_marketing' => false,
  'store_email' => '[redacted]',
  'is_store_country_set' => true,
  'industry' =>
  array (
    0 =>
    array (
      'slug' => 'fashion-apparel-accessories',
    ),
    1 =>
    array (
      'slug' => 'health-beauty',
    ),
  ),
  'product_types' =>
  array (
    0 => 'physical',
  ),
  'product_count' => '0',
  'selling_venues' => 'no',
  'setup_client' => false,
  'business_extensions' =>
  array (
    0 => 'woocommerce-payments',
  ),
  'theme' => 'blank-canvas-3',
  'completed' => true,
)
```

#### Testing when the option does not exist

1. Run `wp option delete woocommerce_onboarding_profile`
3. Run `wp option get woocommerce_onboarding_profile`
6. Observe the value returned is ```array ( 'skipped' => true )```
7. Navigate to `/wp-admin/admin.php?page=wc-admin` and observe you're not redirected to OBW

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.