### PR TITLE
Prepare for release 2.1.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v2.1.7",
+  "version": "v2.1.8",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -23,10 +23,7 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 = 2.1.8 =
-* Merge pull request #1172 from Automattic/fix/1048-wcs-staging-messages
-
-= unreleased =
-* Suppress WooCommerce Subscriptions move/duplicated site messages. #1172 
+* Suppress WooCommerce Subscriptions move/duplicated site messages #1172 
 
 = 2.1.7 =
 * Hide store_details task in free trial sites #1178

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 2.1.8 =
+* Merge pull request #1172 from Automattic/fix/1048-wcs-staging-messages
+
 = unreleased =
 * Suppress WooCommerce Subscriptions move/duplicated site messages. #1172 
 

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancements for users of Store on WordPress.com.
- * Version: 2.1.7
+ * Version: 2.1.8
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -47,7 +47,7 @@ if ( ! defined( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH' ) ) {
 	define( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH', dirname( __FILE__ ) );
 }
 if ( ! defined( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION' ) ) {
-	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.1.7' );
+	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.1.8' );
 }
 if ( ! defined( 'WC_MIN_VERSION' ) ) {
 	define( 'WC_MIN_VERSION', '7.3' );


### PR DESCRIPTION
Preparation for release of 2.1.8

### PRs

- #1048 

### Changelog

```
= 2.1.8 =
* Suppress WooCommerce Subscriptions move/duplicated site messages #1172 
```