### PR TITLE
Remove extension's hidden admin menu items handling from the ecommerce menu controller

### DIFF
--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -64,28 +64,6 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 				'woocommerce-express-dummy-menu-item'
 			);
 		}, 49);
-
-		/**
-		 * Fix stale admin menu items for GC, BIS, and PRL.
-		 *
-		 * @since   2.0.5
-		 * @version 2.0.6
-		 */
-		add_action( 'admin_menu', function() {
-
-			// GC.
-			if ( class_exists( 'WC_GC_Admin_Menus' ) ) {
-				$this->hide_submenu_page( WC_GC_Admin_Menus::$parent_file, 'gc_activity' );
-			}
-
-			// BIS.
-			$this->hide_submenu_page( 'woocommerce', 'bis_notifications' );
-			$this->hide_submenu_page( 'woocommerce', 'bis_activity' );
-
-			// PRL.
-			$this->hide_submenu_page( 'woocommerce', 'prl_locations' );
-
-		}, 9999 );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,8 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 = Unreleashed =
-* Ensure the woocommerce key exists in the global submenu at all times
+* Ensure the woocommerce key exists in the global submenu at all times #1206
+* Remove extension's hidden admin menu items handling from the ecommerce menu controller #1207
 
 = 2.1.9 =
 * Avoid Crowdsignal activation redirect #1192

--- a/readme.txt
+++ b/readme.txt
@@ -27,7 +27,7 @@ This section describes how to install the plugin and get it working.
 * Move "Settings > Advanced" tab to the end of the list #1199
 * Hide advanced options under "Settings > Advanced > Features" for Woo Express stores #1199
 * Ensure the woocommerce key exists in the global submenu at all times #1206
-* Remove extension's hidden admin menu items handling from the ecommerce menu controller #1207 (not merged yet)
+* Remove extension's hidden admin menu items handling from the ecommerce menu controller #1207
 
 = 2.1.9 =
 * Avoid Crowdsignal activation redirect #1192


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1187 

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1.
2.
3.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
