### PR TITLE
Revert aggressive page deletion - Flush cache and sleep

### DIFF
--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -684,7 +684,7 @@ class WC_Calypso_Bridge_Setup {
 	 * @return void
 	 */
 	private function write_to_log( $operation, $message ) {
-		error_log(  'WooExpress: Operation: (' . microtime( true ) . ') ' . $operation . ': ' . print_r( $message, 1 ) );
+		error_log(  'WooExpress: Operation: ' . $operation . ': (' . microtime( true ) . ') ' . print_r( $message, 1 ) );
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -224,7 +224,7 @@ class WC_Calypso_Bridge_Setup {
 			$this->write_to_log( $operation, 'INITIALIZED' );
 
 			// Set the operation as completed if the store is active for more than 10 minutes.
-			if ( WCAdminHelper::is_wc_admin_active_for( 10 * MINUTE_IN_SECONDS ) ) {
+			if ( WCAdminHelper::is_wc_admin_active_for( 5 * MINUTE_IN_SECONDS ) ) {
 				update_option( $this->option_prefix . $operation, 'completed', 'no' );
 				$this->write_to_log( $operation, 'completed (10 minutes)' );
 
@@ -286,7 +286,7 @@ class WC_Calypso_Bridge_Setup {
 				foreach ( $woocommerce_pages as $key => $page_slug ) {
 					$slugs = array( $page_slug, $page_slug . '-2' );
 					foreach ( $slugs as $slug ) {
-						$this->delete_page_by_slug( $slug, $operation );
+						$this->maybe_delete_page_by_slug( $slug, $operation );
 					}
 				}
 
@@ -321,7 +321,7 @@ class WC_Calypso_Bridge_Setup {
 				foreach ( $headstart_slugs as $page_slug ) {
 					$slugs = array( $page_slug, $page_slug . '-2' );
 					foreach ( $slugs as $slug ) {
-						$this->delete_page_by_slug( $slug, $operation );
+						$this->maybe_delete_page_by_slug( $slug, $operation );
 					}
 				}
 
@@ -688,16 +688,17 @@ class WC_Calypso_Bridge_Setup {
 	}
 
 	/**
-	 * Delete page by slug
-	 *
-	 * @param string $slug Slug.
-	 * @param string $operation Operation.
+	 * Maybe delete page by slug.
+	 * If the page is older than 10 minutes, it will be ignored.
 	 *
 	 * @since x.x.x
 	 *
+	 * @param string $operation Operation.
+	 *
+	 * @param string $slug Slug.
 	 * @return void
 	 */
-	private function delete_page_by_slug( $slug, $operation ) {
+	private function maybe_delete_page_by_slug( $slug, $operation ) {
 
 		$page = get_page_by_path( $slug, ARRAY_A );
 
@@ -712,7 +713,7 @@ class WC_Calypso_Bridge_Setup {
 			$diff_ts             = $current_time_gmt_ts - $page_gmt_ts;
 
 			if ( $diff_ts > 10 * MINUTE_IN_SECONDS ) {
-				$this->write_to_log( $operation, 'ignored page deletion (too old) ' . $slug . ' diff: ' . $diff_ts );
+				$this->write_to_log( $operation, 'ignored page deletion ' . $slug . ' diff: ' . $diff_ts / 60 . ' minutes (older than 10 minutes) ' );
 
 				return;
 			}

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -224,7 +224,7 @@ class WC_Calypso_Bridge_Setup {
 			$this->write_to_log( $operation, 'INITIALIZED' );
 
 			// Set the operation as completed if the store is active for more than 10 minutes.
-			if ( WCAdminHelper::is_wc_admin_active_for( 5 * MINUTE_IN_SECONDS ) ) {
+			if ( WCAdminHelper::is_wc_admin_active_for( 10 * MINUTE_IN_SECONDS ) ) {
 				update_option( $this->option_prefix . $operation, 'completed', 'no' );
 				$this->write_to_log( $operation, 'completed (10 minutes)' );
 

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -702,29 +702,31 @@ class WC_Calypso_Bridge_Setup {
 
 		$page = get_page_by_path( $slug, ARRAY_A );
 
-		if ( is_array( $page ) && isset( $page['ID'] ) ) {
-
-			$page_gmt_ts = get_post_time( 'U', true, $page['ID'] );
-			// draft pages don't have a post_date_gmt, so we need to calculate it.
-			if ( false === $page_gmt_ts ) {
-				$page_gmt_ts = get_gmt_from_date( $page['post_date'], 'U' );
-			}
-			$current_time_gmt_ts = current_time( 'U', true );
-			$diff_ts             = $current_time_gmt_ts - $page_gmt_ts;
-
-			if ( $diff_ts > 10 * MINUTE_IN_SECONDS ) {
-				$this->write_to_log( $operation, 'ignored page deletion ' . $slug . ' diff: ' . $diff_ts / 60 . ' minutes (older than 10 minutes) ' );
-
-				return;
-			}
-
-			$result = wp_delete_post( $page['ID'], true );
-			if ( $result ) {
-				$this->write_to_log( $operation, 'deleted page ' . $slug );
-			} else {
-				$this->write_to_log( $operation, 'failed to delete page ' . $slug );
-			}
+		if ( ! is_array( $page ) || ! isset( $page['ID'] ) ) {
+			return;
 		}
+
+		$page_gmt_ts = get_post_time( 'U', true, $page['ID'] );
+		// draft pages don't have a post_date_gmt, so we need to calculate it.
+		if ( false === $page_gmt_ts ) {
+			$page_gmt_ts = get_gmt_from_date( $page['post_date'], 'U' );
+		}
+		$current_time_gmt_ts = current_time( 'U', true );
+		$diff_ts             = $current_time_gmt_ts - $page_gmt_ts;
+
+		if ( $diff_ts > 10 * MINUTE_IN_SECONDS ) {
+			$this->write_to_log( $operation, 'ignored page deletion ' . $slug . ' diff: ' . $diff_ts / 60 . ' minutes (older than 10 minutes) ' );
+
+			return;
+		}
+
+		$result = wp_delete_post( $page['ID'], true );
+		if ( $result ) {
+			$this->write_to_log( $operation, 'deleted page ' . $slug );
+		} else {
+			$this->write_to_log( $operation, 'failed to delete page ' . $slug );
+		}
+
 
 	}
 }

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 2.2.13
+ * @version x.x.x
  */
 
 use Automattic\WooCommerce\Admin\WCAdminHelper;
@@ -221,10 +221,10 @@ class WC_Calypso_Bridge_Setup {
 
 			$operation = 'woocommerce_create_pages';
 
-			$this->write_to_log( $operation, 'initialized' );
+			$this->write_to_log( $operation, 'INITIALIZED' );
 
-			// Set the operation as completed if the store is active for more than 1 hour.
-			if ( WCAdminHelper::is_wc_admin_active_for( 60 * MINUTE_IN_SECONDS ) ) {
+			// Set the operation as completed if the store is active for more than 5 minutes.
+			if ( WCAdminHelper::is_wc_admin_active_for( 5 * MINUTE_IN_SECONDS ) ) {
 				update_option( $this->option_prefix . $operation, 'completed', 'no' );
 				$this->write_to_log( $operation, 'completed (60 minutes)' );
 
@@ -268,28 +268,27 @@ class WC_Calypso_Bridge_Setup {
 			}
 
 			try {
-				/*
-				 * Force delete all pages (including duplicates), except some which are whitelisted.
-				 */
-				$exclude_pages = array( 'faq', 'contact-us', 'blog' );
-				$args_pages    = array(
-					'post_type'      => 'page',
-					'post_status'    => 'any',
-					'posts_per_page' => - 1,
-				);
-				$query_pages   = new WP_Query( $args_pages );
 
-				$this->write_to_log( $operation, 'DELETING PAGES ');
-				if ( ! empty( $query_pages->posts ) ) {
-					foreach ( $query_pages->posts as $page ) {
-						if ( ! in_array( $page->post_name, $exclude_pages ) ) {
-							$result = wp_delete_post( $page->ID, true );
-							$this->write_to_log( $operation, 'deleted WooCommerce page ' . $page->ID . ' - ' . $page->post_name );
-							if ( ! $result ) {
-								$this->write_to_log( $operation, 'failed to delete WooCommerce page ' . $page->ID . ' - ' . $page->post_name );
+				$this->write_to_log( $operation, 'DELETING WOOCOMMERCE PAGES ');
+
+				$woocommerce_slugs = array(
+					'shop'           => _x( 'shop', 'Page slug', 'woocommerce' ),
+					'cart'           => _x( 'cart', 'Page slug', 'woocommerce' ),
+					'checkout'       => _x( 'checkout', 'Page slug', 'woocommerce' ),
+					'myaccount'      => _x( 'my-account', 'Page slug', 'woocommerce' ),
+					'refund_returns' => _x( 'refund_returns', 'Page slug', 'woocommerce' ),
+				);
+				foreach ( $woocommerce_slugs as $key => $page_slug ) {
+					$slugs = array( $page_slug, $page_slug . '-2' );
+					foreach ( $slugs as $slug ) {
+						$page = get_page_by_path( $slug, ARRAY_A );
+						if ( is_array( $page ) && isset( $page['ID'] ) ) {
+							$result = wp_delete_post( $page['ID'], true );
+							if ( $result ) {
+								$this->write_to_log( $operation, 'deleted WooCommerce page ' . $slug );
+							} else {
+								$this->write_to_log( $operation, 'failed to delete WooCommerce page ' . $slug );
 							}
-						} else {
-							$this->write_to_log( $operation, 'skipped WooCommerce page ' . $page->ID . ' - ' . $page->post_name );
 						}
 					}
 				}
@@ -303,21 +302,41 @@ class WC_Calypso_Bridge_Setup {
 				 * `My Account` page id setting, is created with key `myaccount`.
 				 * @see WC_Install::create_pages()
 				 */
-				$this->write_to_log( $operation, 'DELETING OPTIONS ');
-				foreach ( [ 'shop', 'cart', 'myaccount', 'checkout', 'refund_returns' ] as $page ) {
-					$value  = get_option( "woocommerce_{$page}_page_id" );
-					$result = delete_option( "woocommerce_{$page}_page_id" );
-					$this->write_to_log( $operation, 'deleted option woocommerce_' . $page . '_page_id : ' . $value );
-					if ( ! $result ) {
-						$this->write_to_log( $operation, 'failed to delete option woocommerce_' . $page . '_page_id : ' . $value );
+				$this->write_to_log( $operation, 'DELETING WOOCOMMERCE PAGE OPTIONS ');
+
+				foreach ( $woocommerce_slugs as $key => $page_slug ) {
+					$value  = get_option( "woocommerce_{$key}_page_id" );
+					$result = delete_option( "woocommerce_{$key}_page_id" );
+					if ( $result ) {
+						$this->write_to_log( $operation, 'deleted option woocommerce_' . $key . '_page_id : ' . $value );
+					} else {
+						$this->write_to_log( $operation, 'failed to delete option woocommerce_' . $key . '_page_id : ' . $value );
 					}
 				}
 
-				// Commenting this out, to see if this was the reason that the pages are now created.
-//				foreach ( [ 'shop', 'cart', 'myaccount', 'checkout', 'refund_returns' ] as $page ) {
-//					$value  = get_option( "woocommerce_{$page}_page_id" );
-//					$this->write_to_log( $operation, 'getting option woocommerce_' . $page . '_page_id : ' . $value );
-//				}
+				$this->write_to_log( $operation, 'DELETING HEADSTART PAGES ');
+
+				// See https://github.com/Automattic/theme-tsubaki/blob/trunk/inc/headstart/en.json
+				$headstart_slugs   = array( 'shop', 'cart', 'checkout', 'my-account', 'refund_returns' );
+				foreach ( $headstart_slugs as $page_slug ) {
+					$slugs = array( $page_slug, $page_slug . '-2' );
+					foreach ( $slugs as $slug ) {
+						$page = get_page_by_path( $slug, ARRAY_A );
+						if ( is_array( $page ) && isset( $page['ID'] ) ) {
+							$result = wp_delete_post( $page['ID'], true );
+							if ( $result ) {
+								$this->write_to_log( $operation, 'deleted headstart page ' . $slug );
+							} else {
+								$this->write_to_log( $operation, 'failed to delete headstart page ' . $slug );
+							}
+						}
+					}
+				}
+
+				$this->write_to_log( $operation, 'FLUSH CACHE AND SLEEP ');
+				// sleep for 0.5 second to give enough time to memcache to flush and revalidate.
+				wp_cache_flush();
+				usleep( 500000 );
 
 				// Delete the following note, so it can be recreated with the correct refund page ID.
 				if ( class_exists( 'Automattic\WooCommerce\Admin\Notes\Notes' ) ) {
@@ -435,19 +454,6 @@ class WC_Calypso_Bridge_Setup {
 			return $pages;
 
 		}, PHP_INT_MAX );
-
-		// Log if valid page exists.
-		add_filter( 'woocommerce_create_page_id', function ( $valid_page_found, $slug, $page_content ) {
-
-			$operation = 'woocommerce_create_pages';
-			if ( $valid_page_found ) {
-				$this->write_to_log( $operation, 'woocommerce_create_page_id filter - valid page found - slug: ' . $slug );
-			} else {
-				$this->write_to_log( $operation, 'woocommerce_create_page_id filter - valid page not found - slug: ' . $slug );
-			}
-
-			return $valid_page_found;
-		}, PHP_INT_MAX, 3 );
 
 		// Log which pages have been created.
 		add_action( 'woocommerce_page_created', function ( $page_id, $page_data ) {

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,10 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= unreleased = 
+* Revert all page deletion and delete only WooCommerce related pages #xxx
+* Purge cache before creating WooCommerce related pages #xxx
+
 = 2.2.14 =
 * Updated plugins landing page (free trial) #1300
 * Removed some get_options logging during the page creation one time job #1296


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1302 closes #1303 .
- #1302 
- #1303 

TLDR;

Instead of deleting all pages except for `'faq', 'contact-us', 'blog'`, we now delete only WooCommerce related pages.

We're extra careful, and check if the Woo Page we're about to delete is old. 

For example, if we have a simple site with a page called `shop` , when an Ecommerce plan is purchased, this page won't be overwritten. but instead we instruct WooCommerce to create a new page 

"Old" pages, are considered those that are older than 10 minutes.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Create a new Free site and add some pages.
- [ ] Get blog id from store admin
https://wordpress.com/wp-admin/network/admin.php?page=store-admin&action=blog_id_search&id=https%3A%2F%2FYOURTESTSITE.wordpress.com
- [ ] Go to https://mc.a8c.com/atomic/wpcom-dev-blogs/ 
- [ ] Enter the blog id, check `Transfers to Atomic dev server pool` and click `Add dev blog` 
- [ ] Upgrade to Business 
- [ ] Go to `Settings > Hosting management` and activate SFTP/SSH access (keep the credentials handy for the SSH and SCP commands further down)
- [ ] On your laptop, checkout branch `fix/1302-1303-revert-page-deletion-fix-cache` 
- [ ] CD into the local repo and `scp ./includes/class-wc-calypso-bridge-setup.php USERNAME@sftp.wp.com:/srv/htdocs/wp-content/mu-plugins/wpcomsh/vendor/automattic/wc-calypso-bridge/includes` to your WOA DEV site
- [ ] SSH into the new site and `tail -f -n1000 /tmp/php-errors` to see the logfile (keep it open)
- [ ] Click on `Upgrades` and upgrade to Ecommerce plan
- [ ] Check site that the pages created on the free site are not deleted
- [ ] Check that you have all WooCommerce-related pages (shop, cart, checkout, my-account, refund-returns)
- [ ] Check that there are no duplicate pages


You would see something similar to in your terminal - Please copy/paste it in your comments when you wrap up the test.
```
[21-Sep-2023 09:12:11 UTC] WooExpress: Operation: (1695287531.8358) woocommerce_create_pages: INITIALIZED
[21-Sep-2023 09:12:11 UTC] WooExpress: Operation: (1695287531.8361) woocommerce_create_pages: START TRANSACTION
[21-Sep-2023 09:12:11 UTC] WooExpress: Operation: (1695287531.8365) woocommerce_create_pages: DELETING WOOCOMMERCE PAGES
[21-Sep-2023 09:12:11 UTC] WooExpress: Operation: (1695287531.8443) woocommerce_create_pages: deleted page shop
[21-Sep-2023 09:12:11 UTC] WooExpress: Operation: (1695287531.8496) woocommerce_create_pages: deleted page cart
[21-Sep-2023 09:12:11 UTC] WooExpress: Operation: (1695287531.8547) woocommerce_create_pages: deleted page checkout
[21-Sep-2023 09:12:11 UTC] WooExpress: Operation: (1695287531.8598) woocommerce_create_pages: deleted page my-account
[21-Sep-2023 09:12:11 UTC] WooExpress: Operation: (1695287531.8645) woocommerce_create_pages: deleted page refund_returns
[21-Sep-2023 09:12:11 UTC] WooExpress: Operation: (1695287531.8649) woocommerce_create_pages: DELETING WOOCOMMERCE PAGE OPTIONS
[21-Sep-2023 09:12:11 UTC] WooExpress: Operation: (1695287531.8697) woocommerce_create_pages: deleted option woocommerce_shop_page_id : 13
[21-Sep-2023 09:12:11 UTC] WooExpress: Operation: (1695287531.8704) woocommerce_create_pages: deleted option woocommerce_cart_page_id : 14
[21-Sep-2023 09:12:11 UTC] WooExpress: Operation: (1695287531.871) woocommerce_create_pages: deleted option woocommerce_checkout_page_id : 15
[21-Sep-2023 09:12:11 UTC] WooExpress: Operation: (1695287531.8716) woocommerce_create_pages: deleted option woocommerce_myaccount_page_id : 16
[21-Sep-2023 09:12:11 UTC] WooExpress: Operation: (1695287531.8764) woocommerce_create_pages: deleted option woocommerce_refund_returns_page_id : 17
[21-Sep-2023 09:12:11 UTC] WooExpress: Operation: (1695287531.8764) woocommerce_create_pages: DELETING HEADSTART PAGES
[21-Sep-2023 09:12:11 UTC] WooExpress: Operation: (1695287531.8789) woocommerce_create_pages: FLUSH CACHE AND SLEEP
[21-Sep-2023 09:12:12 UTC] WooExpress: Operation: (1695287532.3796) woocommerce_create_pages: CREATING PAGES
[21-Sep-2023 09:12:12 UTC] WooExpress: Operation: (1695287532.3848) woocommerce_create_pages: woocommerce_create_pages filter - updated content to use cart/checkout blocks
[21-Sep-2023 09:12:12 UTC] WooExpress: Operation: (1695287532.388) woocommerce_create_pages: woocommerce_create_pages filter - pages:shop, cart, checkout, myaccount, refund_returns
[21-Sep-2023 09:12:12 UTC] WooExpress: Operation: (1695287532.3886) woocommerce_create_pages: woocommerce_create_page_id force create slug: shop
[21-Sep-2023 09:12:12 UTC] WooExpress: Operation: (1695287532.399) woocommerce_create_pages: woocommerce_page_created action - id: 18, slug: shop
[21-Sep-2023 09:12:12 UTC] WooExpress: Operation: (1695287532.4096) woocommerce_create_pages: woocommerce_create_page_id force create slug: cart
[21-Sep-2023 09:12:12 UTC] WooExpress: Operation: (1695287532.419) woocommerce_create_pages: woocommerce_page_created action - id: 19, slug: cart
[21-Sep-2023 09:12:12 UTC] WooExpress: Operation: (1695287532.4295) woocommerce_create_pages: woocommerce_create_page_id force create slug: checkout
[21-Sep-2023 09:12:12 UTC] WooExpress: Operation: (1695287532.4378) woocommerce_create_pages: woocommerce_page_created action - id: 20, slug: checkout
[21-Sep-2023 09:12:12 UTC] WooExpress: Operation: (1695287532.4481) woocommerce_create_pages: woocommerce_create_page_id force create slug: my-account
[21-Sep-2023 09:12:12 UTC] WooExpress: Operation: (1695287532.4546) woocommerce_create_pages: woocommerce_page_created action - id: 21, slug: my-account
[21-Sep-2023 09:12:12 UTC] WooExpress: Operation: (1695287532.4649) woocommerce_create_pages: woocommerce_create_page_id force create slug: refund_returns
[21-Sep-2023 09:12:12 UTC] WooExpress: Operation: (1695287532.4742) woocommerce_create_pages: woocommerce_page_created action - id: 22, slug: refund_returns
[21-Sep-2023 09:12:12 UTC] WooExpress: Operation: (1695287532.4836) woocommerce_create_pages: finished WC_Install::create_pages
[21-Sep-2023 09:12:12 UTC] WooExpress: Operation: (1695287532.4959) woocommerce_create_pages: created menu items
[21-Sep-2023 09:12:12 UTC] WooExpress: Operation: (1695287532.4969) woocommerce_create_pages: COMMIT and cache deleted
```


<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.