### PR TITLE
Hide store_details task in free trial sites

### DIFF
--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-hide-tasklist-tasks.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-hide-tasklist-tasks.php
@@ -81,6 +81,7 @@ class WC_Calypso_Bridge_Free_Trial_Hide_TaskList_Tasks {
 	private function hide_tasks( $lists ) {
 		$tasklist_id = 'setup';
 		$task_ids_to_be_hidden = Array(
+			'store_details',
 			'marketing',
 		);
 

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,8 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+* Hide store_details task in free trial sites #1178
+
 = 2.1.6 =
 * Default to wide alignment when provisioning the Cart and Checkout pages. #1043
 * Add WooExpress Upgrades > Plans track. #1156


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1131.

This PR hides `store_details` task from the main tasklist for free trial sites.

<img width="779" alt="image" src="https://github.com/Automattic/wc-calypso-bridge/assets/3747241/54ffddee-53e1-4a8a-9f7c-bdf69684b81d">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

1. In a free trial site, go to WooCommerce > Home
2. Observe that the `You added store details` task is no longer shown

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
