### PR TITLE
Prepare for 2.1.3 release

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -25,7 +25,7 @@ This section describes how to install the plugin and get it working.
 = 2.1.3 =
 * Add helper functions to detect the new Essential and Performance Woo Express plans. #1128
 * Remove useSlot monkey patch. #1117
-* Optimize bridge file size by lazy-loading components #1123.
+* Optimize bridge file size by lazy-loading components #1124.
 * Make OBW skip reliable for ecommerce and free trial plans #1125
 
 = 2.1.2 =

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes
 Tags: woocommerce
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 2.1.2
+Stable tag: 2.1.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,7 +22,7 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
-= Unreleased =
+= 2.1.3 =
 * Add helper functions to detect the new Essential and Performance Woo Express plans. #1128
 * Remove useSlot monkey patch. #1117
 * Optimize bridge file size by lazy-loading components #1123.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Preparation for release of version 2.1.3. 

**Note:** I started the deployment process using the new tools but I reverted to manual due an issue with the automation. The main file's version bumps happened here: https://github.com/Automattic/wc-calypso-bridge/commit/1dd9c664813ee6f89e5737b8c281bc3b2a30855f

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### Included PRs
- https://github.com/Automattic/wc-calypso-bridge/pull/1128
- https://github.com/Automattic/wc-calypso-bridge/pull/1117
- https://github.com/Automattic/wc-calypso-bridge/pull/1124
- https://github.com/Automattic/wc-calypso-bridge/pull/1125

### Changelog
```
= 2.1.3 =
* Add helper functions to detect the new Essential and Performance Woo Express plans. #1128
* Remove useSlot monkey patch. #1117
* Optimize bridge file size by lazy-loading components #1124
* Make OBW skip reliable for ecommerce and free trial plans #1125
```
