### PR TITLE
Streamline Settings > Advanced > Features section

### DIFF
--- a/class-wc-calypso-bridge-dotcom-features.php
+++ b/class-wc-calypso-bridge-dotcom-features.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   2.0.0
- * @version 2.1.3
+ * @version x.x.x
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -90,6 +90,19 @@ if ( ! function_exists( 'wc_calypso_bridge_is_woo_express_performance_plan' ) ) 
 	 */
 	function wc_calypso_bridge_is_woo_express_performance_plan() {
 		return WC_Calypso_Bridge_DotCom_Features::is_ecommerce_medium_plan();
+	}
+}
+
+if ( ! function_exists( 'wc_calypso_bridge_is_woo_express_plan' ) ) {
+	/**
+	 * Returns if a site is on the Woo Express plan.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool True if the site is on the Woo Express plan.
+	 */
+	function wc_calypso_bridge_is_woo_express_plan() {
+		return wc_calypso_bridge_is_ecommerce_trial_plan() || wc_calypso_bridge_is_woo_express_essential_plan() || wc_calypso_bridge_is_woo_express_performance_plan();
 	}
 }
 

--- a/class-wc-calypso-bridge-shared.php
+++ b/class-wc-calypso-bridge-shared.php
@@ -111,7 +111,7 @@ class WC_Calypso_Bridge_Shared {
 		$params      = array(
 			'isEcommercePlan'              => (bool) wc_calypso_bridge_has_ecommerce_features(),
 			'isEcommercePlanTrial'         => (bool) wc_calypso_bridge_is_ecommerce_trial_plan(), // This is true for ecommerce trial only.
-			'isWooNavigationEnabled'       => (bool) apply_filters( 'ecommerce_new_woo_atomic_navigation_enabled', true ),
+			'isWooNavigationEnabled'       => (bool) apply_filters( 'ecommerce_new_woo_atomic_navigation_enabled', 'yes' === get_option( 'wooexpress_navigation_enabled', 'yes' ) ),
 			'isWooPage'                    => $is_woo_page,
 			'homeUrl'                      => esc_url( get_home_url() ),
 			'siteSlug'                     => $site_suffix,
@@ -165,7 +165,7 @@ class WC_Calypso_Bridge_Shared {
 	public function add_ecommerce_plan_styles() {
 		wp_enqueue_style( 'wp-calypso-bridge-ecommerce', WC_Calypso_Bridge_Instance()->get_asset_path() . 'assets/css/ecommerce.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
 
-		if ( (bool) apply_filters( 'ecommerce_new_woo_atomic_navigation_enabled', true ) ) {
+		if ( (bool) apply_filters( 'ecommerce_new_woo_atomic_navigation_enabled', 'yes' === get_option( 'wooexpress_navigation_enabled', 'yes' ) ) ) {
 			wp_enqueue_style( 'wp-calypso-bridge-ecommerce-navigation', WC_Calypso_Bridge_Instance()->get_asset_path() . 'assets/css/ecommerce-navigation.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
 		}
 	}

--- a/class-wc-calypso-bridge-shared.php
+++ b/class-wc-calypso-bridge-shared.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 2.0.8
+ * @version x.x.x
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-calypso-bridge-jetpack.php
+++ b/includes/class-wc-calypso-bridge-jetpack.php
@@ -72,7 +72,7 @@ class WC_Calypso_Bridge_Jetpack {
 			 * @return bool
 			 */
 
-			if ( (bool) apply_filters( 'ecommerce_new_woo_atomic_navigation_enabled', true ) && class_exists( '\Automattic\Jetpack\Dashboard_Customizations\Atomic_Admin_Menu' ) ) {
+			if ( (bool) apply_filters( 'ecommerce_new_woo_atomic_navigation_enabled', 'yes' === get_option( 'wooexpress_navigation_enabled', 'yes' ) ) && class_exists( '\Automattic\Jetpack\Dashboard_Customizations\Atomic_Admin_Menu' ) ) {
 				require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php';
 				return Ecommerce_Atomic_Admin_Menu::class;
 			}

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -40,7 +40,7 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 	 */
 	public function __construct() {
 
-		// Only in Woo Express plans.
+		// Only in Ecommerce and Woo Express plans.
 		if ( ! wc_calypso_bridge_has_ecommerce_features() ) {
 			return;
 		}

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -40,7 +40,7 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 	 */
 	public function __construct() {
 
-		// Only in Ecommerce.
+		// Only in Woo Express plans.
 		if ( ! wc_calypso_bridge_has_ecommerce_features() ) {
 			return;
 		}

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 2.0.0
+ * @version x.x.x
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -60,11 +60,15 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 		/*
 		 * Hide the features under 'Advanced > Features' but let users disable our commerce-optimized menu.
 		 */
-		add_filter( 'woocommerce_get_settings_advanced', array( $this, 'filter_woocommerce_settings_features' ), 1000, 2 );
-		add_filter( 'woocommerce_settings_tabs_array', array( $this, 'filter_woocommerce_settings_pages_order' ), 1000 );
-		add_filter( 'option_woocommerce_analytics_enabled', function( $value ) {
-			return 'yes';
-		}, PHP_INT_MAX );
+		add_filter( 'woocommerce_get_settings_advanced', array( $this, 'filter_woocommerce_settings_features' ), PHP_INT_MAX, 2 );
+
+		if ( wc_calypso_bridge_is_woo_express_plan() ) {
+
+			add_filter( 'woocommerce_settings_tabs_array', array( $this, 'filter_woocommerce_settings_pages_order' ), PHP_INT_MAX );
+			add_filter( 'option_woocommerce_analytics_enabled', function( $value ) {
+				return 'yes';
+			}, PHP_INT_MAX );
+		}
 
 		/*
 		 * Refresh the page to get the menu to reload when saving the Settings under 'Advanced > Features'.
@@ -167,15 +171,11 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 			return $settings;
 		}
 
-		$inject_at = wp_list_filter( $settings, array(
-			'id'   => 'woocommerce_navigation_enabled',
-		) );
-
-		array_splice( $settings, key( $inject_at ), 0,
+		array_splice( $settings, 1, 0,
 			array(
 				array(
-					'title'   => __( 'Woo Express Navigation', 'wc-calypso-bridge' ),
-					'desc'    => __( 'A custom navigation experience for Woo Express stores on WordPress.com, optimized for selling.', 'woocommerce' ),
+					'title'   => __( 'Navigation', 'wc-calypso-bridge' ),
+					'desc'    => __( 'A custom navigation experience that is optimized for selling.', 'wc-calypso-bridge' ),
 					'type'    => 'checkbox',
 					'id'      => 'wooexpress_navigation_enabled',
 					'default' => 'yes'
@@ -183,27 +183,38 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
         	)
 		);
 
-		$hpos_enabled = OrderUtil::custom_orders_table_usage_is_enabled();
-		$whitelist    = array( 'features_options', 'wooexpress_navigation_enabled' );
+		if ( wc_calypso_bridge_is_woo_express_plan() ) {
 
-		if ( $hpos_enabled ) {
-			$whitelist[] = 'experimental_features_options';
-		}
+			$hpos_enabled = OrderUtil::custom_orders_table_usage_is_enabled();
+			$whitelist    = array( 'features_options', 'wooexpress_navigation_enabled' );
 
-		foreach ( $settings as $setting_id => $setting_data ) {
-
-			if ( ! is_numeric( $setting_id ) && ! in_array( $setting_id, $whitelist ) ) {
-				unset( $settings[ $setting_id ] );
+			if ( $hpos_enabled ) {
+				$whitelist[] = 'experimental_features_options';
 			}
 
-			if ( is_array( $setting_data ) && isset( $setting_data['id'] ) && ! in_array( $setting_data['id'], $whitelist ) ) {
+			foreach ( $settings as $setting_id => $setting_data ) {
 
-				if ( 'woocommerce_feature_custom_order_tables_enabled' === $setting_data['id'] && $hpos_enabled ) {
-					// If HPOS is enabled, show the option until it's disabled.
-					continue;
+				if ( ! is_numeric( $setting_id ) && ! in_array( $setting_id, $whitelist ) ) {
+					unset( $settings[ $setting_id ] );
 				}
 
-				unset( $settings[ $setting_id ] );
+				if ( is_array( $setting_data ) && isset( $setting_data['id'] ) && ! in_array( $setting_data['id'], $whitelist ) ) {
+
+					if ( 'woocommerce_feature_custom_order_tables_enabled' === $setting_data['id'] && $hpos_enabled ) {
+						// If HPOS is enabled, show the option until it's disabled.
+						continue;
+					}
+
+					unset( $settings[ $setting_id ] );
+				}
+			}
+
+		} else {
+
+			foreach ( $settings as $setting_id => $setting_data ) {
+				if ( is_array( $setting_data ) && isset( $setting_data['id'] ) && 'woocommerce_navigation_enabled' === $setting_data['id'] ) {
+					unset( $settings[ $setting_id ] );
+				}
 			}
 		}
 

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -71,7 +71,7 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 		 */
 		add_action( 'woocommerce_settings_saved', function() {
 			global $current_section, $current_tab;
-			if ( 'advanced' === $current_tab and 'features' === $current_section ) {
+			if ( 'advanced' === $current_tab and 'features' === $current_section && ! empty( $_SERVER['REQUEST_URI'] ) ) {
 				wp_redirect( esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) );
 				exit;
 			}

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -72,7 +72,7 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 		add_action( 'woocommerce_settings_saved', function() {
 			global $current_section, $current_tab;
 			if ( 'advanced' === $current_tab and 'features' === $current_section ) {
-				wp_redirect( $_SERVER['REQUEST_URI'] );
+				wp_redirect( esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) );
 				exit;
 			}
 

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -56,11 +56,26 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 		add_filter( 'woocommerce_admin_features', array( $this, 'filter_wc_admin_enabled_features' ) );
 		add_filter( 'woocommerce_admin_get_feature_config', array( $this, 'filter_woocommerce_admin_features' ), PHP_INT_MAX );
 
-		/**
+		/*
+		 * Hide the features under 'Advanced > Features' but let users disable our commerce-optimized menu.
+		 */
+		add_filter( 'woocommerce_get_settings_advanced', array( $this, 'filter_woocommerce_settings_features' ), 1000, 2 );
+		add_filter( 'woocommerce_settings_tabs_array', array( $this, 'filter_woocommerce_settings_pages_order' ), 1000 );
+
+		/*
+		 * Refresh the page to get the menu to reload when saving the Settings under 'Advanced > Features'.
+		 */
+		add_action( 'woocommerce_settings_saved', function() {
+			global $current_section, $current_tab;
+			if ( 'advanced' === $current_tab and 'features' === $current_section ) {
+				wp_redirect( $_SERVER['REQUEST_URI'] );
+				exit;
+			}
+
+		}, 100 );
+
+		/*
 		 * Hide WC Admin's activity panel in all pages except Home.
-		 *
-		 * @param  mixed  $value
-		 * @return array
 		 */
 		add_filter( 'admin_body_class', array( $this, 'filter_woocommerce_body_classes' ) );
 		add_action( 'admin_init', array( $this, 'add_custom_activity_panels_styles' ) );
@@ -108,7 +123,7 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 	}
 
 	/**
-	 * Enable/disable features for WooCommerce Admin .
+	 * Enable/disable features for WooCommerce Admin.
 	 *
 	 * @param array $features Array containing all wc-calypso-bridge features (enabled and disabled).
 	 *
@@ -117,12 +132,83 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 	public function filter_woocommerce_admin_features( $features ) {
 
 		// Disable and revert the navigation experiment.
-		if ( array_key_exists( 'navigation', $features ) ) {
+		if ( isset( $features['navigation'] ) ) {
 			$features['navigation'] = false;
+		}
+
+		// Disable the new product management experiment.
+		if ( isset( $features['new-product-management-experience'] ) ) {
+			$features['new-product-management-experience'] = false;
 		}
 
 		return $features;
 	}
+
+	/**
+	 * Customize the 'Advanced > Features' Settings tab contents.
+	 *
+	 * @param array $settings Array containing all advanced feature settings.
+	 * @param string $current_section Current settings section.
+	 *
+	 * @return array
+	 */
+	public function filter_woocommerce_settings_features( $settings, $current_section ) {
+
+		if ( 'features' !== $current_section ) {
+			return $settings;
+		}
+
+		$inject_at = wp_list_filter( $settings, array(
+			'id'   => 'woocommerce_navigation_enabled',
+		) );
+
+		array_splice( $settings, key( $inject_at ), 0,
+			array(
+				array(
+					'title'   => __( 'Woo Express Navigation', 'wc-calypso-bridge' ),
+					'desc'    => __( 'A custom navigation experience for Woo Express stores on WordPress.com, optimized for selling.', 'woocommerce' ),
+					'type'    => 'checkbox',
+					'id'      => 'wooexpress_navigation_enabled',
+					'default' => 'yes'
+				)
+        	)
+		);
+
+		$whitelist = array( 'features_options', 'wooexpress_navigation_enabled' );
+
+		foreach ( $settings as $setting_id => $setting_data ) {
+
+			if ( ! is_numeric( $setting_id ) && ! in_array( $setting_id, $whitelist ) ) {
+				unset( $settings[ $setting_id ] );
+			}
+
+			if ( is_array( $setting_data ) && isset( $setting_data['id'] ) && ! in_array( $setting_data['id'], $whitelist ) ) {
+				unset( $settings[ $setting_id ] );
+			}
+		}
+
+		return $settings;
+	}
+
+	/**
+	 * Move the 'Advanced' Settings tab to the end.
+	 *
+	 * @param array $pages Array of tabs.
+	 *
+	 * @return array
+	 */
+	public function filter_woocommerce_settings_pages_order( $pages ) {
+		foreach ( $pages as $page_id => $page ) {
+			if ( 'advanced' === $page_id ) {
+				unset( $pages[ $page_id ] );
+				$pages[ $page_id ] = $page;
+				break;
+			}
+		}
+		return $pages;
+	}
+
+
 
 	/**
 	 * Add is-woocommerce-home body class.

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,11 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleased =
+* Introduce option to disable Woo Express menu under "Settings > Advanced > Features" #1199
+* Move "Settings > Advanced" tab to the end of the list #1199
+* Hide advanced options under "Settings > Advanced > Features" for Woo Express stores #1199
+
 = 2.1.9 =
 * Avoid Crowdsignal activation redirect #1192
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Hide all existing settings under **Settings > Advanced > Features**. Introduce a setting to let users revert back to the self-hosted Woo menu.

Closes #1198 .
- #1198 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

- View the **Settings > Advanced > Features** page. 
- Confirm that this shows up:

<img width="1173" alt="Screenshot 2023-06-23 at 3 47 28 PM" src="https://github.com/Automattic/wc-calypso-bridge/assets/1783726/9e9a6004-1ce3-4648-a064-a5f2db0de0d1">

- Confirm that the Advanced tab has moved to the end.

