### PR TITLE
Fix position of free trial banner

### DIFF
--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-plan-picker-banner.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-plan-picker-banner.php
@@ -4,7 +4,7 @@
  * Class WC_Calypso_Bridge_Free_Trial_Plan_Picker_Banner.
  *
  * @since   2.0.5
- * @version 2.0.16
+ * @version x.x.x
  *
  * Handles Free Trial Plan Picker Banner.
  */
@@ -41,7 +41,7 @@ class WC_Calypso_Bridge_Free_Trial_Plan_Picker_Banner {
 
 		add_action('init', function() {
 			if ( current_user_can( 'manage_woocommerce' ) ) {
-				add_action( 'wp_head', array( $this, 'add_plan_picker_banner' ), -2000 );
+				add_action( 'wp_body_open', array( $this, 'add_plan_picker_banner' ), -2000 );
 				add_filter( 'body_class', function ( $classes ) {
 					if ( !in_array('admin-bar', $classes )) {
 						$classes[] = 'hide-free-trial-plan-picker';

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,7 @@ This section describes how to install the plugin and get it working.
 
 = Unreleased =
 * Reverted !important fixed positioning on snackbar css as it's been changed to absolute on WooCommerce Core #1234
+* Fixe free trial banner position #xxx
 
 = 2.2.2 =
 * Reverted hidden activity bar in WC Admin pages #1217


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1236 .

- #1236 

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Upload the changes on a free trial site
2. Throttle your network speed to fast 3G
3. You wouldn't see the notice appearing while the page is loading
4. View source , and the  `free-trial-plan-picker-banner` is echoed in the `body` rather than in `head`

See #1236 for how the banner looked before this fix


<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
