### PR TITLE
Ensure the woocommerce key exists in the global submenu at all times

### DIFF
--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -4,7 +4,7 @@
  * Class Ecommerce_Atomic_Admin_Menu.
  *
  * @since   1.9.8
- * @version 2.0.8
+ * @version x.x.x
  *
  * The admin menu controller for Ecommerce WoA sites.
  */
@@ -45,6 +45,25 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 			$args[ 'menu_icon' ]           = 'dashicons-cart';
 			return $args;
 		} );
+
+		// Ensure the $submenu['woocommerce] will be available at prio 10.
+		add_action( 'admin_menu', function() {
+			add_submenu_page(
+				'woocommerce-express-dummy-menu-item',
+				'',
+				'',
+				'manage_woocommerce',
+				'woocommerce-express-dummy-menu-item'
+			);
+		}, 10);
+
+		// Remote it after a certain timeframe. See \WC_Admin_Menus::settings_menu which runs at priority 50.
+		add_action( 'admin_menu', function() {
+			remove_submenu_page(
+				'woocommerce',
+				'woocommerce-express-dummy-menu-item'
+			);
+		}, 49);
 
 		/**
 		 * Fix stale admin menu items for GC, BIS, and PRL.

--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -49,13 +49,13 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 		// Ensure the $submenu['woocommerce] will be available at prio 10.
 		add_action( 'admin_menu', function() {
 			add_submenu_page(
-				'woocommerce-express-dummy-menu-item',
+				'woocommerce',
 				'',
 				'',
 				'manage_woocommerce',
 				'woocommerce-express-dummy-menu-item'
 			);
-		}, 10);
+		}, 9);
 
 		// Remote it after a certain timeframe. See \WC_Admin_Menus::settings_menu which runs at priority 50.
 		add_action( 'admin_menu', function() {

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleashed =
+* Ensure the woocommerce key exists in the global submenu at all times
+
 = 2.1.9 =
 * Avoid Crowdsignal activation redirect #1192
 


### PR DESCRIPTION
### Specification
Closes #1201 

The purpose of this PR is to address an issue where the 3PDs cannot locate the `$submenu['woocommerce']` array within the priority range of 10 to 49.

The ecommerce menu controller removes the **Orders** submenu from the **WooCommerce (Extensions)**. As a result, the `$submenu['woocommerce']` array remains empty until the settings menu is added with a priority of `50`, which resolves the issue.

In this PR we introduce the `woocommerce-express-dummy-menu-item` submenu within the same priority range that will ensure the existence of the submenu key at all times.


<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### Validation

- Have a Woo Express plan
- Install the plugin Discount Rules for WooCommerce
- Go to the plugin settings */wp-admin/admin.php?page=woo_discount_rules&tab=settings
- The error "Sorry, you are not allowed to access this page." will show
- Apply this patch
- Refresh and check that the error is resolved

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
