### PR TITLE
Prepare for release 2.2.2

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version x.x.x
+ * @version 2.2.2
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v2.2.1",
+  "version": "v2.2.2",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version x.x.x
+ * @version 2.2.2
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/experiments/class-wc-calypso-bridge-task-list-reminderbar-experiment.php
+++ b/includes/experiments/class-wc-calypso-bridge-task-list-reminderbar-experiment.php
@@ -3,8 +3,8 @@
  * AB Experiment handling for the reminder bar task list nudge.
  *
  * @package WC_Calypso_Bridge/Classes
- * @since   x.x.x
- * @version x.x.x
+ * @since   2.2.2
+ * @version 2.2.2
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -58,7 +58,7 @@ class WC_Calypso_Bridge_Task_List_ReminderBar_Experiment {
 	 * Init experiment.
 	 */
 	public function force_hide_reminder_bar() {
-		
+
 		add_filter( 'pre_option_woocommerce_task_list_reminder_bar_hidden', function( $pre_option ) {
 			return 'yes';
 		} );
@@ -68,7 +68,7 @@ class WC_Calypso_Bridge_Task_List_ReminderBar_Experiment {
 	 * Init experiment.
 	 */
 	public function init() {
-		
+
 		add_filter( 'pre_option_woocommerce_task_list_reminder_bar_hidden', function( $pre_option ) {
 			return self::is_experiment_treatment() ? $pre_option : 'yes';
 		} );
@@ -80,7 +80,7 @@ class WC_Calypso_Bridge_Task_List_ReminderBar_Experiment {
 	 * @return bool Returns true if the current session is treatment.
 	 */
 	protected static function is_experiment_treatment() {
-		
+
 		if ( ! class_exists( '\WooCommerce\Admin\Experimental_Abtest' ) ) {
 			return false;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -23,12 +23,9 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 = 2.2.2 =
-* _Enter your changes here_
-
-= Unreleased =
 * Reverted hidden activity bar in WC Admin pages #1217
 * Introduced the woocommerce_woo_express_remindertopbar_woo_screens_nudge_202307_v1 experiment #1219
-* Hide storefront theme suggestion in addons page #xxx
+* Hide storefront theme suggestion in addons page #1227
 
 = 2.2.1 =
 * Fixed fatal error caused by not checking if tasklist exists #1212

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 2.2.2 =
+* _Enter your changes here_
+
 = Unreleased =
 * Reverted hidden activity bar in WC Admin pages #1217
 * Introduced the woocommerce_woo_express_remindertopbar_woo_screens_nudge_202307_v1 experiment #1219

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancements for users of Store on WordPress.com.
- * Version: 2.2.1
+ * Version: 2.2.2
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -47,7 +47,7 @@ if ( ! defined( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH' ) ) {
 	define( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH', dirname( __FILE__ ) );
 }
 if ( ! defined( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION' ) ) {
-	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.2.1' );
+	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.2.2' );
 }
 if ( ! defined( 'WC_MIN_VERSION' ) ) {
 	define( 'WC_MIN_VERSION', '7.3' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Preparation for release of 2.2.2

- #1217
- #1219
- #1227

### Changelog

```
= 2.2.2 =
* Reverted hidden activity bar in WC Admin pages #1217
* Introduced the woocommerce_woo_express_remindertopbar_woo_screens_nudge_202307_v1 experiment #1219
* Hide storefront theme suggestion in addons page #1227
```