### PR TITLE
Add smart shipping defaults to all countries for Woo Express sites

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -134,11 +134,10 @@ class WC_Calypso_Bridge {
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-skip-obw.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-footer-credits.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-customize-store.php';
+		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-smart-shipping.php';
 
 		// Experiments.
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/experiments/class-wc-calypso-bridge-task-list-reminderbar-experiment.php';
-
-		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-smart-shipping.php';
 	}
 
 	/**

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -138,6 +138,7 @@ class WC_Calypso_Bridge {
 		// Experiments.
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/experiments/class-wc-calypso-bridge-task-list-reminderbar-experiment.php';
 
+		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-smart-shipping.php';
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-smart-shipping.php
+++ b/includes/class-wc-calypso-bridge-smart-shipping.php
@@ -1,78 +1,70 @@
 <?php
 
-	use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Shipping as ShippingTask;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Shipping as ShippingTask;
 
-	/**
-	 * Set free shipping in the same country as the store default
-	 * Flag rate in all other countries when any of the following conditions are ture
-	 *
-	 * - The store sells physical products, has JP and WCS installed and connected, and is located in the US.
-	 * - The store sells physical products, and is not located in US/Canada/Australia/UK (irrelevant if JP is installed or not).
-	 * - The store sells physical products and is located in US, but JP and WCS are not installed.
-	 *
-	 * @param array $settings shared admin settings.
-	 * @return array
-	 */
-
-	 function wc_calypso_bridge_maybe_set_default_shipping_options_on_home( $settings ) {
-		if ( ! function_exists( 'get_current_screen' ) ) {
-			return $settings;
-		}
-
-		$current_screen = get_current_screen();
-
-		// Abort if it's not the homescreen.
-		if ( ! isset( $current_screen->id ) || 'woocommerce_page_wc-admin' !== $current_screen->id ) {
-			return $settings;
-		}
-
-		// Abort if we already created the shipping options.
-		$already_created = get_option( 'woocommerce_admin_created_default_shipping_zones' );
-		if ( $already_created === 'yes' ) {
-			return $settings;
-		}
-
-		$zone_count = count( \WC_Data_Store::load( 'shipping-zone' )->get_zones() );
-		if ( $zone_count ) {
-			update_option( 'woocommerce_admin_created_default_shipping_zones', 'yes' );
-			update_option( 'woocommerce_admin_reviewed_default_shipping_zones', 'yes' );
-			return $settings;
-		}
-
-		$user_skipped_obw           = $settings['onboarding']['profile']['skipped'] ?? false;
-		$store_address              = $settings['preloadSettings']['general']['woocommerce_store_address'] ?? '';
-		$product_types              = $settings['onboarding']['profile']['product_types'] ?? array();
-		$user_has_set_store_country = $settings['onboarding']['profile']['is_store_country_set'] ?? false;
-
-
-		// Do not proceed if user has not filled out their country in the onboarding profiler.
-		if ( ! $user_has_set_store_country ) {
-			return $settings;
-		}
-
-
-		// If user skipped the obw or has not completed the store_details
-		// then we assume the user is going to sell physical products.
-		if ( $user_skipped_obw || '' === $store_address ) {
-			$product_types[] = 'physical';
-		}
-
-		if ( false === in_array( 'physical', $product_types, true ) ) {
-			return $settings;
-		}
-
-		$country_code = wc_format_country_state_string( $settings['preloadSettings']['general']['woocommerce_default_country'] )['country'];
-		$country_name = WC()->countries->get_countries()[ $country_code ] ?? null;
-
-		$zone = new \WC_Shipping_Zone();
-		$zone->set_zone_name( $country_name );
-		$zone->add_location( $country_code, 'country' );
-		$zone->add_shipping_method( 'free_shipping' );
-		update_option( 'woocommerce_admin_created_default_shipping_zones', 'yes' );
-		ShippingTask::delete_zone_count_transient();
-
-
+/**
+ * Set free shipping in the same country as the store default
+ * Flag rate in all other countries when any of the following conditions are ture
+ *
+ * - Country is set.
+ * - No orders exists.
+ *
+ * @param array $settings shared admin settings.
+ * @return array
+ */
+function wc_calypso_bridge_maybe_set_default_shipping_options_on_home( $settings ) {
+	if ( ! function_exists( 'get_current_screen' ) ) {
 		return $settings;
 	}
 
-	add_action( 'woocommerce_admin_shared_settings', 'wc_calypso_bridge_maybe_set_default_shipping_options_on_home', 99, 3 );
+	$current_screen = get_current_screen();
+
+	// Abort if it's not the homescreen.
+	if ( ! isset( $current_screen->id ) || 'woocommerce_page_wc-admin' !== $current_screen->id ) {
+		return $settings;
+	}
+
+	// Abort if we already created the shipping options.
+	$already_created = get_option( 'woocommerce_admin_created_default_shipping_zones' );
+	if ( 'yes' === $already_created ) {
+		return $settings;
+	}
+
+	$zone_count = count( \WC_Data_Store::load( 'shipping-zone' )->get_zones() );
+	if ( $zone_count ) {
+		update_option( 'woocommerce_admin_created_default_shipping_zones', 'yes' );
+		update_option( 'woocommerce_admin_reviewed_default_shipping_zones', 'yes' );
+		return $settings;
+	}
+
+	$country_code = wc_format_country_state_string( $settings['preloadSettings']['general']['woocommerce_default_country'] )['country'];
+	$country_name = WC()->countries->get_countries()[ $country_code ] ?? null;
+
+	// Country is not defined.
+	if ( ! $country_code || ! $country_name ) {
+		return $settings;
+	}
+
+	$args        = array(
+		'limit'  => 4,
+		'offset' => 1,
+	);
+	$orders_count = count( wc_get_orders( $args ) );
+
+	// If there are orders, don't create the default shipping options.
+	// This is to protect from mistakenly adding free shipping to an established store.
+	if ( $orders_count > 0 ) {
+		return $settings;
+	}
+
+	$zone = new \WC_Shipping_Zone();
+	$zone->set_zone_name( $country_name );
+	$zone->add_location( $country_code, 'country' );
+	$zone->add_shipping_method( 'free_shipping' );
+	update_option( 'woocommerce_admin_created_default_shipping_zones', 'yes' );
+	ShippingTask::delete_zone_count_transient();
+
+	return $settings;
+}
+
+add_action( 'woocommerce_admin_shared_settings', 'wc_calypso_bridge_maybe_set_default_shipping_options_on_home', 99, 3 );

--- a/includes/class-wc-calypso-bridge-smart-shipping.php
+++ b/includes/class-wc-calypso-bridge-smart-shipping.php
@@ -10,8 +10,8 @@
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Shipping as ShippingTask;
 
 /**
- * Set free shipping in the same country as the store default
- * Flag rate in all other countries when any of the following conditions are ture
+ * Set free shipping in the same country as the store's current country.
+ * Flag rate in all other countries when any of the following conditions are true:
  *
  * - Country is set.
  * - No orders exists.
@@ -53,8 +53,7 @@ function wc_calypso_bridge_maybe_set_default_shipping_options_on_home( $settings
 	}
 
 	$args         = array(
-		'limit'  => 4,
-		'offset' => 1,
+		'limit'  => 1,
 	);
 	$orders_count = count( wc_get_orders( $args ) );
 

--- a/includes/class-wc-calypso-bridge-smart-shipping.php
+++ b/includes/class-wc-calypso-bridge-smart-shipping.php
@@ -2,75 +2,120 @@
 /**
  * Smart shipping function.
  *
- * @package -
+ * @package WC_Calypso_Bridge/Classes
  * @since   x.x.x
  * @version x.x.x
  */
 
+defined( 'ABSPATH' ) || exit;
+
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Shipping as ShippingTask;
 
 /**
- * Set free shipping in the same country as the store's current country.
- * Flag rate in all other countries when any of the following conditions are true:
- *
- * - Country is set.
- * - No orders exists.
- *
- * @param array $settings shared admin settings.
- * @return array
+ * WC Calypso Bridge Smart shipping
  */
-function wc_calypso_bridge_maybe_set_default_shipping_options_on_home( $settings ) {
-	if ( ! function_exists( 'get_current_screen' ) ) {
-		return $settings;
+class WC_Calypso_Smart_Shipping {
+
+	/**
+	 * Class Instance.
+	 *
+	 * @var WC_Calypso_Smart_Shipping instance
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Get class instance
+	 */
+	public static function get_instance() {
+		if ( ! static::$instance ) {
+			static::$instance = new static();
+		}
+
+		return static::$instance;
 	}
 
-	$current_screen = get_current_screen();
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		// Only in Ecommerce or free trial.
+		if ( ! ( wc_calypso_bridge_has_ecommerce_features() || wc_calypso_bridge_is_ecommerce_trial_plan() ) ) {
+			return;
+		}
 
-	// Abort if it's not the homescreen.
-	if ( ! isset( $current_screen->id ) || 'woocommerce_page_wc-admin' !== $current_screen->id ) {
-		return $settings;
+		add_action( 'woocommerce_admin_shared_settings', array( $this, 'wc_calypso_bridge_maybe_set_default_shipping_options_on_home' ), 99, 3 );
 	}
 
-	// Abort if we already created the shipping options.
-	$already_created = get_option( 'woocommerce_admin_created_default_shipping_zones' );
-	if ( 'yes' === $already_created ) {
-		return $settings;
-	}
+	/**
+	 * Set free shipping in the same country as the store's current country.
+	 * Flag rate in all other countries when any of the following conditions are true:
+	 *
+	 * - Country is set.
+	 * - No orders exists.
+	 *
+	 * @param array $settings shared admin settings.
+	 * @return array
+	 */
+	public function wc_calypso_bridge_maybe_set_default_shipping_options_on_home( $settings ) {
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return $settings;
+		}
 
-	$zone_count = count( \WC_Data_Store::load( 'shipping-zone' )->get_zones() );
-	if ( $zone_count ) {
+		$current_screen = get_current_screen();
+
+		// Abort if it's not the homescreen.
+		if ( ! isset( $current_screen->id ) || 'woocommerce_page_wc-admin' !== $current_screen->id ) {
+			return $settings;
+		}
+
+		// Abort if we already created the shipping options.
+		$already_created = get_option( 'woocommerce_admin_created_default_shipping_zones' );
+		if ( 'yes' === $already_created ) {
+			return $settings;
+		}
+
+		$zone_count = count( \WC_Data_Store::load( 'shipping-zone' )->get_zones() );
+		if ( $zone_count ) {
+			update_option( 'woocommerce_admin_created_default_shipping_zones', 'yes' );
+			update_option( 'woocommerce_admin_reviewed_default_shipping_zones', 'yes' );
+			return $settings;
+		}
+
+		$user_has_set_store_country = $settings['onboarding']['profile']['is_store_country_set'] ?? false;
+		// Do not proceed if user has not filled out their country from NUX.
+		if ( ! $user_has_set_store_country ) {
+			return $settings;
+		}
+
+		$country_code = wc_format_country_state_string( $settings['preloadSettings']['general']['woocommerce_default_country'] )['country'];
+		$country_name = WC()->countries->get_countries()[ $country_code ] ?? null;
+
+		// Country is not defined.
+		if ( ! $country_code || ! $country_name ) {
+			return $settings;
+		}
+
+		$args         = array(
+			'limit'  => 1,
+		);
+		$orders_count = count( wc_get_orders( $args ) );
+
+		// If there are orders, don't create the default shipping options.
+		// This is to protect from mistakenly adding free shipping to an established store.
+		if ( $orders_count > 0 ) {
+			return $settings;
+		}
+
+		$zone = new \WC_Shipping_Zone();
+		$zone->set_zone_name( $country_name );
+		$zone->add_location( $country_code, 'country' );
+		$zone->add_shipping_method( 'free_shipping' );
 		update_option( 'woocommerce_admin_created_default_shipping_zones', 'yes' );
-		update_option( 'woocommerce_admin_reviewed_default_shipping_zones', 'yes' );
+		ShippingTask::delete_zone_count_transient();
+
 		return $settings;
 	}
 
-	$country_code = wc_format_country_state_string( $settings['preloadSettings']['general']['woocommerce_default_country'] )['country'];
-	$country_name = WC()->countries->get_countries()[ $country_code ] ?? null;
-
-	// Country is not defined.
-	if ( ! $country_code || ! $country_name ) {
-		return $settings;
-	}
-
-	$args         = array(
-		'limit'  => 1,
-	);
-	$orders_count = count( wc_get_orders( $args ) );
-
-	// If there are orders, don't create the default shipping options.
-	// This is to protect from mistakenly adding free shipping to an established store.
-	if ( $orders_count > 0 ) {
-		return $settings;
-	}
-
-	$zone = new \WC_Shipping_Zone();
-	$zone->set_zone_name( $country_name );
-	$zone->add_location( $country_code, 'country' );
-	$zone->add_shipping_method( 'free_shipping' );
-	update_option( 'woocommerce_admin_created_default_shipping_zones', 'yes' );
-	ShippingTask::delete_zone_count_transient();
-
-	return $settings;
 }
 
-add_action( 'woocommerce_admin_shared_settings', 'wc_calypso_bridge_maybe_set_default_shipping_options_on_home', 99, 3 );
+WC_Calypso_Smart_Shipping::get_instance();

--- a/includes/class-wc-calypso-bridge-smart-shipping.php
+++ b/includes/class-wc-calypso-bridge-smart-shipping.php
@@ -50,6 +50,8 @@ class WC_Calypso_Smart_Shipping {
 	 * Set free shipping in the same country as the store's current country.
 	 * Flag rate in all other countries when any of the following conditions are true:
 	 *
+	 * - is_store_country_set is true in the onboarding profile.
+	 * - No shipping zone is set.
 	 * - Country is set.
 	 * - No orders exists.
 	 *
@@ -95,9 +97,7 @@ class WC_Calypso_Smart_Shipping {
 			return $settings;
 		}
 
-		$args         = array(
-			'limit'  => 1,
-		);
+		$args         = array( 'limit'  => 1 );
 		$orders_count = count( wc_get_orders( $args ) );
 
 		// If there are orders, don't create the default shipping options.

--- a/includes/class-wc-calypso-bridge-smart-shipping.php
+++ b/includes/class-wc-calypso-bridge-smart-shipping.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Smart shipping function.
+ *
+ * @package WC_Calypso_Bridge/Classes
+ * @since   x.x.x
+ * @version x.x.x
+ */
 
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Shipping as ShippingTask;
 
@@ -45,7 +52,7 @@ function wc_calypso_bridge_maybe_set_default_shipping_options_on_home( $settings
 		return $settings;
 	}
 
-	$args        = array(
+	$args         = array(
 		'limit'  => 4,
 		'offset' => 1,
 	);

--- a/includes/class-wc-calypso-bridge-smart-shipping.php
+++ b/includes/class-wc-calypso-bridge-smart-shipping.php
@@ -1,0 +1,78 @@
+<?php
+
+	use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Shipping as ShippingTask;
+
+	/**
+	 * Set free shipping in the same country as the store default
+	 * Flag rate in all other countries when any of the following conditions are ture
+	 *
+	 * - The store sells physical products, has JP and WCS installed and connected, and is located in the US.
+	 * - The store sells physical products, and is not located in US/Canada/Australia/UK (irrelevant if JP is installed or not).
+	 * - The store sells physical products and is located in US, but JP and WCS are not installed.
+	 *
+	 * @param array $settings shared admin settings.
+	 * @return array
+	 */
+
+	 function wc_calypso_bridge_maybe_set_default_shipping_options_on_home( $settings ) {
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return $settings;
+		}
+
+		$current_screen = get_current_screen();
+
+		// Abort if it's not the homescreen.
+		if ( ! isset( $current_screen->id ) || 'woocommerce_page_wc-admin' !== $current_screen->id ) {
+			return $settings;
+		}
+
+		// Abort if we already created the shipping options.
+		$already_created = get_option( 'woocommerce_admin_created_default_shipping_zones' );
+		if ( $already_created === 'yes' ) {
+			return $settings;
+		}
+
+		$zone_count = count( \WC_Data_Store::load( 'shipping-zone' )->get_zones() );
+		if ( $zone_count ) {
+			update_option( 'woocommerce_admin_created_default_shipping_zones', 'yes' );
+			update_option( 'woocommerce_admin_reviewed_default_shipping_zones', 'yes' );
+			return $settings;
+		}
+
+		$user_skipped_obw           = $settings['onboarding']['profile']['skipped'] ?? false;
+		$store_address              = $settings['preloadSettings']['general']['woocommerce_store_address'] ?? '';
+		$product_types              = $settings['onboarding']['profile']['product_types'] ?? array();
+		$user_has_set_store_country = $settings['onboarding']['profile']['is_store_country_set'] ?? false;
+
+
+		// Do not proceed if user has not filled out their country in the onboarding profiler.
+		if ( ! $user_has_set_store_country ) {
+			return $settings;
+		}
+
+
+		// If user skipped the obw or has not completed the store_details
+		// then we assume the user is going to sell physical products.
+		if ( $user_skipped_obw || '' === $store_address ) {
+			$product_types[] = 'physical';
+		}
+
+		if ( false === in_array( 'physical', $product_types, true ) ) {
+			return $settings;
+		}
+
+		$country_code = wc_format_country_state_string( $settings['preloadSettings']['general']['woocommerce_default_country'] )['country'];
+		$country_name = WC()->countries->get_countries()[ $country_code ] ?? null;
+
+		$zone = new \WC_Shipping_Zone();
+		$zone->set_zone_name( $country_name );
+		$zone->add_location( $country_code, 'country' );
+		$zone->add_shipping_method( 'free_shipping' );
+		update_option( 'woocommerce_admin_created_default_shipping_zones', 'yes' );
+		ShippingTask::delete_zone_count_transient();
+
+
+		return $settings;
+	}
+
+	add_action( 'woocommerce_admin_shared_settings', 'wc_calypso_bridge_maybe_set_default_shipping_options_on_home', 99, 3 );

--- a/includes/class-wc-calypso-bridge-smart-shipping.php
+++ b/includes/class-wc-calypso-bridge-smart-shipping.php
@@ -2,7 +2,7 @@
 /**
  * Smart shipping function.
  *
- * @package WC_Calypso_Bridge/Classes
+ * @package -
  * @since   x.x.x
  * @version x.x.x
  */

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleased =
+* Add smart shipping defaults to all countries for Woo Express sites #1276
+
 = 2.2.23 =
 * Add parameter to go back for theme links in cys intro screen #1351
 

--- a/store-on-wpcom/class-wc-calypso-bridge.php
+++ b/store-on-wpcom/class-wc-calypso-bridge.php
@@ -80,7 +80,6 @@ class WC_Calypso_Bridge_Deprecated {
 		include_once dirname( __FILE__ ) . '/inc/wc-calypso-bridge-paypal-defaults.php';
 		include_once dirname( __FILE__ ) . '/inc/wc-calypso-bridge-paypal-method-supports.php';
 		include_once dirname( __FILE__ ) . '/inc/wc-calypso-bridge-products.php';
-		include_once dirname( __FILE__ ) . '/inc/wc-calypso-bridge-smart-shipping.php';
 	}
 
 	/**

--- a/store-on-wpcom/class-wc-calypso-bridge.php
+++ b/store-on-wpcom/class-wc-calypso-bridge.php
@@ -80,6 +80,7 @@ class WC_Calypso_Bridge_Deprecated {
 		include_once dirname( __FILE__ ) . '/inc/wc-calypso-bridge-paypal-defaults.php';
 		include_once dirname( __FILE__ ) . '/inc/wc-calypso-bridge-paypal-method-supports.php';
 		include_once dirname( __FILE__ ) . '/inc/wc-calypso-bridge-products.php';
+		include_once dirname( __FILE__ ) . '/inc/wc-calypso-bridge-smart-shipping.php';
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/Automattic/wc-calypso-bridge/issues/1144.

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### How to test the changes in this Pull Request:

**Reset instructions:**
1. Ensure `woocommerce_onboarding_profile` site option with value `is_store_country_set: true` exists
1. Go to Settings > WooCommerce > Shipping and delete all shipping zones
1. Go to Settings > WooCommerce > General and select a country
1. Delete the following options:
    - `woocommerce_admin_created_default_shipping_zones`
    - `woocommerce_admin_reviewed_default_shipping_zones`

**Testing happy flow:**
1. Use an existing site and follow the reset instructions or set up a development Woo Express site pdibGW-2pG-p2 (paid plan)
1. In the Homescreen, observe that `Add shipping costs` task is not shown under the main tasklist
2. Observe that `Review shipping options` task is shown under `Things to do next`
1. Click on `Review shipping options` and observe you're redirected to shipping settings with spotlight tour displayed
2. Go back to WooCommerce homescreen
3. Observe that `Review shipping options` is marked as complete

**Testing established site:**
1. Create a dummy product and make a dummy order (any state)
2. Reset your site with the instruction above, **and set your store country to Canada**
3. Go to Homescreen and observe that no `Review shipping options` task is not displayed
4. Observe that `Add shipping costs` task is displayed
5. Go to Settings > WooCommerce > Shipping and observe no shipping zone is set

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.