### PR TITLE
Fix array missing key warning in product task

### DIFF
--- a/includes/tasks/class-wc-calypso-task-headstart-products.php
+++ b/includes/tasks/class-wc-calypso-task-headstart-products.php
@@ -106,7 +106,8 @@ class HeadstartProducts extends Products {
 	public static function is_already_selling() {
 		$data = self::get_onboarding_data();
 		$already_selling_venues = array( 'other', 'brick-mortar', 'other-woocommerce', 'brick-mortar-other' );
-		return in_array( $data['selling_venues'], $already_selling_venues, true );
+		return isset( $data['selling_venues'] ) ?
+			in_array( $data['selling_venues'], $already_selling_venues, true ) : false;
 	}
 
 	/**

--- a/includes/tasks/class-wc-calypso-task-headstart-products.php
+++ b/includes/tasks/class-wc-calypso-task-headstart-products.php
@@ -104,10 +104,10 @@ class HeadstartProducts extends Products {
 	 * @return bool
 	 */
 	public static function is_already_selling() {
-		$data = self::get_onboarding_data();
+		$data                   = self::get_onboarding_data();
 		$already_selling_venues = array( 'other', 'brick-mortar', 'other-woocommerce', 'brick-mortar-other' );
-		return isset( $data['selling_venues'] ) ?
-			in_array( $data['selling_venues'], $already_selling_venues, true ) : false;
+		
+		return isset( $data['selling_venues'] ) && in_array( $data['selling_venues'], $already_selling_venues, true );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -28,6 +28,7 @@ This section describes how to install the plugin and get it working.
 * Hide advanced options under "Settings > Advanced > Features" for Woo Express stores #1199
 * Ensure the woocommerce key exists in the global submenu at all times #1206
 * Remove extension's hidden admin menu items handling from the ecommerce menu controller #1207
+* Fix array missing key warning in product task #1208
 
 = 2.1.9 =
 * Avoid Crowdsignal activation redirect #1192


### PR DESCRIPTION
### Changes proposed in this Pull Request:

@PanosSynetos reported that a warning is produced for older instances where onboarding data is incomplete.

```
[27-Jun-2023 10:54:57 UTC] PHP Warning:  Undefined array key "selling_venues" 
in /srv/htdocs/wp-content/mu-plugins/wpcomsh/vendor/automattic/wc-calypso-bridge/includes/tasks/class-wc-calypso-task-headstart-products.php on line 109
```
This PR adds defensive coding by checking for array key existence before using it.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable debugging and warning display in your code
2. View WooCommerce > Home
3. Observe no warning from the affected code

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
