### PR TITLE
Remove double headings in the Marketing and Extensions pages on the free trial

### DIFF
--- a/assets/css/ecommerce.css
+++ b/assets/css/ecommerce.css
@@ -36,14 +36,6 @@ body.woocommerce_page_wc-addons-landing-page #screen-meta-links {
 	color: #2F2F2F; /* gray-80 */
 }
 
-.wc-addons-landing-page__section-header {
-	font-size: 14px;
-	font-weight: 700;
-	padding: 24px;
-	border-bottom: 1px solid #ddd;
-	margin-bottom: 80px;
-}
-
 .wc-addons-landing-page__title {
 	font-size: 32px;
 	line-height: 40px;
@@ -168,9 +160,6 @@ body.woocommerce_page_wc-addons .wc-addons-wrap .storefront {
 		padding-bottom: 0;
 	}
 
-	.wc-addons-landing-page__section-header {
-		display: none;
-	}
 	.wc-addons-landing-page__title {
 		font-size: 24px;
 		line-height: 32px;

--- a/includes/templates/html-admin-page-addons-landing-page.php
+++ b/includes/templates/html-admin-page-addons-landing-page.php
@@ -4,16 +4,12 @@
 *
 * @package WC_Calypso_Bridge/Templates
 * @since   2.0.4
-* @version 2.1.6
+* @version x.x.x
 *
 * @uses $upgrade_url
 */
 ?>
 <div class="woocommerce woocommerce-page wc-addons-landing-page">
-
-	<div class="wc-addons-landing-page__section-header">
-		<?php esc_html_e( 'Extensions', 'wc-calypso-bridge' ); ?>
-	</div>
 
 	<h1 class="wc-addons-landing-page__title">
 		<?php esc_html_e( 'Take your store to the next level, with extensions', 'wc-calypso-bridge' ); ?>

--- a/src/marketing/index.tsx
+++ b/src/marketing/index.tsx
@@ -71,9 +71,6 @@ export const Marketing = () => {
 
 	return (
 		<div className="woocommerce-marketing-free-trial">
-			<div className="woocommerce-marketing-free-trial-page-title">
-				{ __( 'Marketing', 'wc-calypso-bridge' ) }
-			</div>
 			<div className="woocommerce-marketing-free-trial-welcome">
 				<h1>
 					{ __(

--- a/src/marketing/style.scss
+++ b/src/marketing/style.scss
@@ -21,6 +21,7 @@ body.free-trial-page-marketing {
 	flex-direction: column;
 	align-items: center;
 	margin-bottom: 24px;
+	margin-top: 24px;
 
 	.woocommerce-marketing-free-trial-hero {
 		background: #f6f7f7;
@@ -42,15 +43,6 @@ body.free-trial-page-marketing {
 			max-width: 840px;
 			margin: auto;
 		}
-	}
-
-	.woocommerce-marketing-free-trial-page-title {
-		box-shadow: inset 0px -1px 0px #dddddd;
-		width: 100%;
-		margin-bottom: 80px;
-		font-size: 0.875em;
-		font-weight: 700;
-		padding: 27px;
 	}
 
 	.woocommerce-marketing-free-trial-welcome {
@@ -128,9 +120,6 @@ body.free-trial-page-marketing {
 		font-size: 12px;
 		margin-top: 24px;
 
-		.woocommerce-marketing-free-trial-page-title {
-			display: none;
-		}
 		.woocommerce-marketing-free-trial-welcome {
 			h1 {
 				text-align: center;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1238 

This PR aims to remove the double headings in the 

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Visit wp-admin on a free trial WX site.
2. Navigate to Extensions > Discover and notice the double heading.
3. Navigate to Marketing > Overview and notice the double heading again.
4. Apply this patch.
5. Navigate to both pages and ensure that there is one heading on top.

### Expected results

<img width="1812" alt="Screenshot 2023-07-24 at 5 40 01 PM" src="https://github.com/Automattic/wc-calypso-bridge/assets/1105590/5ed304ea-77c1-4e43-ba00-f9b59b3b3482">
<img width="1852" alt="Screenshot 2023-07-24 at 5 40 05 PM" src="https://github.com/Automattic/wc-calypso-bridge/assets/1105590/6b185255-1a11-4509-8c24-49cbcaa7b3c3">


<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
