### PR TITLE
Introduce error log, increase new site identification time, properly unset onetime jobs for non commerce sites

### DIFF
--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -234,7 +234,7 @@ class WC_Calypso_Bridge_Setup {
 			// Set the operation as completed if the store is active for more than 1 hour.
 			if ( WCAdminHelper::is_wc_admin_active_for( 60 * MINUTE_IN_SECONDS ) ) {
 				update_option( $this->option_prefix . $operation, 'completed', 'no' );
-				$this->write_to_log( $operation, 'completed (15 minutes)' );
+				$this->write_to_log( $operation, 'completed (60 minutes)' );
 
 				return;
 			}

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -61,14 +61,6 @@ class WC_Calypso_Bridge_Setup {
 	protected $option_prefix = 'wc_calypso_bridge_one_time_operation_';
 
 	/**
-	 * Log prefix.
-	 *
-	 * @since xxx
-	 * @var string
-	 */
-	protected $log_prefix = 'WooExpress: Operation: ';
-
-	/**
 	 * Constructor.
 	 */
 	private function __construct() {
@@ -270,7 +262,7 @@ class WC_Calypso_Bridge_Setup {
 
 			if ( 'completed' === $status ) {
 				$wpdb->query( 'ROLLBACK' );
-				$this->write_to_log( $operation, 'ROLLBACK' );
+				$this->write_to_log( $operation, 'ROLLBACK - already completed' );
 
 				return;
 			}
@@ -282,11 +274,11 @@ class WC_Calypso_Bridge_Setup {
 				 * `My Account` page, has slug `my-account`.
 				 * @see WC_Install::create_pages()
 				 */
-				foreach ( [ 'shop', 'cart', 'my-account', 'checkout', 'refund_returns' ] as $page ) {
-					$page = get_page_by_path( $page, ARRAY_A );
+				foreach ( [ 'shop', 'cart', 'my-account', 'checkout', 'refund_returns' ] as $page_slug ) {
+					$page = get_page_by_path( $page_slug, ARRAY_A );
 					if ( is_array( $page ) && isset( $page['ID'] ) ) {
 						wp_delete_post( $page['ID'], true );
-						$this->write_to_log( $operation, 'deleted WooCommerce page ' . $page );
+						$this->write_to_log( $operation, 'deleted WooCommerce page ' . $page_slug );
 					}
 				}
 
@@ -301,8 +293,8 @@ class WC_Calypso_Bridge_Setup {
 				 */
 				foreach ( [ 'shop', 'cart', 'myaccount', 'checkout', 'refund_returns' ] as $page ) {
 					delete_option( "woocommerce_{$page}_page_id" );
+					$this->write_to_log( $operation, 'deleted WooCommerce page id for page ' . $page );
 				}
-				$this->write_to_log( $operation, 'deleted WooCommerce page ids' );
 
 				// Delete the following note, so it can be recreated with the correct refund page ID.
 				if ( class_exists( 'Automattic\WooCommerce\Admin\Notes\Notes' ) ) {
@@ -310,7 +302,7 @@ class WC_Calypso_Bridge_Setup {
 				}
 
 				WC_Install::create_pages();
-				$this->write_to_log( $operation, 'called WC_Install::create_pages' );
+				$this->write_to_log( $operation, 'finished WC_Install::create_pages' );
 
 				// Get navigation menu page and set up the menu.
 				$menu_page_slugs = array(
@@ -649,7 +641,7 @@ class WC_Calypso_Bridge_Setup {
 	 * @return void
 	 */
 	private function write_to_log( $operation, $message ) {
-		error_log( $this->log_prefix . '(' . microtime( true ) . ') ' . $operation . ': ' . print_r( $message, 1 ) );
+		error_log(  'WooExpress: Operation: (' . microtime( true ) . ') ' . $operation . ': ' . print_r( $message, 1 ) );
 	}
 }
 

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version x.x.x
+ * @version 2.2.8
  */
 
 use Automattic\WooCommerce\Admin\WCAdminHelper;
@@ -636,7 +636,7 @@ class WC_Calypso_Bridge_Setup {
 	 * @param string       $operation Operation.
 	 * @param string|array $message   Message.
 	 *
-	 * @since x.x.x
+	 * @since 2.2.8
 	 *
 	 * @return void
 	 */

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 2.1.8
+ * @version x.x.x
  */
 
 use Automattic\WooCommerce\Admin\WCAdminHelper;
@@ -59,6 +59,14 @@ class WC_Calypso_Bridge_Setup {
 	 * @var string
 	 */
 	protected $option_prefix = 'wc_calypso_bridge_one_time_operation_';
+
+	/**
+	 * Log prefix.
+	 *
+	 * @since xxx
+	 * @var string
+	 */
+	protected $log_prefix = 'WooExpress: Operation: ';
 
 	/**
 	 * Constructor.
@@ -138,10 +146,10 @@ class WC_Calypso_Bridge_Setup {
 		if ( ! wc_calypso_bridge_has_ecommerce_features() ) {
 			unset( $this->one_time_operations[ 'set_jetpack_defaults' ] );
 			unset( $this->one_time_operations[ 'woocommerce_create_pages' ] );
-			unset( $this->one_time_operations[ 'set_wc_tracker_twice_daily_callback' ] );
-			unset( $this->one_time_operations[ 'set_wc_tracker_default_callback' ] );
-			unset( $this->one_time_operations[ 'set_wc_subscriptions_siteurl_callback' ] );
-			unset( $this->one_time_operations[ 'set_wc_subscriptions_siteurl_add_domain_callback' ] );
+			unset( $this->one_time_operations[ 'set_wc_tracker_twice_daily' ] );
+			unset( $this->one_time_operations[ 'set_wc_tracker_default' ] );
+			unset( $this->one_time_operations[ 'set_wc_subscriptions_siteurl' ] );
+			unset( $this->one_time_operations[ 'set_wc_subscriptions_siteurl_add_domain' ] );
 		}
 	}
 
@@ -221,9 +229,12 @@ class WC_Calypso_Bridge_Setup {
 
 			$operation = 'woocommerce_create_pages';
 
-			// Set the operation as completed if the store is active for more than 5 minutes.
-			if ( WCAdminHelper::is_wc_admin_active_for( 300 ) ) {
+			$this->write_to_log( $operation, 'initialized' );
+
+			// Set the operation as completed if the store is active for more than 1 hour.
+			if ( WCAdminHelper::is_wc_admin_active_for( 60 * MINUTE_IN_SECONDS ) ) {
 				update_option( $this->option_prefix . $operation, 'completed', 'no' );
+				$this->write_to_log( $operation, 'completed (15 minutes)' );
 
 				return;
 			}
@@ -231,6 +242,7 @@ class WC_Calypso_Bridge_Setup {
 			global $wpdb;
 
 			$wpdb->query( 'START TRANSACTION' );
+			$this->write_to_log( $operation, 'START TRANSACTION' );
 
 			// Prepare to lock the row, when it gets updated.
 			$status = $wpdb->get_var(
@@ -258,6 +270,7 @@ class WC_Calypso_Bridge_Setup {
 
 			if ( 'completed' === $status ) {
 				$wpdb->query( 'ROLLBACK' );
+				$this->write_to_log( $operation, 'ROLLBACK' );
 
 				return;
 			}
@@ -273,6 +286,7 @@ class WC_Calypso_Bridge_Setup {
 					$page = get_page_by_path( $page, ARRAY_A );
 					if ( is_array( $page ) && isset( $page['ID'] ) ) {
 						wp_delete_post( $page['ID'], true );
+						$this->write_to_log( $operation, 'deleted WooCommerce page ' . $page );
 					}
 				}
 
@@ -288,6 +302,7 @@ class WC_Calypso_Bridge_Setup {
 				foreach ( [ 'shop', 'cart', 'myaccount', 'checkout', 'refund_returns' ] as $page ) {
 					delete_option( "woocommerce_{$page}_page_id" );
 				}
+				$this->write_to_log( $operation, 'deleted WooCommerce page ids' );
 
 				// Delete the following note, so it can be recreated with the correct refund page ID.
 				if ( class_exists( 'Automattic\WooCommerce\Admin\Notes\Notes' ) ) {
@@ -295,6 +310,7 @@ class WC_Calypso_Bridge_Setup {
 				}
 
 				WC_Install::create_pages();
+				$this->write_to_log( $operation, 'called WC_Install::create_pages' );
 
 				// Get navigation menu page and set up the menu.
 				$menu_page_slugs = array(
@@ -340,6 +356,7 @@ class WC_Calypso_Bridge_Setup {
 					) );
 
 				}
+				$this->write_to_log( $operation, 'created menu items' );
 
 				$wpdb->query(
 					$wpdb->prepare( "
@@ -354,12 +371,13 @@ class WC_Calypso_Bridge_Setup {
 				// Update and Release row.
 				$wpdb->query( 'COMMIT' );
 				wp_cache_delete( $this->option_prefix . $operation, 'options' );
+				$this->write_to_log( $operation, 'COMMIT and cache deleted' );
 
 				return;
 			} catch ( Exception $e ) {
 				// Release row.
 				$wpdb->query( 'ROLLBACK' );
-				error_log( 'Exception: ' . $e->getMessage() );
+				$this->write_to_log( $operation, 'ROLLBACK with Exception: ' . $e->getMessage() );
 
 				return;
 			}
@@ -368,6 +386,8 @@ class WC_Calypso_Bridge_Setup {
 
 		// Gets triggered from the above WC_Install::create_pages call.
 		add_filter( 'woocommerce_create_pages', function ( $pages ) {
+
+			$operation = 'woocommerce_create_pages';
 
 			// Set the cart and checkout blocks as defaults.
 			if (
@@ -382,6 +402,7 @@ class WC_Calypso_Bridge_Setup {
 				if ( isset( $pages['checkout']['content'] ) ) {
 					$pages['checkout']['content'] = '<!-- wp:woocommerce/checkout {"align":"wide"} --><div class="wp-block-woocommerce-checkout alignwide wc-block-checkout is-loading"><!-- wp:woocommerce/checkout-fields-block --><div class="wp-block-woocommerce-checkout-fields-block"><!-- wp:woocommerce/checkout-express-payment-block --><div class="wp-block-woocommerce-checkout-express-payment-block"></div><!-- /wp:woocommerce/checkout-express-payment-block --><!-- wp:woocommerce/checkout-contact-information-block --><div class="wp-block-woocommerce-checkout-contact-information-block"></div><!-- /wp:woocommerce/checkout-contact-information-block --><!-- wp:woocommerce/checkout-shipping-address-block --><div class="wp-block-woocommerce-checkout-shipping-address-block"></div><!-- /wp:woocommerce/checkout-shipping-address-block --><!-- wp:woocommerce/checkout-billing-address-block --><div class="wp-block-woocommerce-checkout-billing-address-block"></div><!-- /wp:woocommerce/checkout-billing-address-block --><!-- wp:woocommerce/checkout-shipping-methods-block --><div class="wp-block-woocommerce-checkout-shipping-methods-block"></div><!-- /wp:woocommerce/checkout-shipping-methods-block --><!-- wp:woocommerce/checkout-payment-block --><div class="wp-block-woocommerce-checkout-payment-block"></div><!-- /wp:woocommerce/checkout-payment-block --><!-- wp:woocommerce/checkout-order-note-block --><div class="wp-block-woocommerce-checkout-order-note-block"></div><!-- /wp:woocommerce/checkout-order-note-block --><!-- wp:woocommerce/checkout-terms-block --><div class="wp-block-woocommerce-checkout-terms-block"></div><!-- /wp:woocommerce/checkout-terms-block --><!-- wp:woocommerce/checkout-actions-block --><div class="wp-block-woocommerce-checkout-actions-block"></div><!-- /wp:woocommerce/checkout-actions-block --></div><!-- /wp:woocommerce/checkout-fields-block --><!-- wp:woocommerce/checkout-totals-block --><div class="wp-block-woocommerce-checkout-totals-block"><!-- wp:woocommerce/checkout-order-summary-block --><div class="wp-block-woocommerce-checkout-order-summary-block"></div><!-- /wp:woocommerce/checkout-order-summary-block --></div><!-- /wp:woocommerce/checkout-totals-block --></div><!-- /wp:woocommerce/checkout -->';
 				}
+				$this->write_to_log( $operation, 'set cart/checkout blocks' );
 
 				// Inform the merchant that we've enabled the new checkout experience.
 				include_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/notes/class-wc-calypso-bridge-cart-checkout-blocks-default-inbox-note.php';
@@ -389,9 +410,22 @@ class WC_Calypso_Bridge_Setup {
 				WC_Calypso_Bridge_Cart_Checkout_Blocks_Default_Inbox_Note::possibly_add_note();
 			}
 
+			$log_pages = array();
+			foreach ( $pages as $key => $details ) {
+				$log_pages[] = $key;
+			}
+			$this->write_to_log( $operation, 'woocommerce_create_pages filter - pages:' . implode( ', ', $log_pages ) );
+
 			return $pages;
 
 		}, PHP_INT_MAX );
+
+		// Log which pages have been created.
+		add_action( 'woocommerce_page_created', function ( $page_id, $page_data ) {
+			$operation = 'woocommerce_create_pages';
+			$slug      = isset( $page_data['post_name'] ) ? $page_data['post_name'] : '';
+			$this->write_to_log( $operation, 'woocommerce_page_created action - ' . 'id: ' . $page_id . ', slug: ' . $slug );
+		}, PHP_INT_MAX, 2 );
 
 	}
 
@@ -602,6 +636,20 @@ class WC_Calypso_Bridge_Setup {
 		}
 
 		return $location;
+	}
+
+	/**
+	 * error_log wrapper
+	 *
+	 * @param string       $operation Operation.
+	 * @param string|array $message   Message.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return void
+	 */
+	private function write_to_log( $operation, $message ) {
+		error_log( $this->log_prefix . '(' . microtime( true ) . ') ' . $operation . ': ' . print_r( $message, 1 ) );
 	}
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,11 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= unreleased = 
+* Add logging in the page creation one time job #xxx
+* Increase old site identification to older than 1 hour for the page creation one time job #xxx
+* Properly unset one time jobs for non commerce sites #xxx
+
 = 2.2.7 =
 * Add `wp-cli` as a developer dependency #1250
 

--- a/readme.txt
+++ b/readme.txt
@@ -26,9 +26,9 @@ This section describes how to install the plugin and get it working.
 * Fix Tax task for free trial #1247
 * Fix tax task component UIs #1261
 * Introduce the remaining tasks bubble nudge under My Home > Home admin menu item #1225
-* Add logging in the page creation one time job #xxx
-* Increase old site identification to older than 1 hour for the page creation one time job #xxx
-* Properly unset one time jobs for non commerce sites #xxx
+* Add logging in the page creation one time job #1258
+* Increase old site identification to older than 1 hour for the page creation one time job #1258
+* Properly unset one time jobs for non commerce sites #1258
 
 = 2.2.7 =
 * Add `wp-cli` as a developer dependency #1250


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1257 .
- #1257 

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Sync this PR in an existing site
- [ ] Comment out line 47 `'woocommerce_create_pages'                => 'woocommerce_create_pages_callback',`
- [ ] Comment out lines 227-232, to force the job run for older sites
```php
			if ( WCAdminHelper::is_wc_admin_active_for( 60 * MINUTE_IN_SECONDS ) ) {
				update_option( $this->option_prefix . $operation, 'completed', 'no' );
				$this->write_to_log( $operation, 'completed (60 minutes)' );

				return;
			}
```
- [ ] Execute `wp option delete wc_calypso_bridge_one_time_operation_woocommerce_create_pages` - You can access CLI by visiting `/_cli` on a site (when proxied)
- [ ] ~Go to wp-admin and delete pages `shop, cart, checkout, myaccount, refund_returns` and also empty trash~
- [ ] Uncomment line 47 `'woocommerce_create_pages'                => 'woocommerce_create_pages_callback',`
- [ ] Execute `wp option get woocommerce_admin_install_timestamp` - This will trigger the one time job (or go to wp-admin > pages)
- [ ] Get your site's ID - It's the number in parenthesis in `/_cli`
- [ ] Go to logstash https://logstash.a8c.com/logstash/goto/d351e93188b84a27243f627938b86b93 and set the filter to your site id and click refresh


You will see something like

```
Aug 4, 2023 @ 09:34:00.000	WooExpress: Operation: (1691141640.1449) woocommerce_create_pages: created menu items
Aug 4, 2023 @ 09:34:00.000	WooExpress: Operation: (1691141640.1187) woocommerce_create_pages: finished WC_Install::create_pages
Aug 4, 2023 @ 09:34:00.000	WooExpress: Operation: (1691141640.1459) woocommerce_create_pages: COMMIT and cache deleted
Aug 4, 2023 @ 09:34:00.000	WooExpress: Operation: (1691141640.0065) woocommerce_create_pages: woocommerce_page_created action - id: 1406, slug: refund_returns
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.0517) woocommerce_create_pages: initialized
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.1442) woocommerce_create_pages: deleted WooCommerce page refund_returns
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.3303) woocommerce_create_pages: deleted WooCommerce page id for page checkout
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.3893) woocommerce_create_pages: woocommerce_create_pages filter - pages:shop, cart, checkout, myaccount, refund_returns
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.0778) woocommerce_create_pages: deleted WooCommerce page shop
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.1392) woocommerce_create_pages: deleted WooCommerce page checkout
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.2186) woocommerce_create_pages: deleted WooCommerce page id for page cart
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.4261) woocommerce_create_pages: woocommerce_page_created action - id: 1398, slug: shop
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.098) woocommerce_create_pages: deleted WooCommerce page cart
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.2744) woocommerce_create_pages: deleted WooCommerce page id for page myaccount
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.0519) woocommerce_create_pages: START TRANSACTION
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.5792) woocommerce_create_pages: woocommerce_page_created action - id: 1400, slug: cart
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.1602) woocommerce_create_pages: deleted WooCommerce page id for page shop
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.3878) woocommerce_create_pages: set cart/checkout blocks
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.729) woocommerce_create_pages: woocommerce_page_created action - id: 1402, slug: checkout
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.1189) woocommerce_create_pages: deleted WooCommerce page my-account
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.8789) woocommerce_create_pages: woocommerce_page_created action - id: 1404, slug: my-account
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.3864) woocommerce_create_pages: deleted WooCommerce page id for page refund_returns
```

If you notice things happening out of order, you're right; you have a keen eye for details.

Logstash does not keep the time with milliseconds. I've introduced the time in milliseconds in parenthesis, so we can sort externally in an editor and see the events in the order they happened.

Here's a sorted version:
```
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.0517) woocommerce_create_pages: initialized
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.0519) woocommerce_create_pages: START TRANSACTION
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.0778) woocommerce_create_pages: deleted WooCommerce page shop
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.098) woocommerce_create_pages: deleted WooCommerce page cart
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.1189) woocommerce_create_pages: deleted WooCommerce page my-account
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.1392) woocommerce_create_pages: deleted WooCommerce page checkout
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.1442) woocommerce_create_pages: deleted WooCommerce page refund_returns
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.1602) woocommerce_create_pages: deleted WooCommerce page id for page shop
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.2186) woocommerce_create_pages: deleted WooCommerce page id for page cart
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.2744) woocommerce_create_pages: deleted WooCommerce page id for page myaccount
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.3303) woocommerce_create_pages: deleted WooCommerce page id for page checkout
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.3864) woocommerce_create_pages: deleted WooCommerce page id for page refund_returns
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.3878) woocommerce_create_pages: set cart/checkout blocks
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.3893) woocommerce_create_pages: woocommerce_create_pages filter - pages:shop, cart, checkout, myaccount, refund_returns
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.4261) woocommerce_create_pages: woocommerce_page_created action - id: 1398, slug: shop
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.5792) woocommerce_create_pages: woocommerce_page_created action - id: 1400, slug: cart
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.729) woocommerce_create_pages: woocommerce_page_created action - id: 1402, slug: checkout
Aug 4, 2023 @ 09:33:59.000	WooExpress: Operation: (1691141639.8789) woocommerce_create_pages: woocommerce_page_created action - id: 1404, slug: my-account
Aug 4, 2023 @ 09:34:00.000	WooExpress: Operation: (1691141640.0065) woocommerce_create_pages: woocommerce_page_created action - id: 1406, slug: refund_returns
Aug 4, 2023 @ 09:34:00.000	WooExpress: Operation: (1691141640.1187) woocommerce_create_pages: finished WC_Install::create_pages
Aug 4, 2023 @ 09:34:00.000	WooExpress: Operation: (1691141640.1449) woocommerce_create_pages: created menu items
Aug 4, 2023 @ 09:34:00.000	WooExpress: Operation: (1691141640.1459) woocommerce_create_pages: COMMIT and cache deleted
```

------------------

This PR also increases the old site identification, from 5 minutes, to one hour.
We've noticed that 5 minutes is too short, and might be possible to cause the pages not being created and the job marked as complete (when it's not)

-------------------

I've also found that I was not unsetting the one-time job keys properly, for non commerce sites. Accidentally I was unsetting using the callback name, instead of the key. No need to test this, it's obvious :)

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
