### PR TITLE
Fix plugins mobile screen UI

### DIFF
--- a/assets/css/ecommerce.css
+++ b/assets/css/ecommerce.css
@@ -155,6 +155,10 @@ body.woocommerce_page_wc-bridge .wc-bridge-wrap .storefront {
 	.wc-bridge-landing-page__features-grid__item {
 		padding: 0 10px;
 	}
+
+	.woocommerce.wc-bridge-landing-page h1.wc-bridge-landing-page__title {
+		padding: 0 2em;
+	}
 }
 @media screen and (max-width: 600px) {
 

--- a/readme.txt
+++ b/readme.txt
@@ -25,6 +25,7 @@ This section describes how to install the plugin and get it working.
 = Unreleased =
 * Handling footer credits for Woo Express plans #1265
 * Convert plugins page to a WC page #1278
+* Fix plugins mobile screen UI #1281
 
 = 2.2.10 =
 * Update translation files on every release


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Addresses p1692873123860529/1692862121.108019-slack-CNA89KY6M

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. In Woo Express free trial site, go to WooCommerce > Plugins
2. Set screen to mobile (< 768px width)
3. Observe heading is centered

<img width="669" alt="image" src="https://github.com/Automattic/wc-calypso-bridge/assets/3747241/9e5c1579-9329-45c7-a67a-c25a6ddbcece">


<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.