### PR TITLE
Suppress WooCommerce Subscriptions move/duplicated site messages

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= unreleased =
+* Suppress WooCommerce Subscriptions move/duplicated site messages. #xxx 
+
 = 2.1.6 =
 * Default to wide alignment when provisioning the Cart and Checkout pages. #1043
 * Add WooExpress Upgrades > Plans track. #1156


### PR DESCRIPTION


### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1048  .

- #1048

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

**Before syncing this PR to your site, make sure your store has a USA address, so that the notice pops up.**

Once you see the notice, run `wp option get wc_subscriptions_siteurl` . In case it returns something, delete it `wp option delete wc_subscriptions_siteurl`

The reason we delete it, is because new sites don't have this option, that's why the message appears

Checkout this PR and sync calypso-bridge.

- [x] When you visit the site, the staging notice should be gone
- [x] Executing `wp option get wc_subscriptions_siteurl` will return something similar to `https://devpanos.wpc_[wc_subscriptions_siteurl]_omstaging.com`
- [x] Executing `wp option get wc_calypso_bridge_one_time_operation_set_wc_subscriptions_siteurl_add_domain` should return `init` as this job will run forever until a domain is purchased
- [x] To test that the add domain job is complete, edit `class-wc-calypso-bridge-setup.php` and "fake" the site_url on line 553, something like `$site_url = 'panosisawesome.com';`
Execute `wp option get wc_calypso_bridge_one_time_operation_set_wc_subscriptions_siteurl_add_domain` and should return `complete`.
- [x] No staging messages should appear



<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
