### PR TITLE
fix: reverted snackbar fixed positioning

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleased =
+* Reverted !important fixed positioning on snackbar css as it's been changed to absolute on WooCommerce Core #1234
+
 = 2.2.2 =
 * Reverted hidden activity bar in WC Admin pages #1217
 * Introduced the woocommerce_woo_express_remindertopbar_woo_screens_nudge_202307_v1 experiment #1219

--- a/src/task-completion/style.scss
+++ b/src/task-completion/style.scss
@@ -33,8 +33,3 @@ $ces-feedback-height: 64px;
 	padding-top: 32px;
 	padding-bottom: 8px;
 }
-
-.woocommerce-transient-notices {
-	// there's an ordering conflict which causes this to be overriden by the styles from .components-snackbar-list
-	position: fixed !important; 
-}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Revert of #1041 as WC Core has changed it to absolute positioning and this rule is now causing the snackbar to not show up.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Setup your test site with this change on it
2. Run `wp.data.dispatch('core/notices').createErrorNotice("test snackbar")` in the browser console to trigger a notice
3. Should be able to see the snackbar notice 

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
