### PR TITLE
Prepare for release 2.2.4

### DIFF
--- a/class-wc-calypso-bridge-shared.php
+++ b/class-wc-calypso-bridge-shared.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version x.x.x
+ * @version 2.2.4
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v2.2.3",
+  "version": "v2.2.4",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v2.2.2",
+  "version": "v2.2.3",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/includes/class-wc-calypso-bridge-jetpack.php
+++ b/includes/class-wc-calypso-bridge-jetpack.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.9.8
- * @version x.x.x
+ * @version 2.2.4
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version x.x.x
+ * @version 2.2.4
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-plan-picker-banner.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-plan-picker-banner.php
@@ -4,7 +4,7 @@
  * Class WC_Calypso_Bridge_Free_Trial_Plan_Picker_Banner.
  *
  * @since   2.0.5
- * @version x.x.x
+ * @version 2.2.4
  *
  * Handles Free Trial Plan Picker Banner.
  */

--- a/includes/templates/html-admin-page-addons-landing-page.php
+++ b/includes/templates/html-admin-page-addons-landing-page.php
@@ -4,7 +4,7 @@
 *
 * @package WC_Calypso_Bridge/Templates
 * @since   2.0.4
-* @version x.x.x
+* @version 2.2.4
 *
 * @uses $upgrade_url
 */

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,14 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 2.2.4 =
+= 2.2.4 =
+* Hide Brands column in Products list table #1235
+* Reverted !important fixed positioning on snackbar css as it's been changed to absolute on WooCommerce Core #1234
+* Fixed free trial banner position #1237
+* Remove double headings in the Marketing and Extensions pages on the free trial #1239
+* Disable ecommerce menu and relevant JS fixes when SSO is disabled #925
+
 = Unreleased =
 * Hide Brands column in Products list table #1235
 * Reverted !important fixed positioning on snackbar css as it's been changed to absolute on WooCommerce Core #1234

--- a/readme.txt
+++ b/readme.txt
@@ -23,17 +23,11 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 = 2.2.4 =
-= 2.2.4 =
 * Hide Brands column in Products list table #1235
 * Reverted !important fixed positioning on snackbar css as it's been changed to absolute on WooCommerce Core #1234
 * Fixed free trial banner position #1237
 * Remove double headings in the Marketing and Extensions pages on the free trial #1239
 * Disable ecommerce menu and relevant JS fixes when SSO is disabled #925
-
-= Unreleased =
-* Hide Brands column in Products list table #1235
-* Reverted !important fixed positioning on snackbar css as it's been changed to absolute on WooCommerce Core #1234
-* Fixe free trial banner position #xxx
 
 = 2.2.2 =
 * Reverted hidden activity bar in WC Admin pages #1217

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancements for users of Store on WordPress.com.
- * Version: 2.2.3
+ * Version: 2.2.4
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -47,7 +47,7 @@ if ( ! defined( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH' ) ) {
 	define( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH', dirname( __FILE__ ) );
 }
 if ( ! defined( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION' ) ) {
-	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.2.3' );
+	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.2.4' );
 }
 if ( ! defined( 'WC_MIN_VERSION' ) ) {
 	define( 'WC_MIN_VERSION', '7.3' );

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancements for users of Store on WordPress.com.
- * Version: 2.2.2
+ * Version: 2.2.3
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -47,7 +47,7 @@ if ( ! defined( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH' ) ) {
 	define( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH', dirname( __FILE__ ) );
 }
 if ( ! defined( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION' ) ) {
-	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.2.2' );
+	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.2.3' );
 }
 if ( ! defined( 'WC_MIN_VERSION' ) ) {
 	define( 'WC_MIN_VERSION', '7.3' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Preparation for release of 2.2.4

### Changelog

```
= 2.2.4 =
* Hide Brands column in Products list table #1235
* Reverted !important fixed positioning on snackbar css as it's been changed to absolute on WooCommerce Core #1234
* Fixed free trial banner position #1237
* Remove double headings in the Marketing and Extensions pages on the free trial #1239
* Disable ecommerce menu and relevant JS fixes when SSO is disabled #925
```