### PR TITLE
Hide storefront theme suggestion in addons page

### DIFF
--- a/assets/css/ecommerce.css
+++ b/assets/css/ecommerce.css
@@ -153,6 +153,10 @@ body.woocommerce_page_wc-addons-landing-page #screen-meta-links {
 	text-decoration: underline;
 }
 
+body.woocommerce_page_wc-addons .wc-addons-wrap .storefront {
+	display: none;
+}
+
 @media screen and (max-width: 782px) {
 	.wc-addons-landing-page__features-grid__item {
 		padding: 0 10px;

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,7 @@ This section describes how to install the plugin and get it working.
 
 = Unreleased =
 * Reverted hidden activity bar in WC Admin pages #1217
+* Hide storefront theme suggestion in addons page #xxx
 
 = 2.2.1 =
 * Fixed fatal error caused by not checking if tasklist exists #1212


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1226 .
- #1226

![image](https://github.com/Automattic/wc-calypso-bridge/assets/2484390/8abaa8b9-94b7-43ce-8df7-51fd66fe2b3e)

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. [ ] Visit `wp-admin/admin.php?page=wc-addons&section=_all` on a performance/essential plan
2. [ ]  Storefront suggestion at the bottom of the page, should not be visible
3.  [ ] Visit the same page on a business site
4.  [ ] Storefront suggestion at the bottom of the page, should still be visible

<!-- End testing instructions -->
