### PR TITLE
Introduce blocklist for feature settings to be hidden

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,11 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= unreleased = 
+* Introduce a blocklist for feature settings to be hidden (Analytics, Old Navigation) #1284
+* Add logic to search explicitly for the right key in order to inject the Navigation setting under the "Features" section #1284
+* Restore access to the editor and HPOS experimental options #1284
+
 = 2.2.11 =
 * Handling footer credits for Woo Express plans #1265
 * Convert plugins page to a WC page #1278


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR:

- Introduces a blocklist for feature settings to be hidden (Analytics, Old Navigation)
- Adds some logic to search search explicitly for the right key in order to inject the **Navigation** setting under the "Features" section. Previously, it was assumed that this section is always the first one in the array.
- Finally, restores access to the editor and HPOS experimental options.


<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1282, closes #1283

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

- Navigate to **Settings > Advanced > Features**.
- Confirm that you see all settings except for the **Analytics** one:

<img width="978" alt="Screenshot 2023-08-29 at 1 04 08 PM" src="https://github.com/Automattic/wc-calypso-bridge/assets/1783726/d3ae081c-85c4-4f68-9df3-46b5677c97ad">

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
