### PR TITLE
Fix tax task component UIs

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,7 @@ This section describes how to install the plugin and get it working.
 
 = Unreleased =
 * Fix Tax task for free trial #1247
+* Fix tax task component UIs #1261
 
 = 2.2.7 =
 * Add `wp-cli` as a developer dependency #1250

--- a/src/free-trial/tax/components/location.js
+++ b/src/free-trial/tax/components/location.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { COUNTRIES_STORE_NAME } from '@woocommerce/data';
-import { Fragment } from '@wordpress/element';
+import { Fragment, useState } from '@wordpress/element';
 import { Form, Spinner } from '@woocommerce/components';
 import { useSelect } from '@wordpress/data';
 
@@ -33,7 +33,9 @@ const StoreLocation = ( {
 				countryStore.hasFinishedResolution( 'getCountries' ),
 		};
 	} );
+	const [ isSubmitting, setSubmitting ] = useState( false );
 	const onSubmit = async ( values ) => {
+		setSubmitting( true );
 		await updateAndPersistSettingsForGroup( 'general', {
 			general: {
 				...settings,
@@ -45,6 +47,7 @@ const StoreLocation = ( {
 			},
 		} );
 
+		setSubmitting( false );
 		if ( ! isSettingsError ) {
 			onComplete( values );
 		} else {
@@ -98,7 +101,7 @@ const StoreLocation = ( {
 						getInputProps={ getInputProps }
 						setValue={ setValue }
 					/>
-					<Button isPrimary onClick={ handleSubmit }>
+					<Button isPrimary onClick={ handleSubmit } isBusy={ isSubmitting }>
 						{ buttonText }
 					</Button>
 				</Fragment>

--- a/src/free-trial/tax/woocommerce-tax/index.tsx
+++ b/src/free-trial/tax/woocommerce-tax/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { difference } from 'lodash';
 import { useSelect } from '@wordpress/data';
 import { Spinner } from '@woocommerce/components';
 import { PLUGINS_STORE_NAME, SETTINGS_STORE_NAME } from '@woocommerce/data';
@@ -10,12 +9,7 @@ import { PLUGINS_STORE_NAME, SETTINGS_STORE_NAME } from '@woocommerce/data';
 /**
  * Internal dependencies
  */
-import {
-	AUTOMATION_PLUGINS,
-	hasCompleteAddress,
-	TaxChildProps,
-} from '../utils';
-import { AutomatedTaxes } from './automated-taxes';
+import { TaxChildProps } from '../utils';
 import { Setup } from './setup';
 
 export const WooCommerceTax: React.FC< TaxChildProps > = ( {
@@ -24,39 +18,22 @@ export const WooCommerceTax: React.FC< TaxChildProps > = ( {
 	onManual,
 	onDisable,
 } ) => {
-	const {
-		generalSettings,
-		isJetpackConnected,
-		isResolving,
-		pluginsToActivate,
-	} = useSelect( ( select ) => {
+	const { isResolving } = useSelect( ( select ) => {
 		const { getSettings } = select( SETTINGS_STORE_NAME );
 		const { getActivePlugins, hasFinishedResolution } =
 			select( PLUGINS_STORE_NAME );
-		const activePlugins = getActivePlugins();
+		getActivePlugins();
 
 		return {
 			generalSettings: getSettings( 'general' ).general,
-			isJetpackConnected:
-				select( PLUGINS_STORE_NAME ).isJetpackConnected(),
 			isResolving:
-				! hasFinishedResolution( 'isJetpackConnected' ) ||
 				! select( SETTINGS_STORE_NAME ).hasFinishedResolution(
 					'getSettings',
 					[ 'general' ]
 				) ||
 				! hasFinishedResolution( 'getActivePlugins' ),
-			pluginsToActivate: difference( AUTOMATION_PLUGINS, activePlugins ),
 		};
 	} );
-
-	const canAutomateTaxes = () => {
-		return (
-			hasCompleteAddress( generalSettings || {} ) &&
-			! pluginsToActivate.length &&
-			isJetpackConnected
-		);
-	};
 
 	if ( isResolving ) {
 		return <Spinner />;
@@ -68,10 +45,6 @@ export const WooCommerceTax: React.FC< TaxChildProps > = ( {
 		onManual,
 		onDisable,
 	};
-
-	if ( canAutomateTaxes() ) {
-		return <AutomatedTaxes { ...childProps } />;
-	}
 
 	return <Setup { ...childProps } />;
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Follow-up to https://github.com/Automattic/wc-calypso-bridge/pull/1247#issuecomment-1668959429.

This PR:

1. Removes the direct use of `AutomatedTax` component since it should be displayed under `Setup` component instead, which includes a stepper.
2. The checks for Jetpack and the activated plugin are not relevant in Woo Express context since they're mandatory, I think they're safe to be removed. However, I don't remove queries to `generalSettings` and `getActivePlugins` since we render a spinner while resolving, and they're used in children components.
3. Add a loading indicator when submitting store address.

<img width="769" alt="image" src="https://github.com/Automattic/wc-calypso-bridge/assets/3747241/76ef8bb7-f602-4610-a890-5f5f9f023302">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Checkout this branch in your setup and make sure Jetpack is connected.
2. Remove all addresses by deleting `woocommerce_store_address`, `woocommerce_store_city`, and `woocommerce_store_postcode`
3. Click `Add tax rates` task in WooCommerce Home
5. Click `WooCommerce Tax`
6. Fill in the address information and click on `Continue`
7. Observe `Continue` button is changed to `busy` state ([image](https://github.com/Automattic/wc-calypso-bridge/assets/3747241/dd98364a-5783-4b32-b937-0f4ffd30398a))
8. Confirm Automated Tax is displayed per design as the screenshot provided

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
