### PR TITLE
Add WooExpress `Upgrades > Plans` track in WooCommerce screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"scripts"
 			],
 			"dependencies": {
+				"@automattic/calypso-analytics": "^1.0.0-alpha.1",
 				"@automattic/interpolate-components": "^1.2.1",
 				"@woocommerce/onboarding": "^3.3.0",
 				"classnames": "^2.3.2",
@@ -48,6 +49,24 @@
 			"engines": {
 				"node": ">=6.0.0"
 			}
+		},
+		"node_modules/@automattic/calypso-analytics": {
+			"version": "1.0.0-alpha.1",
+			"resolved": "https://registry.npmjs.org/@automattic/calypso-analytics/-/calypso-analytics-1.0.0-alpha.1.tgz",
+			"integrity": "sha512-iW5UKXSj+XOvZGbD0T6eWE7bFFZnrDgjSQdaN3XFEhznuLN3+2ABqT3jdG492+xgklikCbY3mIEeSxoU4Okuww==",
+			"dependencies": {
+				"@automattic/load-script": "^1.0.0",
+				"cookie": "^0.4.0",
+				"debug": "^4.1.1",
+				"hash.js": "^1.1.7",
+				"lodash": "^4.17.15",
+				"tslib": "^1.10.0"
+			}
+		},
+		"node_modules/@automattic/calypso-analytics/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@automattic/calypso-color-schemes": {
 			"version": "2.1.1",
@@ -220,6 +239,23 @@
 			"integrity": "sha512-froTyDbTmLitHkvY9WLCpFdjUo6moOLkDKw63J2fLiB2gBApy2thkBV+LRx4Z0kIF5iXVkQF4yYOPYkT9Sr13Q==",
 			"dependencies": {
 				"tslib": "^2.3.0"
+			}
+		},
+		"node_modules/@automattic/load-script": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@automattic/load-script/-/load-script-1.0.0.tgz",
+			"integrity": "sha512-Hc1mRmTK12OKrONnGhe7Ht1Gpo4B/ls8WQ1IZ1/qBws1bUZ6u7Crnpv3HZkN4UI7irG3OU4l4Pn1TXtoJLcKRw==",
+			"dependencies": {
+				"@babel/runtime": "^7.4.4",
+				"debug": "^3.2.6"
+			}
+		},
+		"node_modules/@automattic/load-script/node_modules/debug": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+			"dependencies": {
+				"ms": "^2.1.1"
 			}
 		},
 		"node_modules/@automattic/tour-kit": {
@@ -25552,6 +25588,26 @@
 				"@jridgewell/trace-mapping": "^0.3.9"
 			}
 		},
+		"@automattic/calypso-analytics": {
+			"version": "1.0.0-alpha.1",
+			"resolved": "https://registry.npmjs.org/@automattic/calypso-analytics/-/calypso-analytics-1.0.0-alpha.1.tgz",
+			"integrity": "sha512-iW5UKXSj+XOvZGbD0T6eWE7bFFZnrDgjSQdaN3XFEhznuLN3+2ABqT3jdG492+xgklikCbY3mIEeSxoU4Okuww==",
+			"requires": {
+				"@automattic/load-script": "^1.0.0",
+				"cookie": "^0.4.0",
+				"debug": "^4.1.1",
+				"hash.js": "^1.1.7",
+				"lodash": "^4.17.15",
+				"tslib": "^1.10.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
 		"@automattic/calypso-color-schemes": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/@automattic/calypso-color-schemes/-/calypso-color-schemes-2.1.1.tgz",
@@ -25697,6 +25753,25 @@
 			"integrity": "sha512-froTyDbTmLitHkvY9WLCpFdjUo6moOLkDKw63J2fLiB2gBApy2thkBV+LRx4Z0kIF5iXVkQF4yYOPYkT9Sr13Q==",
 			"requires": {
 				"tslib": "^2.3.0"
+			}
+		},
+		"@automattic/load-script": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@automattic/load-script/-/load-script-1.0.0.tgz",
+			"integrity": "sha512-Hc1mRmTK12OKrONnGhe7Ht1Gpo4B/ls8WQ1IZ1/qBws1bUZ6u7Crnpv3HZkN4UI7irG3OU4l4Pn1TXtoJLcKRw==",
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"debug": "^3.2.6"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				}
 			}
 		},
 		"@automattic/tour-kit": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"typescript": "^4.9.5"
 	},
 	"dependencies": {
+		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
 		"@automattic/interpolate-components": "^1.2.1",
 		"@woocommerce/onboarding": "^3.3.0",
 		"classnames": "^2.3.2",

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,7 @@ This section describes how to install the plugin and get it working.
 
 = Unreleased =
 * Default to wide alignment when provisioning the Cart and Checkout pages. #1043
+* Add WooExpress Upgrades > Plans track. #1156
 
 = 2.1.5 =
 * Make the readme update command run standalone

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ import {
 import './index.scss';
 import { CalypsoBridgeHomescreenBanner } from './homescreen-banner';
 import './task-headers';
+import './track-menu-item';
 
 // Modify webpack to append the ?ver parameter to JS chunk
 // https://webpack.js.org/api/module-variables/#__webpack_get_script_filename__-webpack-specific

--- a/src/track-menu-item.ts
+++ b/src/track-menu-item.ts
@@ -27,6 +27,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		}
 
 		possiblePlanLink.addEventListener( 'click', function () {
+			// Note that we also track this event in Calypso Screen via wp-calypso. If you change this event, please update it there as well. See: https://github.com/Automattic/wp-calypso/pull/77303.
 			recordTracksEvent( 'calypso_sidebar_item_click', {
 				path: '/plans',
 			} );

--- a/src/track-menu-item.ts
+++ b/src/track-menu-item.ts
@@ -11,8 +11,15 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	);
 	possiblePlansLinks.forEach( ( possiblePlanLink ) => {
 		possiblePlanLink.addEventListener( 'click', function ( evt ) {
-			const href = evt && evt.target ? evt.target.getAttribute( 'href' ) : null;
-			if ( ! href || typeof href !== 'string' || ! href.startsWith( 'https://wordpress.com/plans/' )  ) {
+			const href =
+				evt && evt.target
+					? ( evt.target as HTMLLinkElement ).getAttribute( 'href' )
+					: null;
+			if (
+				! href ||
+				typeof href !== 'string' ||
+				! href.startsWith( 'https://wordpress.com/plans/' )
+			) {
 				return;
 			}
 			// Check if we're navigating to /plans/:siteSlug or some deeper path below /plans/[something]/siteSlug
@@ -25,5 +32,5 @@ document.addEventListener( 'DOMContentLoaded', function () {
 				path: '/plans',
 			} );
 		} );
-	}
+	} );
 } );

--- a/src/track-menu-item.ts
+++ b/src/track-menu-item.ts
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+
+document.addEventListener( 'DOMContentLoaded', function () {
+	// Track clicks on the "Upgrades > Plans" menu item in the sidebar
+	const el = document.querySelector(
+		'#toplevel_page_paid-upgrades > ul > li.wp-first-item'
+	);
+	if ( el ) {
+		el.addEventListener( 'click', function () {
+			recordTracksEvent( 'calypso_sidebar_item_click', {
+				path: '/plans',
+			} );
+		} );
+	}
+} );

--- a/src/track-menu-item.ts
+++ b/src/track-menu-item.ts
@@ -10,24 +10,23 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		'#toplevel_page_paid-upgrades a[href^="https://wordpress.com/plans/"]'
 	);
 	possiblePlansLinks.forEach( ( possiblePlanLink ) => {
-		possiblePlanLink.addEventListener( 'click', function ( evt ) {
-			const href =
-				evt && evt.target
-					? ( evt.target as HTMLLinkElement ).getAttribute( 'href' )
-					: null;
-			if (
-				! href ||
-				typeof href !== 'string' ||
-				! href.startsWith( 'https://wordpress.com/plans/' )
-			) {
-				return;
-			}
-			// Check if we're navigating to /plans/:siteSlug or some deeper path below /plans/[something]/siteSlug
-			// The implementation can be changed to be simpler or different, but the check is needed.
-			const hasDeeperPath = href.substring( 28 ).includes( '/' );
-			if ( hasDeeperPath ) {
-				return;
-			}
+		const href = possiblePlanLink.getAttribute( 'href' );
+		if (
+			! href ||
+			typeof href !== 'string' ||
+			! href.startsWith( 'https://wordpress.com/plans/' )
+		) {
+			return;
+		}
+
+		// Check if we're navigating to /plans/:siteSlug or some deeper path below /plans/[something]/siteSlug
+		// The implementation can be changed to be simpler or different, but the check is needed.
+		const hasDeeperPath = href.substring( 28 ).includes( '/' );
+		if ( hasDeeperPath ) {
+			return;
+		}
+
+		possiblePlanLink.addEventListener( 'click', function () {
 			recordTracksEvent( 'calypso_sidebar_item_click', {
 				path: '/plans',
 			} );

--- a/src/track-menu-item.ts
+++ b/src/track-menu-item.ts
@@ -5,11 +5,22 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 
 document.addEventListener( 'DOMContentLoaded', function () {
 	// Track clicks on the "Upgrades > Plans" menu item in the sidebar
-	const el = document.querySelector(
-		'#toplevel_page_paid-upgrades > ul > li.wp-first-item'
+	// Find all links under Upgrades that point to /plans/* paths
+	const possiblePlansLinks = document.querySelectorAll(
+		'#toplevel_page_paid-upgrades a[href^="https://wordpress.com/plans/"]'
 	);
-	if ( el ) {
-		el.addEventListener( 'click', function () {
+	possiblePlansLinks.forEach( ( possiblePlanLink ) => {
+		possiblePlanLink.addEventListener( 'click', function ( evt ) {
+			const href = evt && evt.target ? evt.target.getAttribute( 'href' ) : null;
+			if ( ! href || typeof href !== 'string' || ! href.startsWith( 'https://wordpress.com/plans/' )  ) {
+				return;
+			}
+			// Check if we're navigating to /plans/:siteSlug or some deeper path below /plans/[something]/siteSlug
+			// The implementation can be changed to be simpler or different, but the check is needed.
+			const hasDeeperPath = href.substring( 28 ).includes( '/' );
+			if ( hasDeeperPath ) {
+				return;
+			}
 			recordTracksEvent( 'calypso_sidebar_item_click', {
 				path: '/plans',
 			} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/Automattic/wp-calypso/issues/76877.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

Related: https://github.com/Automattic/wp-calypso/pull/77303

This PR adds `calypso_sidebar_item_click` track which is fired when a user clicks on Upgrades > Plans menu item in WooCommerce Screen in a WooExpress/WooTrial site.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Go to a free trial site
2. Go to WooCommerce > Home 
3. Open the dev tool console and enable debugging via `window.localStorage.setItem( 'debug', 'calypso:analytics' )`
4. Click on `Upgrades > Plans`
5. Observe that `calypso_sidebar_item_click` event is recorded with prop `path = '/plans'`.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
