### PR TITLE
Deploy Automation: Make the changelog update command a standalone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We now have a series of scripts that will help with automating the release proce
 1. Make sure you're running NodeJS v16. If you use [nvm](https://github.com/nvm-sh/nvm), you can simply type `nvm use`. If you prefer [fnm](https://github.com/Schniz/fnm), you can run `fnm use` instead.
 2. Run `npm install` in the project root to make sure all dependencies are installed at the project level and in the `./scripts` folder.
 3. Run `npm run bump-version` in the project root. This will increment the project version and create a git commit.
-4. Run `node run update-readme` in the project root. This will prompt you to select the commits that are part of this release. The commit log messages will be automatically added to the [changelog](readme.txt) and committed.
+4. Run `npm run update-readme` in the project root. This will prompt you to select the commits that are part of this release. The commit log messages will be automatically added to the [changelog](readme.txt) and committed.
 5. Manually create a new PR with the updated version and change log.
 6. Once that PR is approved and merged, run `npm run create-release`. Follow the prompts to do a build, create a new release tag, and deploy the release tag.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We now have a series of scripts that will help with automating the release proce
 1. Make sure you're running NodeJS v16. If you use [nvm](https://github.com/nvm-sh/nvm), you can simply type `nvm use`. If you prefer [fnm](https://github.com/Schniz/fnm), you can run `fnm use` instead.
 2. Run `npm install` in the project root to make sure all dependencies are installed at the project level and in the `./scripts` folder.
 3. Run `npm run bump-version` in the project root. This will increment the project version and create a git commit.
-4. Run `node scripts/commands/readme.js` in the project root. This will prompt you to select the commits that are part of this release. The commit log messages will be automatically added to the [changelog](readme.txt) and committed.
+4. Run `node run update-readme` in the project root. This will prompt you to select the commits that are part of this release. The commit log messages will be automatically added to the [changelog](readme.txt) and committed.
 5. Manually create a new PR with the updated version and change log.
 6. Once that PR is approved and merged, run `npm run create-release`. Follow the prompts to do a build, create a new release tag, and deploy the release tag.
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"test:unit": "wp-scripts test-unit-js",
 		"create-release": "node ./scripts/release.js",
 		"bump-version": "node ./scripts/commands/bump-version.js",
+		"update-readme": "node ./scripts/commands/readme.js",
 		"makepot": "node ./scripts/commands/update-translations.js"
 	},
 	"workspaces": [

--- a/scripts/commands/readme.js
+++ b/scripts/commands/readme.js
@@ -6,6 +6,7 @@ import {
 	info,
 	success,
 	NOTICE_LEVEL,
+	getCurrentBranchName,
 	getCurrentVersion,
 	gitFactory,
 	promptContinue,
@@ -13,9 +14,11 @@ import {
 	updateChangelog,
 } from '../utils.js';
 
-async function updateReadMe( currentBranchName ) {
+async function updateReadMe() {
 	// Ensure we're always running in the project root.
 	process.chdir( `${ __dirname }/..` );
+
+	const currentBranchName = await getCurrentBranchName();
 
 	if ( ! fs.existsSync( 'readme.txt' ) ) {
 		return abortAndSwitchToBranch(
@@ -85,3 +88,5 @@ async function updateReadMe( currentBranchName ) {
 	success( 'Readme updated successfully.' );
 	return true;
 }
+
+updateReadMe();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Related to #1096.

Eventually, we plan to roll the bump-version and update-readme commands into a single command which performs both actions and creates an associated PR.

For now though, we do both as standalone commands. We had a bug where the update-readme command couldn't run by itself. This fixes that bug.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

This command will be rolled into another command later. For now, run it with `npm run update-readme`.

### Don't select any commits
* When presented with the list of commits, simply press `ENTER`.
* You should see a `ERROR: No commits selected. Aborting readme update.` error.

### Don't update the readme
* When presented with the list of commits, select several and press `ENTER`.
* At the "Would you like to update readme.txt with the above changelog entry?", say `N`.
* You should get a `INFO: Aborting readme update.` message and no changes will be made.

### Update the readme
* When presented with the list of commits, select several and press `ENTER`.
* At the "Would you like to update readme.txt with the above changelog entry?", say `Y`.
* You should get an `SUCCESS: Readme updated successfully.` message.
* Run `git log`.
* You should see a new commit that reads `Added version x.x.x to the changelog`.
* Run `git show HEAD`.
* You should see the commits you selected added to the changelog in the correct place.

Once you're done testing this last step, run `git reset --hard HEAD~1` to remove the readme update commit.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
