### PR TITLE
Add UTM tags on the "Extensions > Discover" page links

### DIFF
--- a/includes/templates/html-admin-page-addons-landing-page.php
+++ b/includes/templates/html-admin-page-addons-landing-page.php
@@ -4,7 +4,7 @@
 *
 * @package WC_Calypso_Bridge/Templates
 * @since   2.0.4
-* @version 2.0.16
+* @version 2.1.6
 *
 * @uses $upgrade_url
 */

--- a/includes/templates/html-admin-page-addons-landing-page.php
+++ b/includes/templates/html-admin-page-addons-landing-page.php
@@ -27,7 +27,7 @@
 		<a href="<?php echo esc_url( $upgrade_url ); ?>" class="button button-primary" id="upgrade_now_button">
 			<?php esc_html_e( 'Upgrade now', 'wc-calypso-bridge' ); ?>
 		</a>
-		<a href="https://woocommerce.com/product-category/woocommerce-extensions/?categoryIds=1021&collections=product&page=1" target="_blank" class="button button-secondary" id="browse_extension_button">
+		<a href="https://woocommerce.com/product-category/woocommerce-extensions/?categoryIds=1021&collections=product&page=1&utm_source=wooextensionstab&utm_medium=product&utm_campaign=woocommerceplugin" target="_blank" class="button button-secondary" id="browse_extension_button">
 			<?php esc_html_e( 'Browse extensions', 'wc-calypso-bridge' ); ?>
 		</a>
 	</div>
@@ -56,7 +56,7 @@
 			<p>
 				<?php esc_html_e( 'Add extra features and functionality, or integrate with other platforms and tools.', 'wc-calypso-bridge' ); ?>
 			</p>
-			<a href="https://woocommerce.com/product-category/woocommerce-extensions/?categoryIds=1021&collections=product&page=1" target="_blank" id="browse_extension_button_2"><?php esc_html_e( 'Browse extensions', 'wc-calypso-bridge' ); ?></a>
+			<a href="https://woocommerce.com/product-category/woocommerce-extensions/?categoryIds=1021&collections=product&page=1&utm_source=wooextensionstab&utm_medium=product&utm_campaign=woocommerceplugin" target="_blank" id="browse_extension_button_2"><?php esc_html_e( 'Browse extensions', 'wc-calypso-bridge' ); ?></a>
 		</div>
 
 		<div class="wc-addons-landing-page__features-grid__item">
@@ -70,7 +70,7 @@
 			<p>
 				<?php esc_html_e( 'Quickly get started with our curated extension collections.', 'wc-calypso-bridge' ); ?>
 			</p>
-			<a href="https://woocommerce.com/collections" target="_blank" id="discover_collections_button"><?php esc_html_e( 'Discover collections', 'wc-calypso-bridge' ); ?></a>
+			<a href="https://woocommerce.com/collections?utm_source=wooextensionstab&utm_medium=product&utm_campaign=woocommerceplugin" target="_blank" id="discover_collections_button"><?php esc_html_e( 'Discover collections', 'wc-calypso-bridge' ); ?></a>
 		</div>
 
 		<div class="wc-addons-landing-page__features-grid__item">
@@ -84,7 +84,7 @@
 			<p>
 				<?php esc_html_e( 'Tips, tricks, and ecommerce inspiration from our blog.', 'wc-calypso-bridge' ); ?>
 			</p>
-			<a href="https://woocommerce.com/blog" target="_blank" id="get_inspired_button"><?php esc_html_e( 'Get inspired', 'wc-calypso-bridge' ); ?></a>
+			<a href="https://woocommerce.com/blog?utm_source=wooextensionstab&utm_medium=product&utm_campaign=woocommerceplugin" target="_blank" id="get_inspired_button"><?php esc_html_e( 'Get inspired', 'wc-calypso-bridge' ); ?></a>
 		</div>
 
 	</div>

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,7 @@ This section describes how to install the plugin and get it working.
 
 = Unreleased =
 * Default to wide alignment when provisioning the Cart and Checkout pages. #1043
+* Add UTM tags on the "Extensions > Discover" page links in Free Trial. #1161
 
 = 2.1.5 =
 * Make the readme update command run standalone


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1160 

Based on the discussion at p1684443710375769-slack-C2CM2ELTG, we need to add UTM tags in the page links under the "Extensions > Discover" page. 

See:
![Screenshot 2023-05-23 at 2 16 22 PM](https://github.com/Automattic/wc-calypso-bridge/assets/1105590/0f868764-0cf8-4c0d-9bc2-017191647489)


<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Open a Woo Express site.
2. Check that the links under the "Extensions > Discover" page doesn't include any utm tags.
3. Apply this patch and ensure that all links are tagged correctly.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
