### PR TITLE
Prepare for release 2.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v2.1.9",
+  "version": "v2.2.0",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -22,8 +22,7 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
-= Unreleased =
-
+= 2.2.0 =
 * Update Free Trial Upgrade message on Task List #1203
 * Introduce option to disable Woo Express menu under "Settings > Advanced > Features" #1199
 * Move "Settings > Advanced" tab to the end of the list #1199

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancements for users of Store on WordPress.com.
- * Version: 2.1.9
+ * Version: 2.2.0
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -47,7 +47,7 @@ if ( ! defined( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH' ) ) {
 	define( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH', dirname( __FILE__ ) );
 }
 if ( ! defined( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION' ) ) {
-	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.1.9' );
+	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.2.0' );
 }
 if ( ! defined( 'WC_MIN_VERSION' ) ) {
 	define( 'WC_MIN_VERSION', '7.3' );


### PR DESCRIPTION
Preparation for release of 2.2.0

### PRs

- #1203
- #1199
- #1202
- #1206
- #1205
- #1208

### Changelog

```
= 2.2.0 =
* Update Free Trial Upgrade message on Task List #1203
* Introduce option to disable Woo Express menu under "Settings > Advanced > Features" #1199
* Move "Settings > Advanced" tab to the end of the list #1199
* Hide advanced options under "Settings > Advanced > Features" for Woo Express stores #1199
* Replace appearance task with choosing theme #1202
* Ensure the woocommerce key exists in the global submenu at all times #1206
* Suppress the WooCommerce Help tab in all WooCommerce pages #1205
* Creates a dedicated section under "Settings > General > Onboarding", where users can restore the visibility of suppressed Task Lists #1205
* Remove extension's hidden admin menu items handling from the ecommerce menu controller #1207
* Fix array missing key warning in product task #1208
```