### PR TITLE
Improved footer credits handling

### DIFF
--- a/includes/class-wc-calypso-bridge-footer-credits.php
+++ b/includes/class-wc-calypso-bridge-footer-credits.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * WC Calypso Bridge Footer Credits
+ *
+ * @package WC_Calypso_Bridge/Classes
+ * @since   2.2.11
+ * @version x.x.x
+ */
 
 defined( 'ABSPATH' ) || exit;
 
@@ -36,21 +43,32 @@ class WC_Calypso_Bridge_Footer_Credits {
 			return;
 		}
 
-        return add_filter( 'wpcom_better_footer_credit_link', array( $this, 'get_footer_credits' ) );
+        add_filter( 'wpcom_better_footer_credit_link', array( $this, 'get_footer_credits' ), PHP_INT_MAX, 2 );
     }
 
-    /**
-     * Get footer credit as HTML.
-     *
-     * @see <wpcomsh/block-theme-footer-credits/class-wpcom-block-theme-footer-credits.php>
-     *
-     * @return string
-     */
-    public function get_footer_credits(): string {
-        $utm_string = '?utm_source=referral&utm_medium=footer-credit&utm_campaign=woo-express-footer-credit';
-				/* translators: %1$s is replaced with a link to WooCommerce.com */
-        return sprintf( __( 'Powered by %1$s', 'wc-calypso-bridge' ), '<a href="https://woocommerce.com/express/' . $utm_string . '" rel="nofollow">Woo</a>' );
-    }
+	/**
+	 * Override footer credit as HTML - Only if there is no option in the DB or if it's set to default.
+	 *
+	 * @param $credit
+	 * @param $lang
+	 *
+	 * @return string
+	 * @see <wpcomsh/block-theme-footer-credits/class-wpcom-block-theme-footer-credits.php>
+	 *
+	 */
+	public function get_footer_credits( $credit, $lang ) {
+
+		$credit_option = get_option( 'footercredit', false );
+		if ( empty( $credit_option ) || 'default' === $credit_option ) {
+			$utm_string = '?utm_source=referral&utm_medium=footer-credit&utm_campaign=woo-express-footer-credit';
+
+			/* translators: %1$s is replaced with a link to WooCommerce.com */
+			return sprintf( __( 'Powered by %1$s', 'wc-calypso-bridge' ), '<a href="https://woocommerce.com/express/' . $utm_string . '" rel="nofollow">Woo</a>' );
+		}
+
+		return $credit;
+
+	}
 
 };
 WC_Calypso_Bridge_Footer_Credits::get_instance();

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= unreleased =
+* Improve handling footer credits for Woo Express plans #xxx
+
 = 2.2.11 =
 * Handling footer credits for Woo Express plans #1265
 * Convert plugins page to a WC page #1278


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1285 .
- https://github.com/Automattic/wc-calypso-bridge/issues/1285

We should only update the footer link, if the footer credit options is set to `default` or if it doesn't exist. 

For all the other options, we do nothing and return the passed value

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

- [ ] Rsync this branch to your test site
- [ ] ssh into your site and `wp option delete footercredit`
- [ ] Visit your site and see `Powered by Woo` at the footer
- [ ] Go to the customizer, site identity, footer credits, and set it to `hidden`
- [ ] Visit your site and see `Powered by Woo` will be hidden
- [ ] Go to the customizer, site identity, footer credits, and set it to `default`
- [ ] Visit your site and see `Powered by Woo` at the footer
- [ ] Go to the customizer, site identity, footer credits, and choose any other option
- [ ] Visit your site and see the appropriate link at the footer

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
