### PR TITLE
Update paid plan upgrade message on Task List

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 2.1.10 =
+* Update Free Trial Upgrade message on Task List
+
 = 2.1.9 =
 * Avoid Crowdsignal activation redirect #1192
 

--- a/readme.txt
+++ b/readme.txt
@@ -22,7 +22,7 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
-= 2.1.10 =
+= Unreleased =
 * Update Free Trial Upgrade message on Task List
 
 = 2.1.9 =

--- a/src/disabled-tasks/index.tsx
+++ b/src/disabled-tasks/index.tsx
@@ -18,7 +18,7 @@ export const DisabledTasks = () => {
 		'wc-calypso-bridge'
 	);
 	const listLabel = __(
-		'Upgrade to paid plan to unlock the next tasks',
+		'Upgrade to a paid plan to unlock more features and start selling',
 		'wc-calypso-bridge'
 	);
 	const signupUrl =


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Improves the upgrade message on the task list.

Closes https://github.com/Automattic/wc-calypso-bridge/issues/1068.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

Set up Woo Express site in Free Trial mode and with the task list incomplete.
1. See that the task list contains the message `Upgrade to a paid plan to unlock more features and start selling`

<img width="700" alt="Screen Shot 2023-06-26 at 9 57 22 am" src="https://github.com/Automattic/wc-calypso-bridge/assets/9312929/3b89e970-5b3b-4b3a-9995-0d1a2c30ad71">

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
