### PR TITLE
Hide Brands column in Products list table

### DIFF
--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 2.0.5
+ * @version x.x.x
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -238,7 +238,7 @@ class WC_Calypso_Bridge_Plugins {
 	 */
 	public function hide_product_columns( $hidden, $screen ) {
 		if ( isset( $screen->id ) && 'edit-product' === $screen->id ) {
-			return array_merge( $hidden, array( 'likes', 'date' ) );
+			return array_merge( $hidden, array( 'likes', 'date', 'taxonomy-product_brand' ) );
 		}
 
 		return $hidden;

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleased =
+* Hide Brands column in Products list table #xxx
+
 = 2.2.2 =
 * Reverted hidden activity bar in WC Admin pages #1217
 * Introduced the woocommerce_woo_express_remindertopbar_woo_screens_nudge_202307_v1 experiment #1219


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1210 .
- #1210

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Make sure Brands is active on your site
2. Get your user's ID `wp user list`
3. Delete meta `wp user meta delete manageedit-productcolumnshidden bio` (no worries if it doesn't exist)
4. Go to `wp-admin/edit.php?post_type=product` and see that Brands is not selected by default

![image](https://github.com/Automattic/wc-calypso-bridge/assets/2484390/ec91ae18-fd29-4850-b0be-d5aaa5d3326c)


<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
