### PR TITLE
Enable the creation of Translation updates

### DIFF
--- a/scripts/commands/update-translations.js
+++ b/scripts/commands/update-translations.js
@@ -52,11 +52,7 @@ export default async function updateTranslations() {
 			`wp i18n make-pot . ${ POT_FILE_PATH } --ignore-domain`
 		);
 
-		if ( makePotResult.stderr ) {
-			error( `wp i18n make-pot failure: ${ makePotResult.stderr }` );
-			return false;
-		}
-
+		// If execPromise doesn't reject the promise, the command was successful
 		success( 'wp i18n make-pot command executed successfully.' );
 
 		const status = await git.status();

--- a/scripts/commands/update-translations.js
+++ b/scripts/commands/update-translations.js
@@ -48,11 +48,11 @@ export default async function updateTranslations() {
 	try {
 		info( 'Executing wp i18n make-pot command...' );
 
+		// If the `wp i18n make-pot` command generates an error, an exception is thrown
 		const makePotResult = await execPromise(
 			`wp i18n make-pot . ${ POT_FILE_PATH } --ignore-domain`
 		);
 
-		// If execPromise doesn't reject the promise, the command was successful
 		success( 'wp i18n make-pot command executed successfully.' );
 
 		const status = await git.status();
@@ -160,6 +160,12 @@ export default async function updateTranslations() {
 
 		return success( 'Script execution completed.' );
 	} catch ( err ) {
+		if ( err.stdout ) {
+			info( err.stdout )
+		}
+		if ( err.stderr ) {
+			warning( err.stderr );
+		}
 		return error( 'Error executing the script: ' + err.message );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Currently, the release process allows the user to update translations. However, when this option is selected, the update is aborted because it treats _any_ output to the stderr, including warnings, as an error. This is incorrect. Errors generated by the `wp i18n make-pot` command will cause `execPromise` to throw an exception.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Relates to https://github.com/Automattic/i18n-issues/issues/594 .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Execute `npm run prepare-release`, and attempt the first 3 steps
   ```
   a. Bump the version number in the composer.json file and the wc-calypso-bridge.php file.
   b. Update the changelog in readme.txt.
   c. Update the translation files (optional).
   ```
3. Attempt to download the translation files.
6. Verify that the translation files have been updated.
7. Once successful, abort, and delete the branch that was created.
8. Modify the `wp i18n make-pot` [command](https://github.com/Automattic/wc-calypso-bridge/blob/master/scripts/commands/update-translations.js#L52) to point to a non-existent source directory. e.g Change line 53 of `scripts/commands/update-translations.js` to `wp i18n make-pot ./non-existent-directory ${ POT_FILE_PATH } --ignore-domain`
9. Attempt steps 1-2.
10. Verify that it failed, and the output terminal describes the error correctly.
11. Delete the branch that was created.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
