### PR TITLE
Suppress WooCommerce Help tab

### DIFF
--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -359,7 +359,13 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 		$is_setup_list_hidden    = $setup_list->is_hidden();
 		$is_extended_list_hidden = $extended_list->is_hidden();
 
-		if ( ! $is_setup_list_hidden && ! $is_extended_list_hidden ) {
+		$is_setup_list_complete    = $setup_list->is_complete();
+		$is_extended_list_complete = $extended_list->is_complete();
+
+		$is_setup_list_restorable    = $is_setup_list_hidden && ! $is_setup_list_complete;
+		$is_extended_list_restorable = $is_extended_list_hidden && ! $is_extended_list_complete;
+
+		if ( ! $is_setup_list_restorable && ! $is_extended_list_restorable ) {
 			return $settings;
 		}
 
@@ -374,7 +380,7 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 			)
 		);
 
-		if ( $is_setup_list_hidden ) {
+		if ( $is_setup_list_restorable ) {
 
 			$settings = array_merge( $settings,
 				array(
@@ -385,7 +391,7 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 			);
 		}
 
-		if ( $is_extended_list_hidden ) {
+		if ( $is_extended_list_restorable ) {
 
 			$settings = array_merge( $settings,
 				array(

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -249,8 +249,6 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 		return $pages;
 	}
 
-
-
 	/**
 	 * Add is-woocommerce-home body class.
 	 *
@@ -332,6 +330,8 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 	/**
 	 * Remove Woo Onboarding settings in site-wide Help tab. They have no place there.
 	 *
+	 * @since  x.x.x
+	 *
 	 * @return void
 	 */
 	public function remove_onboarding_help_tab() {
@@ -358,7 +358,9 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 
 	/**
 	 * Introduces onboarding settings under Settings > General.
-	 * Visibile only when the primary or secondary task list is hidden.
+	 * Visible only when the primary or secondary task list is hidden.
+	 *
+	 * @since x.x.x
 	 *
 	 * @param array $settings Settings configuration
 	 */
@@ -427,6 +429,8 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 
 	/**
 	 * Render button to restore the primary task list.
+	 *
+	 * @since x.x.x
 	 */
 	public function restore_setup_task_list_button( $value ) {
 		self::render_restore_task_list_button( 'setup' );
@@ -434,6 +438,8 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 
 	/**
 	 * Render button to restore the extended task list.
+	 *
+	 * @since x.x.x
 	 */
 	public function restore_extended_task_list_button( $value ) {
 		self::render_restore_task_list_button( 'extended' );
@@ -442,6 +448,8 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 	/**
 	 * Render button to restore the setup/extended task list.
 	 * The request itself is handled by Automattic\WooCommerce\Internal\Admin\Onboarding
+	 *
+	 * @since x.x.x
 	 *
 	 * @param $type Task list type - setup or extended.
 	 */

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -96,6 +96,11 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 		add_filter( 'pre_option_woocommerce_navigation_enabled', static function ( $pre ) {
 			return 'no';
 		}, PHP_INT_MAX );
+
+		/*
+		 * Suppress WooCommerce Help tab.
+		 */
+		add_filter( 'woocommerce_enable_admin_help_tab', '__return_false' );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -27,6 +27,8 @@ This section describes how to install the plugin and get it working.
 * Move "Settings > Advanced" tab to the end of the list #1199
 * Hide advanced options under "Settings > Advanced > Features" for Woo Express stores #1199
 * Ensure the woocommerce key exists in the global submenu at all times #1206
+* Suppress the WooCommerce Help tab in all WooCommerce pages #1205
+* Creates a dedicated section under "Settings > General > Onboarding", where users can restore the visibility of suppressed Task Lists #1205
 
 = 2.1.9 =
 * Avoid Crowdsignal activation redirect #1192


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR: 

- Suppresses the WooCommerce Help tab in all WooCommerce pages. Refer to the issue for details.
- Creates a dedicated section under Settings > General > Onboarding, where users can restore the visibility of suppressed Task Lists -- previously possible via the WooCommerce Help tab (!).

Closes #1204 .
- #1204

### How to test the changes in this Pull Request:


1. Create a new/test WooCommerce site with remaining items in the main setup Task List and "Things to do next" list.
2. Hide one of them at a time.
3. Check that a new Onboarding area shows up under Woo **Settings > General** that wasn't there before.
4. Use the Restore buttons to bring back the Task List(s).
5. Confirm the result.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
