### PR TITLE
Display server based incentive header

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= unreleased =
+* Display a server based WooPayments setup task header when an incentive is available.
+
 = 2.2.12 =
 * Improve handling footer credits for Woo Express plans #1286
 * Introduce a blocklist for feature settings to be hidden (Analytics, Old Navigation) #1284

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,7 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 = unreleased =
-* Display a server based WooPayments setup task header when an incentive is available.
+* Display a server based WooPayments setup task header when an incentive is available #1294
 
 = 2.2.12 =
 * Improve handling footer credits for Woo Express plans #1286

--- a/src/free-trial/fills/task-headers/woocommerce-payments.js
+++ b/src/free-trial/fills/task-headers/woocommerce-payments.js
@@ -13,8 +13,13 @@ import { Link } from '@woocommerce/components';
  */
 import TimerImage from '../../../task-headers/assets/images/timer.svg';
 import { WC_ASSET_URL } from '../../../utils/admin-settings';
+import { sanitizeHTML } from '../../../payment-gateway-suggestions/utils';
 
 const WoocommercePaymentsHeader = () => {
+	const incentive =
+		window.wcSettings?.admin?.wcpayWelcomePageIncentive ||
+		window.wcpaySettings?.connectIncentive;
+
 	return (
 		<WooOnboardingTaskListHeader id="woocommerce-payments">
 			{ ( { task, goToTask } ) => {
@@ -38,12 +43,20 @@ const WoocommercePaymentsHeader = () => {
 									'wc-calypso-bridge'
 								) }
 							</h1>
-							<p>
-								{ __(
-									'Power your payments with a simple, all-in-one option. Verify your business details to start testing transactions with WooCommerce Payments.',
-									'wc-calypso-bridge'
-								) }
-							</p>
+							{ incentive?.task_header_content ? (
+								<p
+									dangerouslySetInnerHTML={ sanitizeHTML(
+										incentive.task_header_content
+									) }
+								/>
+							) : (
+								<p>
+									{ __(
+										'Power your payments with a simple, all-in-one option. Verify your business details to start testing transactions with WooCommerce Payments.',
+										'wc-calypso-bridge'
+									) }
+								</p>
+							) }
 							<p>
 								{ interpolateComponents( {
 									mixedString: __(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/Automattic/woocommerce-payments/issues/7036

Display a server based WooPayments setup task header when an incentive is available. Getting its value from `window.wcSettings.admin.wcpayWelcomePageIncentive` or `window.wcpaySettings.connectIncentive`.

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### How to test the changes in this Pull Request:
- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

>[!Note]
> This PR requires unreleased versions of WC (https://github.com/woocommerce/woocommerce/pull/40034) and WooPayments (https://github.com/Automattic/woocommerce-payments/pull/7132)

- Set up an atomic site if you don't have one already. (Useful guide: pdqkbG-2Ma-p2)
- Sync this PR branch.
- If you don't see the `Payments (1)` menu, ensure you meet [the action incentive requirements ](https://github.com/Automattic/woocommerce-payments-server/blob/2a2bab907d6e950ea8a011b0680f5bea1d6f4886/server/wp-content/rest-api-plugins/endpoints/wcpay/service/class-incentive-service.php#L572). Edit [get_store_context](https://github.com/Automattic/woocommerce-payments/blob/e8dfc6de076642bef99c20f5404c787bbc908175/includes/class-wc-payments-incentives-service.php#L255) if WooPayments is enabled, otherwise [get_incentive from WC](https://github.com/woocommerce/woocommerce/blob/bd1351e265c865de9f632bfb978ebc01c8f9823a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php#L331).
- Go to WC Home and complete any WC Home task before `Set up WooPayments` until it becomes the active one.
- `Set up WooPayments` task should have the badge and the new task header, matching the attached screenshot.

### Screenshots
| Before | After |
|-|-|
|<img width="695" alt="Screenshot 2023-09-06 at 15 00 48" src="https://github.com/Automattic/wc-calypso-bridge/assets/7670276/20307d1a-061e-4b94-8402-6e4c9c8a99dc">|<img width="696" alt="Screenshot 2023-09-06 at 14 59 26" src="https://github.com/Automattic/wc-calypso-bridge/assets/7670276/ab4d261e-a554-4bc1-b5fc-690dd3de7cb9">|


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.