### PR TITLE
Prepare for release 2.2.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v2.2.7",
+  "version": "v2.2.8",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/readme.txt
+++ b/readme.txt
@@ -25,9 +25,6 @@ This section describes how to install the plugin and get it working.
 = 2.2.8 =
 * Fix Tax task for free trial #1247
 
-= Unreleased =
-* Fix Tax task for free trial #1247
-
 = 2.2.7 =
 * Add `wp-cli` as a developer dependency #1250
 

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 2.2.8 =
+* Fix Tax task for free trial #1247
+
 = Unreleased =
 * Fix Tax task for free trial #1247
 

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,12 @@ This section describes how to install the plugin and get it working.
 
 = 2.2.8 =
 * Fix Tax task for free trial #1247
+* Fix tax task component UIs #1261
+* Introduce the remaining tasks bubble nudge under My Home > Home admin menu item #1225
+* Add logging in the page creation one time job #1258
+* Increase old site identification to older than 1 hour for the page creation one time job #1258
+* Properly unset one time jobs for non commerce sites #1258
+* Add the Plugins menu item back to free trial sites #1249
 
 = 2.2.7 =
 * Add `wp-cli` as a developer dependency #1250

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancements for users of Store on WordPress.com.
- * Version: 2.2.7
+ * Version: 2.2.8
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -47,7 +47,7 @@ if ( ! defined( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH' ) ) {
 	define( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH', dirname( __FILE__ ) );
 }
 if ( ! defined( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION' ) ) {
-	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.2.7' );
+	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.2.8' );
 }
 if ( ! defined( 'WC_MIN_VERSION' ) ) {
 	define( 'WC_MIN_VERSION', '7.3' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Preparation for release of 2.2.8

### Changelog

```
= 2.2.8 =
* Fix Tax task for free trial #1247
* Fix tax task component UIs #1261
* Introduce the remaining tasks bubble nudge under My Home > Home admin menu item #1225
* Add logging in the page creation one time job #1258
* Increase old site identification to older than 1 hour for the page creation one time job #1258
* Properly unset one time jobs for non commerce sites #1258
* Add the Plugins menu item back to free trial sites #1249

```