### PR TITLE
Add the Plugins menu item back to free trial sites

### DIFF
--- a/assets/css/ecommerce.css
+++ b/assets/css/ecommerce.css
@@ -23,20 +23,20 @@
 
 /* Extensions > Discover landing page styles. */
 
-body.woocommerce_page_wc-addons-landing-page {
+body.woocommerce_page_wc-bridge-landing-page {
 	background: white;
 }
 
-body.woocommerce_page_wc-addons-landing-page #screen-meta-links {
+body.woocommerce_page_wc-bridge-landing-page #screen-meta-links {
 	display: none;
 }
 
-.wc-addons-landing-page {
+.wc-bridge-landing-page {
 	background: white;
 	color: #2F2F2F; /* gray-80 */
 }
 
-.wc-addons-landing-page__title {
+.wc-bridge-landing-page__title {
 	font-size: 32px;
 	line-height: 40px;
 	font-weight: 400;
@@ -45,7 +45,7 @@ body.woocommerce_page_wc-addons-landing-page #screen-meta-links {
 	margin: .67em auto;
 	padding: 0 2em;
 }
-.wc-addons-landing-page__description {
+.wc-bridge-landing-page__description {
 	font-size: 16px;
 	line-height: 24px;
 	text-align: center;
@@ -54,39 +54,39 @@ body.woocommerce_page_wc-addons-landing-page #screen-meta-links {
 	padding: 0 2em;
 }
 
-.wc-addons-landing-page__button-container {
+.wc-bridge-landing-page__button-container {
 	margin: 0 auto 120px;
 	text-align: center;
 }
-.wc-addons-landing-page__button-container .button {
+.wc-bridge-landing-page__button-container .button {
 	line-height: 1em;
 	padding: 13px 16px;
 }
-.wc-addons-landing-page__button-container .button-secondary {
+.wc-bridge-landing-page__button-container .button-secondary {
 	background: white;
 	color: var( --wp-admin-theme-color ) !important;
 }
-.wc-addons-landing-page__button-container .button-primary {
+.wc-bridge-landing-page__button-container .button-primary {
 	margin-right: 20px;
 	color: white !important;
 }
 
-.wc-addons-landing-page__hero-image-container--mobile {
+.wc-bridge-landing-page__hero-image-container--mobile {
 	display: none;
 	background-color: #F6F7F7; /* Gray-0 */
 	text-align: center;
 }
-.wc-addons-landing-page__hero-image-container {
+.wc-bridge-landing-page__hero-image-container {
 	background-color: #F6F7F7; /* Gray-0 */
 	text-align: center;
 }
-.wc-addons-landing-page__hero-image-container--mobile img,
-.wc-addons-landing-page__hero-image-container img {
+.wc-bridge-landing-page__hero-image-container--mobile img,
+.wc-bridge-landing-page__hero-image-container img {
 	width: 80%;
 	margin-top: -60px;
 }
 
-.wc-addons-landing-page__sub-title {
+.wc-bridge-landing-page__sub-title {
 	font-size: 24px;
 	line-height: 32px;
 	font-weight: 400;
@@ -96,7 +96,7 @@ body.woocommerce_page_wc-addons-landing-page #screen-meta-links {
 	padding: 0 2em;
 }
 
-.wc-addons-landing-page__features-grid {
+.wc-bridge-landing-page__features-grid {
 	max-width: 1100px;
 	margin: 65px auto 0;
 	display: flex;
@@ -104,12 +104,12 @@ body.woocommerce_page_wc-addons-landing-page #screen-meta-links {
 	text-align: center;
 }
 
-.wc-addons-landing-page__features-grid__item {
+.wc-bridge-landing-page__features-grid__item {
 	width: 33%;
 	padding: 0 35px;
 }
 
-.wc-addons-landing-page__features-grid__item__icon {
+.wc-bridge-landing-page__features-grid__item__icon {
 	text-align: center;
 	background: var( --color-accent-5 );
 	width: 64px;
@@ -121,80 +121,85 @@ body.woocommerce_page_wc-addons-landing-page #screen-meta-links {
 	justify-content: center;
 }
 
-.wc-addons-landing-page__features-grid__item h3 {
+.wc-bridge-landing-page__features-grid__item h3 {
 	font-size: 16px;
 	line-height: 24px;
 	font-weight: 600;
 	margin: 30px 0 10px;
 }
-.wc-addons-landing-page__features-grid__item p {
+.wc-bridge-landing-page__features-grid__item p {
 	font-size: 16px;
 	line-height: 24px;
 	font-weight: 400;
 	margin: 0;
 }
-.wc-addons-landing-page__features-grid__item a {
+.wc-bridge-landing-page__features-grid__item a {
 	font-size: 13px;
 	text-decoration: none;
 	color: var( --wp-admin-theme-color );
 	padding: 1em;
 	display: inline-block;
 }
-.wc-addons-landing-page__features-grid__item a:hover {
+.wc-bridge-landing-page__features-grid__item a:hover {
 	color: var( --wp-admin-theme-color );
 	text-decoration: underline;
 }
 
-body.woocommerce_page_wc-addons .wc-addons-wrap .storefront {
+body.woocommerce_page_wc-bridge .wc-bridge-wrap .storefront {
 	display: none;
 }
 
 @media screen and (max-width: 782px) {
-	.wc-addons-landing-page__features-grid__item {
+	.wc-bridge-landing-page__features-grid__item {
 		padding: 0 10px;
 	}
 }
 @media screen and (max-width: 600px) {
 
-	body.woocommerce_page_wc-addons-landing-page #wpbody-content {
+	body.woocommerce_page_wc-bridge-landing-page #wpbody-content {
 		padding-bottom: 0;
 	}
 
-	.wc-addons-landing-page__title {
+	.wc-bridge-landing-page__title {
 		font-size: 24px;
 		line-height: 32px;
 		margin: 40px auto .67em;
 	}
-	.wc-addons-landing-page__description {
+	.wc-bridge-landing-page__description {
 		font-size: 13px;
 		line-height: 16px;
 	}
-	.wc-addons-landing-page__button-container {
+	.wc-bridge-landing-page__button-container {
 		margin: 0 auto 80px;
 	}
-	.wc-addons-landing-page__sub-title {
+	.wc-bridge-landing-page__sub-title {
 		font-size: 20px;
 		line-height: 28px;
 		margin: 50px auto .67em;
 	}
-	.wc-addons-landing-page__hero-image-container--mobile {
+	.wc-bridge-landing-page__hero-image-container--mobile {
 		display: block;
 	}
-	.wc-addons-landing-page__hero-image-container--mobile img {
+	.wc-bridge-landing-page__hero-image-container--mobile img {
 		width: 100%;
 	}
-	.wc-addons-landing-page__hero-image-container {
+	.wc-bridge-landing-page__hero-image-container {
 		display: none;
 	}
-	.wc-addons-landing-page__features-grid {
+	.wc-bridge-landing-page__features-grid {
 		flex-wrap: wrap;
 		margin: 32px auto 0;
 	}
-	.wc-addons-landing-page__features-grid__item {
+	.wc-bridge-landing-page__features-grid__item {
 		width: 100%;
 		padding: 0 50px;
 		margin-bottom: 40px;
 	}
+}
+
+/* Plugins landing page styles. */
+body.woocommerce_page_wc-plugins-landing-page .wc-bridge-landing-page {
+	margin-top: 10em;
 }
 
 .woocommerce-task-list__setup

--- a/assets/css/ecommerce.css
+++ b/assets/css/ecommerce.css
@@ -126,6 +126,7 @@ body.woocommerce_page_wc-bridge-landing-page #screen-meta-links {
 	line-height: 24px;
 	font-weight: 600;
 	margin: 30px 0 10px;
+	text-transform: capitalize;
 }
 .wc-bridge-landing-page__features-grid__item p {
 	font-size: 16px;

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -127,6 +127,7 @@ class WC_Calypso_Bridge {
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/free-trial/class-wc-calypso-bridge-free-trial-wc-payments.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/free-trial/class-wc-calypso-bridge-free-trial-plan-picker-banner.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-notice.php';
+		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/free-trial/class-wc-calypso-bridge-free-trial-plugins-screen.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-free-trial-store-details-task.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-product-import-fix.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-skip-obw.php';

--- a/includes/class-wc-calypso-bridge-addons.php
+++ b/includes/class-wc-calypso-bridge-addons.php
@@ -64,7 +64,7 @@ class WC_Calypso_Bridge_Addons {
 			add_filter( 'admin_body_class', function( $classes ) {
 				$screen = get_current_screen();
 				if ( $screen && 'woocommerce_page_wc-addons' === $screen->id ) {
-					$classes .= 'woocommerce_page_wc-bridge-landing-page woocommerce_page_wc-addons-landing-page';
+					$classes .= ' woocommerce_page_wc-bridge-landing-page woocommerce_page_wc-addons-landing-page ';
 				}
 
 				return $classes;

--- a/includes/class-wc-calypso-bridge-addons.php
+++ b/includes/class-wc-calypso-bridge-addons.php
@@ -64,7 +64,7 @@ class WC_Calypso_Bridge_Addons {
 			add_filter( 'admin_body_class', function( $classes ) {
 				$screen = get_current_screen();
 				if ( $screen && 'woocommerce_page_wc-addons' === $screen->id ) {
-					$classes .= 'woocommerce_page_wc-addons-landing-page';
+					$classes .= 'woocommerce_page_wc-bridge-landing-page woocommerce_page_wc-addons-landing-page';
 				}
 
 				return $classes;

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-plugins-screen.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-plugins-screen.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * WC Calypso Bridge Free Trial Plugins Screen - Landing page.
+ *
+ * @package WC_Calypso_Bridge/Classes
+ * @since   x.x.x
+ * @version x.x.x
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Calypso_Bridge_Free_Trial_Plugins_Screen Class.
+ */
+class WC_Calypso_Bridge_Free_Trial_Plugins_Screen {
+
+	/**
+	 * Class instance.
+	 */
+	protected static $instance = false;
+
+	/**
+	 * Get class instance.
+	 */
+	final public static function get_instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	protected function __construct() {
+
+		// Only for free trials.
+		if ( ! wc_calypso_bridge_is_ecommerce_trial_plan() ) {
+			return;
+		}
+
+		$this->init();
+	}
+
+	/**
+	 * Initialize hooks.
+	 */
+	protected function init() {
+
+		add_action( 'admin_menu', array($this, 'add_menu_page'));
+		add_filter( 'admin_body_class', function( $classes ) {
+				$screen = get_current_screen();
+				if ( $screen && 'toplevel_page_plugins-upgrade' === $screen->id ) {
+					$classes .= 'woocommerce_page_wc-bridge-landing-page woocommerce_page_wc-plugins-landing-page';
+				}
+
+				return $classes;
+			} );
+	}
+
+	/**
+	 * Initialize hooks.
+	 */
+	public function add_menu_page() {
+		add_menu_page( __( 'Plugins', 'wc-calypso-bridge' ), __( 'Plugins', 'wc-calypso-bridge' ), 'manage_options', 'plugins-upgrade', array( $this, 'output' ), 'dashicons-admin-plugins', 65 );
+	}
+
+	public function output() {
+
+		$upgrade_url = sprintf( 'https://wordpress.com/plans/%s', WC_Calypso_Bridge_Instance()->get_site_slug() );
+
+		/**
+		 * Addon page view.
+		 *
+		 * @uses $upgrade_url
+		 */
+		include_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/templates/html-admin-page-plugins-landing-page.php';
+	}
+}
+
+WC_Calypso_Bridge_Free_Trial_Plugins_Screen::get_instance();

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-plugins-screen.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-plugins-screen.php
@@ -3,8 +3,8 @@
  * WC Calypso Bridge Free Trial Plugins Screen - Landing page.
  *
  * @package WC_Calypso_Bridge/Classes
- * @since   x.x.x
- * @version x.x.x
+ * @since   2.2.8
+ * @version 2.2.8
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -34,7 +34,6 @@ class WC_Calypso_Bridge_Free_Trial_Plugins_Screen {
 	 * Constructor.
 	 */
 	protected function __construct() {
-
 		// Only for free trials.
 		if ( ! wc_calypso_bridge_is_ecommerce_trial_plan() ) {
 			return;
@@ -47,7 +46,6 @@ class WC_Calypso_Bridge_Free_Trial_Plugins_Screen {
 	 * Initialize hooks.
 	 */
 	protected function init() {
-
 		add_action( 'admin_menu', array($this, 'add_menu_page'));
 		add_filter( 'admin_body_class', function( $classes ) {
 				$screen = get_current_screen();
@@ -67,7 +65,6 @@ class WC_Calypso_Bridge_Free_Trial_Plugins_Screen {
 	}
 
 	public function output() {
-
 		$upgrade_url = sprintf( 'https://wordpress.com/plans/%s', WC_Calypso_Bridge_Instance()->get_site_slug() );
 
 		/**

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-plugins-screen.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-plugins-screen.php
@@ -50,7 +50,7 @@ class WC_Calypso_Bridge_Free_Trial_Plugins_Screen {
 		add_filter( 'admin_body_class', function( $classes ) {
 				$screen = get_current_screen();
 				if ( $screen && 'toplevel_page_plugins-upgrade' === $screen->id ) {
-					$classes .= 'woocommerce_page_wc-bridge-landing-page woocommerce_page_wc-plugins-landing-page';
+					$classes .= ' woocommerce_page_wc-bridge-landing-page woocommerce_page_wc-plugins-landing-page ';
 				}
 
 				return $classes;

--- a/includes/templates/html-admin-page-addons-landing-page.php
+++ b/includes/templates/html-admin-page-addons-landing-page.php
@@ -16,7 +16,7 @@
 	</h1>
 
 	<p class="wc-bridge-landing-page__description">
-		<?php esc_html_e( 'Customize your store to work perfectly for your business, with Woo extensions. Upgrade to a paid plan to gain access to hundreds of tools and features that can help you achieve your business goals. Curious about what’s available? Browse our extensions marketplace.', 'wc-calypso-bridge' ); ?>
+		<?php esc_html_e( 'Customize your store to work perfectly for your business, with WooCommerce Extensions. Upgrade to a paid plan to gain access to hundreds of tools and features that can help you achieve your goals. Curious about what’s available? Browse our Extensions Marketplace.', 'wc-calypso-bridge' ); ?>
 	</p>
 
 	<div class="wc-bridge-landing-page__button-container">
@@ -24,7 +24,7 @@
 			<?php esc_html_e( 'Upgrade now', 'wc-calypso-bridge' ); ?>
 		</a>
 		<a href="https://woocommerce.com/product-category/woocommerce-extensions/?categoryIds=1021&collections=product&page=1&utm_source=wooextensionstab&utm_medium=product&utm_campaign=woocommerceplugin" target="_blank" class="button button-secondary" id="browse_extension_button">
-			<?php esc_html_e( 'Browse extensions', 'wc-calypso-bridge' ); ?>
+			<?php esc_html_e( 'Browse Extensions', 'wc-calypso-bridge' ); ?>
 		</a>
 	</div>
 
@@ -34,10 +34,6 @@
 	<div class="wc-bridge-landing-page__hero-image-container--mobile">
 		<img src="<?php echo WC_Calypso_Bridge_Instance()->get_asset_path() . 'assets/images/extensions-landing-page-hero-mobile.png' ?>" alt="<?php esc_html_e( 'Take your store to the next level, with extensions', 'wc-calypso-bridge' ); ?>">
 	</div>
-
-	<h2 class="wc-bridge-landing-page__sub-title">
-		<?php esc_html_e( 'Do more with your store – add extensions', 'wc-calypso-bridge' ); ?>
-	</h2>
 
 	<div class="wc-bridge-landing-page__features-grid">
 

--- a/includes/templates/html-admin-page-plugins-landing-page.php
+++ b/includes/templates/html-admin-page-plugins-landing-page.php
@@ -74,7 +74,7 @@
 			</div>
 			<h3><?php esc_html_e( 'Do it your way', 'wc-calypso-bridge' ); ?></h3>
 			<p>
-				<?php esc_html_e( 'Can’t find the right plugin for your needs? From service integrations to new, exotic features, our experts can help you build the store of your dreams.', 'wc-calypso-bridge' ); ?>
+				<?php esc_html_e( 'Can’t find the right plugin for your needs? From service integrations to exotic customizations, our team of experts can help you get the job done right.', 'wc-calypso-bridge' ); ?>
 			</p>
 			<a href="https://woocommerce.com/customizations?utm_source=wooextensionstab&utm_medium=product&utm_campaign=woocommerceplugin" target="_blank" id="get_inspired_button"><?php esc_html_e( 'Get inspired', 'wc-calypso-bridge' ); ?></a>
 		</div>

--- a/includes/templates/html-admin-page-plugins-landing-page.php
+++ b/includes/templates/html-admin-page-plugins-landing-page.php
@@ -1,10 +1,10 @@
 <?php
 /**
-* Admin View: Page - Addons
+* Admin View: Page - Plugins
 *
 * @package WC_Calypso_Bridge/Templates
-* @since   2.0.4
-* @version 2.2.4
+* @since   x.x.x
+* @version x.x.x
 *
 * @uses $upgrade_url
 */
@@ -86,34 +86,3 @@
 	</div>
 
 </div>
-
-<script>
-document.addEventListener( 'DOMContentLoaded', function() {
-	// Prefer wc.tracks.recordEvent since it supports debugging.
-	let recordEvent = null;
-	if ( window.wc && window.wc.tracks && window.wc.tracks.recordEvent ) {
-		recordEvent = window.wc.tracks.recordEvent;
-	} else if ( window.wcTracks && window.wcTracks.recordEvent ) {
-		recordEvent = window.wcTracks.recordEvent;
-	} else {
-		recordEvent = function() {};
-	}
-
-	const recordButtonEvent = function( buttonId, eventName ) {
-		const el = document.getElementById( buttonId );
-		if ( el ) {
-			el.addEventListener( 'click', function() {
-				recordEvent( eventName, {
-					source: 'extensions',
-				} );
-			} );
-		}
-	};
-
-	recordButtonEvent( 'upgrade_now_button', 'free_trial_upgrade_now' );
-	recordButtonEvent( 'browse_extension_button', 'free_trial_browse_extensions' );
-	recordButtonEvent( 'browse_extension_button_2', 'free_trial_browse_extensions' );
-	recordButtonEvent( 'discover_collections_button', 'free_trial_discover_collections' );
-	recordButtonEvent( 'get_inspired_button', 'free_trial_get_inspired' );
-} );
-</script>

--- a/includes/templates/html-admin-page-plugins-landing-page.php
+++ b/includes/templates/html-admin-page-plugins-landing-page.php
@@ -12,19 +12,19 @@
 <div class="woocommerce woocommerce-page wc-bridge-landing-page">
 
 	<h1 class="wc-bridge-landing-page__title">
-		<?php esc_html_e( 'Take your store to the next level, with extensions', 'wc-calypso-bridge' ); ?>
+		<?php esc_html_e( 'Make anything happen, with plugins', 'wc-calypso-bridge' ); ?>
 	</h1>
 
 	<p class="wc-bridge-landing-page__description">
-		<?php esc_html_e( 'Customize your store to work perfectly for your business, with Woo extensions. Upgrade to a paid plan to gain access to hundreds of tools and features that can help you achieve your business goals. Curious about what’s available? Browse our extensions marketplace.', 'wc-calypso-bridge' ); ?>
+		<?php esc_html_e( 'Turn your WordPress site into anything you set your mind on. Upgrade to a paid plan and gain access to thousands of free and paid plugins. Curious to find out what’s possible?', 'wc-calypso-bridge' ); ?>
 	</p>
 
 	<div class="wc-bridge-landing-page__button-container">
 		<a href="<?php echo esc_url( $upgrade_url ); ?>" class="button button-primary" id="upgrade_now_button">
 			<?php esc_html_e( 'Upgrade now', 'wc-calypso-bridge' ); ?>
 		</a>
-		<a href="https://woocommerce.com/product-category/woocommerce-extensions/?categoryIds=1021&collections=product&page=1&utm_source=wooextensionstab&utm_medium=product&utm_campaign=woocommerceplugin" target="_blank" class="button button-secondary" id="browse_extension_button">
-			<?php esc_html_e( 'Browse extensions', 'wc-calypso-bridge' ); ?>
+		<a href="https://wordpress.org/plugins/" target="_blank" class="button button-secondary" id="browse_extension_button">
+			<?php esc_html_e( 'Browse plugins', 'wc-calypso-bridge' ); ?>
 		</a>
 	</div>
 
@@ -35,10 +35,6 @@
 		<img src="<?php echo WC_Calypso_Bridge_Instance()->get_asset_path() . 'assets/images/extensions-landing-page-hero-mobile.png' ?>" alt="<?php esc_html_e( 'Take your store to the next level, with extensions', 'wc-calypso-bridge' ); ?>">
 	</div>
 
-	<h2 class="wc-bridge-landing-page__sub-title">
-		<?php esc_html_e( 'Do more with your store – add extensions', 'wc-calypso-bridge' ); ?>
-	</h2>
-
 	<div class="wc-bridge-landing-page__features-grid">
 
 		<div class="wc-bridge-landing-page__features-grid__item">
@@ -48,11 +44,11 @@
 					<path d="M32 17.2307H28.8978C28.3246 23.4014 23.4014 28.3245 17.2308 28.8978V32H14.7693V28.8978C8.59855 28.3246 3.67546 23.4014 3.10222 17.2307H0V14.7692H3.10222C3.67543 8.59851 8.59861 3.67542 14.7693 3.10218V-4.57764e-05H17.2308V3.10218C23.4015 3.67538 28.3246 8.59857 28.8978 14.7692H32V17.2307ZM17.2308 5.56366V8.56473H14.7693V5.56366C9.98107 6.13687 6.13701 9.9473 5.56377 14.7692H8.56483V17.2307H5.56377C6.13698 22.0189 9.94741 25.8629 14.7693 26.4362V23.4351H17.2308V26.4362C22.019 25.863 25.863 22.0525 26.4363 17.2307H23.4352V14.7692H26.4363C25.8294 9.94736 22.019 6.1369 17.2308 5.56366Z" fill="var( --color-accent )"/>
 				</svg>
 			</div>
-			<h3><?php esc_html_e( 'Customize and extend', 'wc-calypso-bridge' ); ?></h3>
+			<h3><?php esc_html_e( 'Transform WordPress', 'wc-calypso-bridge' ); ?></h3>
 			<p>
-				<?php esc_html_e( 'Add extra features and functionality, or integrate with other platforms and tools.', 'wc-calypso-bridge' ); ?>
+				<?php esc_html_e( 'Make WordPress do anything. Create a store, host a podcast, or showcase your work. You are in control with over 55,000 plugins.', 'wc-calypso-bridge' ); ?>
 			</p>
-			<a href="https://woocommerce.com/product-category/woocommerce-extensions/?categoryIds=1021&collections=product&page=1&utm_source=wooextensionstab&utm_medium=product&utm_campaign=woocommerceplugin" target="_blank" id="browse_extension_button_2"><?php esc_html_e( 'Browse extensions', 'wc-calypso-bridge' ); ?></a>
+			<a href="https://wordpress.org/plugins/" target="_blank" id="browse_extension_button_2"><?php esc_html_e( 'Browse plugins', 'wc-calypso-bridge' ); ?></a>
 		</div>
 
 		<div class="wc-bridge-landing-page__features-grid__item">
@@ -62,11 +58,11 @@
 					<path d="M22.7511 0.158203L24.2496 4.20773L28.2991 5.70619L24.2496 7.20465L22.7511 11.2542L21.2527 7.20465L17.2031 5.70619L21.2527 4.20773L22.7511 0.158203Z" fill="var( --color-accent-light )"/>
 				</svg>
 			</div>
-			<h3><?php esc_html_e( 'Curated collections', 'wc-calypso-bridge' ); ?></h3>
+			<h3><?php esc_html_e( 'Extend your store', 'wc-calypso-bridge' ); ?></h3>
 			<p>
-				<?php esc_html_e( 'Quickly get started with our curated extension collections.', 'wc-calypso-bridge' ); ?>
+				<?php esc_html_e( 'Looking for more payment and shipping methods? Want to build a memberships site, or accept donations? Choose among hundreds of Extensions hand-picked by our team.', 'wc-calypso-bridge' ); ?>
 			</p>
-			<a href="https://woocommerce.com/collections?utm_source=wooextensionstab&utm_medium=product&utm_campaign=woocommerceplugin" target="_blank" id="discover_collections_button"><?php esc_html_e( 'Discover collections', 'wc-calypso-bridge' ); ?></a>
+			<a href="https://woocommerce.com/product-category/woocommerce-extensions/?categoryIds=1021&collections=product&page=1&utm_source=wooextensionstab&utm_medium=product&utm_campaign=woocommerceplugin" target="_blank" id="discover_collections_button"><?php esc_html_e( 'Discover Extensions', 'wc-calypso-bridge' ); ?></a>
 		</div>
 
 		<div class="wc-bridge-landing-page__features-grid__item">
@@ -76,11 +72,11 @@
 					<path fill-rule="evenodd" clip-rule="evenodd" d="M22.6988 9.93852C23.9677 9.93852 25.1847 9.43442 26.082 8.53712C26.9793 7.63981 27.4834 6.42281 27.4834 5.15383C27.4834 3.88485 26.9793 2.66785 26.082 1.77054C25.1847 0.87324 23.9677 0.369141 22.6988 0.369141C21.4298 0.369141 20.2128 0.87324 19.3155 1.77054C18.4182 2.66785 17.9141 3.88485 17.9141 5.15383C17.9141 6.42281 18.4182 7.63981 19.3155 8.53712C20.2128 9.43442 21.4298 9.93852 22.6988 9.93852ZM31.7897 17.594V21.4218H28.9188V17.594C28.9188 16.2734 27.8471 15.2017 26.5265 15.2017H21.7418V12.3309H26.5265C27.9224 12.3309 29.2611 12.8854 30.2481 13.8724C31.2351 14.8594 31.7897 16.1981 31.7897 17.594ZM22.6988 7.06759C23.2063 7.06759 23.6931 6.86595 24.0521 6.50703C24.411 6.1481 24.6126 5.6613 24.6126 5.15371C24.6126 4.64612 24.411 4.15932 24.0521 3.8004C23.6931 3.44148 23.2063 3.23984 22.6988 3.23984C22.1912 3.23984 21.7044 3.44148 21.3454 3.8004C20.9865 4.15932 20.7849 4.64612 20.7849 5.15371C20.7849 5.6613 20.9865 6.1481 21.3454 6.50703C21.7044 6.86595 22.1912 7.06759 22.6988 7.06759Z" fill="var( --color-accent-light )"/>
 				</svg>
 			</div>
-			<h3><?php esc_html_e( 'Get inspired', 'wc-calypso-bridge' ); ?></h3>
+			<h3><?php esc_html_e( 'Do it your way', 'wc-calypso-bridge' ); ?></h3>
 			<p>
-				<?php esc_html_e( 'Tips, tricks, and ecommerce inspiration from our blog.', 'wc-calypso-bridge' ); ?>
+				<?php esc_html_e( 'Can’t find the right plugin for your needs? From service integrations to new, exotic features, our experts can help you build the store of your dreams.', 'wc-calypso-bridge' ); ?>
 			</p>
-			<a href="https://woocommerce.com/blog?utm_source=wooextensionstab&utm_medium=product&utm_campaign=woocommerceplugin" target="_blank" id="get_inspired_button"><?php esc_html_e( 'Get inspired', 'wc-calypso-bridge' ); ?></a>
+			<a href="https://woocommerce.com/customizations?utm_source=wooextensionstab&utm_medium=product&utm_campaign=woocommerceplugin" target="_blank" id="get_inspired_button"><?php esc_html_e( 'Get inspired', 'wc-calypso-bridge' ); ?></a>
 		</div>
 
 	</div>

--- a/includes/templates/html-admin-page-plugins-landing-page.php
+++ b/includes/templates/html-admin-page-plugins-landing-page.php
@@ -23,7 +23,7 @@
 		<a href="<?php echo esc_url( $upgrade_url ); ?>" class="button button-primary" id="upgrade_now_button">
 			<?php esc_html_e( 'Upgrade now', 'wc-calypso-bridge' ); ?>
 		</a>
-		<a href="https://wordpress.org/plugins/" target="_blank" class="button button-secondary" id="browse_extension_button">
+		<a href="https://wordpress.org/plugins/" target="_blank" class="button button-secondary" id="browse_plugins_button">
 			<?php esc_html_e( 'Browse plugins', 'wc-calypso-bridge' ); ?>
 		</a>
 	</div>
@@ -48,7 +48,7 @@
 			<p>
 				<?php esc_html_e( 'Make WordPress do anything. Create a store, host a podcast, or showcase your work. You are in control with over 55,000 plugins.', 'wc-calypso-bridge' ); ?>
 			</p>
-			<a href="https://wordpress.org/plugins/" target="_blank" id="browse_extension_button_2"><?php esc_html_e( 'Browse plugins', 'wc-calypso-bridge' ); ?></a>
+			<a href="https://wordpress.org/plugins/" target="_blank" id="browse_plugins_button_2"><?php esc_html_e( 'Browse plugins', 'wc-calypso-bridge' ); ?></a>
 		</div>
 
 		<div class="wc-bridge-landing-page__features-grid__item">
@@ -62,7 +62,7 @@
 			<p>
 				<?php esc_html_e( 'Looking for more payment and shipping methods? Want to build a memberships site, or accept donations? Choose among hundreds of Extensions hand-picked by our team.', 'wc-calypso-bridge' ); ?>
 			</p>
-			<a href="https://woocommerce.com/product-category/woocommerce-extensions/?categoryIds=1021&collections=product&page=1&utm_source=wooextensionstab&utm_medium=product&utm_campaign=woocommerceplugin" target="_blank" id="discover_collections_button"><?php esc_html_e( 'Discover Extensions', 'wc-calypso-bridge' ); ?></a>
+			<a href="https://woocommerce.com/product-category/woocommerce-extensions/?categoryIds=1021&collections=product&page=1&utm_source=wooextensionstab&utm_medium=product&utm_campaign=woocommerceplugin" target="_blank" id="discover_extensions_button"><?php esc_html_e( 'Discover Extensions', 'wc-calypso-bridge' ); ?></a>
 		</div>
 
 		<div class="wc-bridge-landing-page__features-grid__item">
@@ -82,3 +82,34 @@
 	</div>
 
 </div>
+
+<script>
+document.addEventListener( 'DOMContentLoaded', function() {
+	// Prefer wc.tracks.recordEvent since it supports debugging.
+	let recordEvent = null;
+	if ( window.wc && window.wc.tracks && window.wc.tracks.recordEvent ) {
+		recordEvent = window.wc.tracks.recordEvent;
+	} else if ( window.wcTracks && window.wcTracks.recordEvent ) {
+		recordEvent = window.wcTracks.recordEvent;
+	} else {
+		recordEvent = function() {};
+	}
+
+	const recordButtonEvent = function( buttonId, eventName ) {
+		const el = document.getElementById( buttonId );
+		if ( el ) {
+			el.addEventListener( 'click', function() {
+				recordEvent( eventName, {
+					source: 'plugins',
+				} );
+			} );
+		}
+	};
+
+	recordButtonEvent( 'upgrade_now_button', 'free_trial_upgrade_now' );
+	recordButtonEvent( 'browse_plugins_button', 'free_trial_browse_plugins' );
+	recordButtonEvent( 'browse_plugins_button_2', 'free_trial_browse_plugins' );
+	recordButtonEvent( 'discover_extensions_button', 'free_trial_discover_extensions' );
+	recordButtonEvent( 'get_inspired_button', 'free_trial_get_inspired' );
+} );
+</script>

--- a/includes/templates/html-admin-page-plugins-landing-page.php
+++ b/includes/templates/html-admin-page-plugins-landing-page.php
@@ -3,8 +3,8 @@
 * Admin View: Page - Plugins
 *
 * @package WC_Calypso_Bridge/Templates
-* @since   x.x.x
-* @version x.x.x
+* @since   2.2.8
+* @version 2.2.8
 *
 * @uses $upgrade_url
 */

--- a/readme.txt
+++ b/readme.txt
@@ -29,6 +29,7 @@ This section describes how to install the plugin and get it working.
 * Add logging in the page creation one time job #1258
 * Increase old site identification to older than 1 hour for the page creation one time job #1258
 * Properly unset one time jobs for non commerce sites #1258
+* Add the Plugins menu item back to free trial sites #1249
 
 = 2.2.7 =
 * Add `wp-cli` as a developer dependency #1250


### PR DESCRIPTION
### Specification

This PR adds a new "Plugins" landing page for WX trial sites at the `domain.com/wp-admin/admin.php?page=plugins-upgrade` URL.

It also introduces the following track events:
- `free_trial_upgrade_now`
- `free_trial_browse_plugins`
- `free_trial_discover_extensions`
- `free_trial_get_inspired`

**Note:** Every track includes the `source: plugins` metadata.

Closes #1191 

### Validation

- Visit a WX trial site. 
- Ensure you see the "Plugins" landing page in the admin menu (and the expected priority.)
- Ensure the landing page doesn't appear for other WX plans (Essential, Performance) and the WPCOM's ecommerce plan.