### PR TITLE
Prepare for 2.1.6 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v2.1.5",
+  "version": "v2.1.6",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -22,7 +22,7 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
-= Unreleased =
+= 2.1.6 =
 * Default to wide alignment when provisioning the Cart and Checkout pages. #1043
 * Add WooExpress Upgrades > Plans track. #1156
 * Add UTM tags on the "Extensions > Discover" page links in Free Trial. #1161

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancements for users of Store on WordPress.com.
- * Version: 2.1.5
+ * Version: 2.1.6
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -47,7 +47,7 @@ if ( ! defined( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH' ) ) {
 	define( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH', dirname( __FILE__ ) );
 }
 if ( ! defined( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION' ) ) {
-	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.1.5' );
+	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.1.6' );
 }
 if ( ! defined( 'WC_MIN_VERSION' ) ) {
 	define( 'WC_MIN_VERSION', '7.3' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Preparation for release of version 2.1.6.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### Included PRs

* #1043
* #1156
* #1161
* #1162

### Changelog

```
= 2.1.6 =
* Default to wide alignment when provisioning the Cart and Checkout pages. #1043
* Add WooExpress Upgrades > Plans track. #1156
* Add UTM tags on the "Extensions > Discover" page links in Free Trial. #1161
* Fix fatal errors in onboarding option filters #1162
```