### PR TITLE
Remove Jetpack Connection step in tax task on a free trial 

### DIFF
--- a/assets/css/free-trial-admin.css
+++ b/assets/css/free-trial-admin.css
@@ -43,3 +43,8 @@
 	.woocommerce-experimental-list__item.complete {
 	color: var( --wp-admin-theme-color );
 }
+
+.woocommerce-task-tax__success {
+	flex-direction: row !important;
+	padding: 0!important;
+}

--- a/assets/css/free-trial-admin.css
+++ b/assets/css/free-trial-admin.css
@@ -46,5 +46,5 @@
 
 .woocommerce-task-tax__success {
 	flex-direction: row !important;
-	padding: 0!important;
+	padding: 0 !important;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 2.2.6 =
+* Fix Tax task for free trial #1247
+
 = 2.2.5 =
 * Enable downloading updated translation files
 

--- a/src/free-trial/tax/index.tsx
+++ b/src/free-trial/tax/index.tsx
@@ -8,7 +8,6 @@ import { getAdminLink } from '@woocommerce/settings';
 import {
 	OPTIONS_STORE_NAME,
 	SETTINGS_STORE_NAME,
-	PLUGINS_STORE_NAME,
 	TaskType,
 } from '@woocommerce/data';
 import { queueRecordEvent, recordEvent } from '@woocommerce/tracks';
@@ -25,7 +24,7 @@ import interpolateComponents from '@automattic/interpolate-components';
 /**
  * Internal dependencies
  */
-import { redirectToTaxSettings, supportsAvalara } from './utils';
+import { redirectToTaxSettings } from './utils';
 import { Card as WooCommerceTaxCard } from './woocommerce-tax/card';
 import {
 	getCountryCode,
@@ -35,7 +34,6 @@ import {
 import { ManualConfiguration } from './manual-configuration';
 import { WooCommerceTax } from './woocommerce-tax';
 import Notice from '../../notice';
-import { Card as AvalaraCard } from './avalara/card';
 import { Partners } from './components/partners';
 
 const TaskCard: React.FC = ( { children } ) => {
@@ -93,12 +91,10 @@ export const Tax: React.FC< TaxProps > = ( { onComplete, query, task } ) => {
 	const { createNotice } = useDispatch( 'core/notices' );
 	const { updateAndPersistSettingsForGroup } =
 		useDispatch( SETTINGS_STORE_NAME );
-	const { generalSettings, isResolving, taxSettings, avalaraInstallState } =
-		useSelect( ( select ) => {
+	const { generalSettings, isResolving, taxSettings } = useSelect(
+		( select ) => {
 			const { getSettings, hasFinishedResolution } =
 				select( SETTINGS_STORE_NAME );
-
-			const { getPluginInstallState } = select( PLUGINS_STORE_NAME );
 
 			return {
 				generalSettings: getSettings( 'general' ).general,
@@ -106,10 +102,9 @@ export const Tax: React.FC< TaxProps > = ( { onComplete, query, task } ) => {
 					'general',
 				] ),
 				taxSettings: getSettings( 'tax' ).tax || {},
-				avalaraInstallState:
-					getPluginInstallState( 'woocommerce-avatax' ),
 			};
-		} );
+		}
+	);
 
 	const onManual = useCallback( async () => {
 		setIsPending( true );
@@ -210,16 +205,6 @@ export const Tax: React.FC< TaxProps > = ( { onComplete, query, task } ) => {
 				isVisible:
 					! taxJarActivated && // WCS integration doesn't work with the official TaxJar plugin.
 					woocommerceTaxCountries.includes( countryCode ),
-			},
-			{
-				id: 'avalara',
-				card: AvalaraCard,
-				component: null,
-				isVisible:
-					supportsAvalara( countryCode ) &&
-					[ 'installed', 'activated' ].includes(
-						avalaraInstallState
-					),
 			},
 		];
 

--- a/src/free-trial/tax/woocommerce-tax/automated-taxes.tsx
+++ b/src/free-trial/tax/woocommerce-tax/automated-taxes.tsx
@@ -30,22 +30,7 @@ export const AutomatedTaxes: React.FC<
 					onAutomate();
 				} }
 			>
-				{ __( 'Yes please', 'woocommerce' ) }
-			</Button>
-			<Button
-				disabled={ isPending }
-				isTertiary
-				onClick={ () => {
-					recordEvent( 'tasklist_tax_setup_automated_proceed', {
-						setup_automatically: false,
-					} );
-					onManual();
-				} }
-			>
-				{ __( "No thanks, I'll set up manually", 'woocommerce' ) }
-			</Button>
-			<Button disabled={ isPending } isTertiary onClick={ onDisable }>
-				{ __( "I don't charge sales tax", 'woocommerce' ) }
+				{ __( 'Automate taxes', 'woocommerce' ) }
 			</Button>
 		</div>
 	);

--- a/src/free-trial/tax/woocommerce-tax/automated-taxes.tsx
+++ b/src/free-trial/tax/woocommerce-tax/automated-taxes.tsx
@@ -20,28 +20,6 @@ export const AutomatedTaxes: React.FC<
 > = ( { isPending, onAutomate, onManual, onDisable } ) => {
 	return (
 		<div className="woocommerce-task-tax__success">
-			<span
-				className="woocommerce-task-tax__success-icon"
-				role="img"
-				aria-labelledby="woocommerce-task-tax__success-message"
-			>
-				🎊
-			</span>
-			<H id="woocommerce-task-tax__success-message">
-				{ __( 'Good news!', 'woocommerce' ) }
-			</H>
-			<p>
-				{ interpolateComponents( {
-					mixedString: __(
-						'{{strong}}Jetpack{{/strong}} and {{strong}}WooCommerce Tax{{/strong}} ' +
-							'can automate your sales tax calculations for you.',
-						'woocommerce'
-					),
-					components: {
-						strong: <strong />,
-					},
-				} ) }
-			</p>
 			<Button
 				isPrimary
 				isBusy={ isPending }

--- a/src/free-trial/tax/woocommerce-tax/setup.tsx
+++ b/src/free-trial/tax/woocommerce-tax/setup.tsx
@@ -20,6 +20,7 @@ import { Connect } from './connect';
 import { Plugins } from './plugins';
 import { StoreLocation } from '../components/store-location';
 import './setup.scss';
+import { AutomatedTaxes } from './automated-taxes';
 
 export type SetupProps = {
 	isPending: boolean;
@@ -102,24 +103,13 @@ export const Setup: React.FC< SetupProps > = ( {
 			content: <StoreLocation { ...stepProps } />,
 		},
 		{
-			key: 'plugins',
-			label: pluginsToActivate.includes( 'woocommerce-services' )
-				? __( 'Install Jetpack and WooCommerce Tax', 'woocommerce' )
-				: __( 'Install Jetpack', 'woocommerce' ),
-			description: __(
-				'Jetpack and WooCommerce Tax allow you to automate sales tax calculations',
-				'woocommerce'
-			),
-			content: <Plugins { ...stepProps } />,
-		},
-		{
 			key: 'connect',
-			label: __( 'Connect your store', 'woocommerce' ),
+			label: __( 'Automate Taxes', 'woocommerce' ),
 			description: __(
-				'Connect your store to WordPress.com to enable automated sales tax calculations',
+				'WooCommerce Tax can automate your sales tax calculations for you.',
 				'woocommerce'
 			),
-			content: <Connect { ...stepProps } />,
+			content: <AutomatedTaxes { ...stepProps } />,
 		},
 	];
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1146 

This PR removes Jetpack connection step in WooCommerce Tax setup step as atomic sites are already connected to Jetpack. 



<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Checkout this branch in your setup and make sure Jetpack is connected.
2. Click `Add tax rates` task in WooCommerce Home
3. Click `WooCommerce Tax`
4. Confirm the changes

![Screen Shot 2023-07-30 at 2 05 56 PM](https://github.com/Automattic/wc-calypso-bridge/assets/4723145/8ed22285-d0fa-48e0-ac7c-3658a2c2a0e7)
![Screen Shot 2023-07-30 at 2 05 45 PM](https://github.com/Automattic/wc-calypso-bridge/assets/4723145/b9ad9adc-ce72-4588-9ddf-b684c31cd463)


<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
