### PR TITLE
Introduce helper functions for small and medium ecommerce plans detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Plan-specific tweaks can be managed using the following global functions:
 | `wc_calypso_bridge_is_ecommerce_trial_plan()`  |  Returns `true` if the site has an Ecommerce Trial plan. |
 | `wc_calypso_bridge_is_woo_express_performance_plan()`  |  Returns `true` if the site has a Woo Express Performance plan. |
 | `wc_calypso_bridge_is_woo_express_essential_plan()`  |  Returns `true` if the site has a Woo Express Essential plan. |
-| `wc_calypso_bridge_is_wpcom_ecommerce_plan()`  |  Returns `true` if the site has an Ecommerce plan from dotCom. |
+| `wc_calypso_bridge_is_wpcom_ecommerce_plan()`  |  Returns `true` if the site has an Ecommerce plan from WordPress.com. |
 | `wc_calypso_bridge_is_business_plan()` | Returns `true` if the site has a business plan. |
 
 Similarly, on the JS side, use the global `window.wcCalypsoBridge` object for fetching information about the active plan:

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ Here's a handy boilerplate for starting a new file in [this gist](https://gist.g
 Plan-specific tweaks can be managed using the following global functions:
 | Helper function |  Return value  |
 |---|---|
-| `wc_calypso_bridge_has_ecommerce_features()`   | This will return `true` for all ecommerce-related plans *(including all dotCom, Woo Express plans, and the Ecommerce Free Trial)* |
-| `wc_calypso_bridge_is_ecommerce_plan()`   | Returns `true` if the site has a paid Ecommerce plan (including all dotCom and Woo Express plans) |
+| `wc_calypso_bridge_has_ecommerce_features()`   | This will return `true` for all ecommerce-related plans *(including all WordPress.com, Woo Express plans, and the Ecommerce Free Trial)* |
+| `wc_calypso_bridge_is_ecommerce_plan()`   | Returns `true` if the site has a paid Ecommerce plan (including all WordPress.com and Woo Express plans) |
 | `wc_calypso_bridge_is_ecommerce_trial_plan()`  |  Returns `true` if the site has an Ecommerce Trial plan. |
 | `wc_calypso_bridge_is_woo_express_performance_plan()`  |  Returns `true` if the site has a Woo Express Performance plan. |
 | `wc_calypso_bridge_is_woo_express_essential_plan()`  |  Returns `true` if the site has a Woo Express Essential plan. |

--- a/README.md
+++ b/README.md
@@ -88,9 +88,12 @@ Here's a handy boilerplate for starting a new file in [this gist](https://gist.g
 Plan-specific tweaks can be managed using the following global functions:
 | Helper function |  Return value  |
 |---|---|
-| `wc_calypso_bridge_has_ecommerce_features()`   | This will return `true` for all ecommerce-related plans *(such as the Ecommerce and Ecommerce Trial.)* |
-| `wc_calypso_bridge_is_ecommerce_plan()`   | Returns `true` if site has the specific Ecommerce plan. e.g., `false` for the trial plan. |
+| `wc_calypso_bridge_has_ecommerce_features()`   | This will return `true` for all ecommerce-related plans *(including all dotCom, Woo Express plans, and the Ecommerce Free Trial)* |
+| `wc_calypso_bridge_is_ecommerce_plan()`   | Returns `true` if the site has a paid Ecommerce plan (including all dotCom and Woo Express plans) |
 | `wc_calypso_bridge_is_ecommerce_trial_plan()`  |  Returns `true` if the site has an Ecommerce Trial plan. |
+| `wc_calypso_bridge_is_woo_express_performance_plan()`  |  Returns `true` if the site has a Woo Express Performance plan. |
+| `wc_calypso_bridge_is_woo_express_essential_plan()`  |  Returns `true` if the site has a Woo Express Essential plan. |
+| `wc_calypso_bridge_is_wpcom_ecommerce_plan()`  |  Returns `true` if the site has an Ecommerce plan from dotCom. |
 | `wc_calypso_bridge_is_business_plan()` | Returns `true` if the site has a business plan. |
 
 Similarly, on the JS side, use the global `window.wcCalypsoBridge` object for fetching information about the active plan:

--- a/class-wc-calypso-bridge-dotcom-features.php
+++ b/class-wc-calypso-bridge-dotcom-features.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   2.0.0
- * @version 2.0.0
+ * @version 2.1.3
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -54,6 +54,32 @@ if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_trial_plan' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_small_plan' ) ) {
+	/**
+	 * Returns if a site is an Small eCommerce plan site or not.
+	 *
+	 * @since 2.1.3
+	 *
+	 * @return bool True if the site is an small ecommerce site.
+	 */
+	function wc_calypso_bridge_is_ecommerce_small_plan() {
+		return WC_Calypso_Bridge_DotCom_Features::is_ecommerce_small_plan();
+	}
+}
+
+if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_medium_plan' ) ) {
+	/**
+	 * Returns if a site is an Medium eCommerce plan site or not.
+	 *
+	 * @since 2.1.3
+	 *
+	 * @return bool True if the site is an medium ecommerce site.
+	 */
+	function wc_calypso_bridge_is_ecommerce_medium_plan() {
+		return WC_Calypso_Bridge_DotCom_Features::is_ecommerce_medium_plan();
+	}
+}
+
 /**
  * WC Calypso Bridge DotCom Features class.
  */
@@ -81,6 +107,20 @@ class WC_Calypso_Bridge_DotCom_Features {
 	 * @var bool
 	 */
 	protected static $is_ecommerce_trial_plan = null;
+
+	/**
+	 * Is Ecommerce Small plan.
+	 *
+	 * @var bool
+	 */
+	protected static $is_ecommerce_small_plan = null;
+
+	/**
+	 * Is Ecommerce Medium plan.
+	 *
+	 * @var bool
+	 */
+	protected static $is_ecommerce_medium_plan = null;
 
 	/**
 	 * Is Business plan.
@@ -115,6 +155,35 @@ class WC_Calypso_Bridge_DotCom_Features {
 		return self::$is_ecommerce_plan;
 	}
 
+	/**
+	 * Determine if site is Small Ecommerce and cache it.
+	 *
+	 * @since 2.1.3
+	 *
+	 * @var bool
+	 */
+	public static function is_ecommerce_small_plan() {
+		if ( is_null( self::$is_ecommerce_small_plan ) ) {
+			self::$is_ecommerce_small_plan = self::has_ecommerce_features() && wpcom_site_has_feature( \WPCOM_Features::ECOMMERCE_MANAGED_PLUGINS_SMALL );
+		}
+
+		return self::$is_ecommerce_small_plan;
+	}
+
+	/**
+	 * Determine if site is Medium Ecommerce and cache it.
+	 *
+	 * @since 2.1.3
+	 *
+	 * @var bool
+	 */
+	public static function is_ecommerce_medium_plan() {
+		if ( is_null( self::$is_ecommerce_medium_plan ) ) {
+			self::$is_ecommerce_medium_plan = self::has_ecommerce_features() && wpcom_site_has_feature( \WPCOM_Features::ECOMMERCE_MANAGED_PLUGINS_MEDIUM );
+		}
+
+		return self::$is_ecommerce_medium_plan;
+	}
 
 	/**
 	 * Determine if site is Ecommerce Trial and cache it.

--- a/class-wc-calypso-bridge-dotcom-features.php
+++ b/class-wc-calypso-bridge-dotcom-features.php
@@ -67,7 +67,7 @@ if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_trial_plan' ) ) {
 	}
 }
 
-if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_small_plan' ) ) {
+if ( ! function_exists( 'wc_calypso_bridge_is_woo_express_essential_plan' ) ) {
 	/**
 	 * Returns if a site is an Small eCommerce plan (Woo Express Essential) site or not.
 	 *
@@ -75,12 +75,12 @@ if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_small_plan' ) ) {
 	 *
 	 * @return bool True if the site is an small ecommerce site.
 	 */
-	function wc_calypso_bridge_is_ecommerce_small_plan() {
+	function wc_calypso_bridge_is_woo_express_essential_plan() {
 		return WC_Calypso_Bridge_DotCom_Features::is_ecommerce_small_plan();
 	}
 }
 
-if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_medium_plan' ) ) {
+if ( ! function_exists( 'wc_calypso_bridge_is_woo_express_performance_plan' ) ) {
 	/**
 	 * Returns if a site is an Medium eCommerce plan (Woo Express Performance) site or not.
 	 *
@@ -88,7 +88,7 @@ if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_medium_plan' ) ) {
 	 *
 	 * @return bool True if the site is an medium ecommerce site.
 	 */
-	function wc_calypso_bridge_is_ecommerce_medium_plan() {
+	function wc_calypso_bridge_is_woo_express_performance_plan() {
 		return WC_Calypso_Bridge_DotCom_Features::is_ecommerce_medium_plan();
 	}
 }

--- a/class-wc-calypso-bridge-dotcom-features.php
+++ b/class-wc-calypso-bridge-dotcom-features.php
@@ -194,6 +194,10 @@ class WC_Calypso_Bridge_DotCom_Features {
 		if ( is_null( self::$is_wpcom_ecommerce_plan ) ) {
 
 			self::$is_wpcom_ecommerce_plan = false;
+			if ( ! function_exists( 'wpcom_get_site_purchases' ) ) {
+				return self::$is_wpcom_ecommerce_plan;
+			}
+
 			$all_site_purchases      = wpcom_get_site_purchases();
 			$plan_purchases          = array_filter(
 				$all_site_purchases,

--- a/class-wc-calypso-bridge-dotcom-features.php
+++ b/class-wc-calypso-bridge-dotcom-features.php
@@ -36,7 +36,7 @@ if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_plan' ) ) {
 	/**
 	 * Returns if a site is an eCommerce paid plan site or not.
 	 *
-	 * @return bool True if the site is an paid ecommerce site.
+	 * @return bool True if the site is a paid ecommerce site.
 	 */
 	function wc_calypso_bridge_is_ecommerce_plan() {
 		return WC_Calypso_Bridge_DotCom_Features::is_ecommerce_plan();
@@ -45,11 +45,11 @@ if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_plan' ) ) {
 
 if ( ! function_exists( 'wc_calypso_bridge_is_wpcom_ecommerce_plan' ) ) {
 	/**
-	 * Returns if a site is an eCommerce plan site from dotCom or not.
+	 * Returns if a site has an eCommerce plan from WordPress.com or not.
 	 *
 	 * @since 2.1.3
 	 *
-	 * @return bool True if the site is an ecommerce from dotCom site.
+	 * @return bool True if the site has a WordPress.com eCommerce plan.
 	 */
 	function wc_calypso_bridge_is_wpcom_ecommerce_plan() {
 		return WC_Calypso_Bridge_DotCom_Features::is_wpcom_ecommerce_plan();
@@ -73,7 +73,7 @@ if ( ! function_exists( 'wc_calypso_bridge_is_woo_express_essential_plan' ) ) {
 	 *
 	 * @since 2.1.3
 	 *
-	 * @return bool True if the site is an small ecommerce site.
+	 * @return bool True if the site has a small ecommerce plan.
 	 */
 	function wc_calypso_bridge_is_woo_express_essential_plan() {
 		return WC_Calypso_Bridge_DotCom_Features::is_ecommerce_small_plan();
@@ -86,7 +86,7 @@ if ( ! function_exists( 'wc_calypso_bridge_is_woo_express_performance_plan' ) ) 
 	 *
 	 * @since 2.1.3
 	 *
-	 * @return bool True if the site is an medium ecommerce site.
+	 * @return bool True if the site has a medium ecommerce plan.
 	 */
 	function wc_calypso_bridge_is_woo_express_performance_plan() {
 		return WC_Calypso_Bridge_DotCom_Features::is_ecommerce_medium_plan();
@@ -115,7 +115,7 @@ class WC_Calypso_Bridge_DotCom_Features {
 	protected static $is_ecommerce_plan = null;
 
 	/**
-	 * Is an Ecommerce plan from dotCom.
+	 * Is an Ecommerce plan from WordPress.com.
 	 *
 	 * @since 2.1.3
 	 *
@@ -156,7 +156,7 @@ class WC_Calypso_Bridge_DotCom_Features {
 	protected static $is_business_plan = null;
 
 	/**
-	 * Determine if site is Ecommerce and cache it.
+	 * Determine if site has a WordPress.com eCommerce plan and cache the result.
 	 *
 	 * @var bool
 	 */
@@ -169,7 +169,7 @@ class WC_Calypso_Bridge_DotCom_Features {
 	}
 
 	/**
-	 * Determine if site is a paid Ecommerce plan and cache it (refers all ecommerce plans from dotCom or WCCOM).
+	 * Determine if site is a paid Ecommerce plan and cache it (includes all WordPress.com and Woo Express ecommerce plans).
 	 *
 	 * @var bool
 	 */
@@ -184,7 +184,7 @@ class WC_Calypso_Bridge_DotCom_Features {
 	}
 
 	/**
-	 * Determine if site is Ecommerce from dotCom and cache it.
+	 * Determine if site has a WordPress.com eCommerce plan and cache the result.
 	 *
 	 * @since 2.1.3
 	 *

--- a/class-wc-calypso-bridge-dotcom-features.php
+++ b/class-wc-calypso-bridge-dotcom-features.php
@@ -174,13 +174,13 @@ class WC_Calypso_Bridge_DotCom_Features {
 	 * @var bool
 	 */
 	public static function is_ecommerce_plan() {
-		if ( is_null( self::$is_wpcom_ecommerce_plan ) ) {
-			self::$is_wpcom_ecommerce_plan = self::has_ecommerce_features() && (
+		if ( is_null( self::$is_ecommerce_plan ) ) {
+			self::$is_ecommerce_plan = self::has_ecommerce_features() && (
 				wpcom_site_has_feature( \WPCOM_Features::ECOMMERCE_MANAGED_PLUGINS_SMALL ) || wpcom_site_has_feature( \WPCOM_Features::ECOMMERCE_MANAGED_PLUGINS_MEDIUM )
 			);
 		}
 
-		return self::$is_wpcom_ecommerce_plan;
+		return self::$is_ecommerce_plan;
 	}
 
 	/**
@@ -191,9 +191,9 @@ class WC_Calypso_Bridge_DotCom_Features {
 	 * @var bool
 	 */
 	public static function is_wpcom_ecommerce_plan() {
-		if ( is_null( self::$is_ecommerce_plan ) ) {
+		if ( is_null( self::$is_wpcom_ecommerce_plan ) ) {
 
-			self::$is_ecommerce_plan = false;
+			self::$is_wpcom_ecommerce_plan = false;
 			$all_site_purchases      = wpcom_get_site_purchases();
 			$plan_purchases          = array_filter(
 				$all_site_purchases,
@@ -206,12 +206,12 @@ class WC_Calypso_Bridge_DotCom_Features {
 				// We have exactly one plan
 				$plan_purchase = reset( $plan_purchases );
 				if ( 'wp-bundle-ecommerce' === $plan_purchase->billing_product_slug ) {
-					self::$is_ecommerce_plan = self::has_ecommerce_features();
+					self::$is_wpcom_ecommerce_plan = self::has_ecommerce_features();
 				}
 			}
 		}
 
-		return self::$is_ecommerce_plan;
+		return self::$is_wpcom_ecommerce_plan;
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-tracks.php
+++ b/includes/class-wc-calypso-bridge-tracks.php
@@ -120,6 +120,10 @@ class WC_Calypso_Bridge_Tracks {
 		// since some plans may have overlapping features.
 		if ( wc_calypso_bridge_is_ecommerce_trial_plan() ) {
 			$host_value = 'ecommplan-freetrial';
+		} elseif ( wc_calypso_bridge_is_ecommerce_medium_plan() ) {
+			$host_value = 'woo-express-performance';
+		} elseif ( wc_calypso_bridge_is_ecommerce_small_plan() ) {
+			$host_value = 'woo-express-essentials';
 		} elseif ( wc_calypso_bridge_has_ecommerce_features() ) {
 			$host_value = 'ecommplan';
 		}

--- a/includes/class-wc-calypso-bridge-tracks.php
+++ b/includes/class-wc-calypso-bridge-tracks.php
@@ -120,9 +120,9 @@ class WC_Calypso_Bridge_Tracks {
 		// since some plans may have overlapping features.
 		if ( wc_calypso_bridge_is_ecommerce_trial_plan() ) {
 			$host_value = 'ecommplan-freetrial';
-		} elseif ( wc_calypso_bridge_is_ecommerce_medium_plan() ) {
+		} elseif ( wc_calypso_bridge_is_woo_express_performance_plan() ) {
 			$host_value = 'woo-express-performance';
-		} elseif ( wc_calypso_bridge_is_ecommerce_small_plan() ) {
+		} elseif ( wc_calypso_bridge_is_woo_express_essential_plan() ) {
 			$host_value = 'woo-express-essentials';
 		} elseif ( wc_calypso_bridge_is_wpcom_ecommerce_plan() ) {
 			$host_value = 'ecommplan';

--- a/includes/class-wc-calypso-bridge-tracks.php
+++ b/includes/class-wc-calypso-bridge-tracks.php
@@ -124,6 +124,8 @@ class WC_Calypso_Bridge_Tracks {
 			$host_value = 'woo-express-performance';
 		} elseif ( wc_calypso_bridge_is_ecommerce_small_plan() ) {
 			$host_value = 'woo-express-essentials';
+		} elseif ( wc_calypso_bridge_is_wpcom_ecommerce_plan() ) {
+			$host_value = 'ecommplan';
 		} elseif ( wc_calypso_bridge_has_ecommerce_features() ) {
 			$host_value = 'ecommplan';
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -23,6 +23,7 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 = Unreleased =
+* Add helper functions to detect the new Essential and Performance WooX plans. #1128
 * Remove useSlot monkey patch. #1117
 * Make OBW skip reliable for ecommerce and free trial plans #1125
 

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,7 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 = Unreleased =
-* Add helper functions to detect the new Essential and Performance WooX plans. #1128
+* Add helper functions to detect the new Essential and Performance Woo Express plans. #1128
 * Remove useSlot monkey patch. #1117
 * Make OBW skip reliable for ecommerce and free trial plans #1125
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR aims to introduce new helper functions to detect the following:
- `wc_calypso_bridge_is_woo_express_performance_plan `: Ecommerce Medium Plan (aka Woo Express Performance)
- `wc_calypso_bridge_is_woo_express_essential_plan `: Ecommerce Small Plan (aka Woo Express Essential)
- `wc_calypso_bridge_is_wpcom_ecommerce_plan`: Ecommerce Plan from wpcom.

In addition, it enhances our ability to pinpoint the following plans with more precision:
- `wc_calypso_bridge_is_ecommerce_trial_plan`: Woo Express Free Trial; and
- `wc_calypso_bridge_is_ecommerce_plan`: Whether the site has a **paid** Ecommerce plan (including all dotCom and WCCOM-related ecommerce plans)

Lastly, updates the Host value for the WC Tracks and the WC Tracker controller as follows:

- `ecommplan`: For Ecommerce sites registered from dotCom
- `ecommplan-freetrial`: For Free Trial sites
- `woo-express-essentials`: For the sites that upgraded from Trial to the Woo Express Essential plan.
- `woo-express-performance`: For the sites that upgraded from Trial to the Woo Express Performance plan.

Closes #1085 

**Note to self:** Update the repo's readme with the new functions for posterity.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

To verify, look for the `woocommerceTracksFilterProperties` token in the "View Source" for all plans and confirm that the appropriate host is assigned to each.
Remember to test for:
1. Free Trial sites
2. Ecommerce sites registered from dotCom.
3. Ecommerce sites that upgraded to the Essential plan.
4. Ecommerce sites that upgraded to the Performance plan.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
