### PR TITLE
Introduce additional cache purging when creating pages - Consider old pages older than 60 minutes

### DIFF
--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 2.2.15
+ * @version x.x.x
  */
 
 use Automattic\WooCommerce\Admin\WCAdminHelper;
@@ -223,10 +223,10 @@ class WC_Calypso_Bridge_Setup {
 
 			$this->write_to_log( $operation, 'INITIALIZED' );
 
-			// Set the operation as completed if the store is active for more than 10 minutes.
-			if ( WCAdminHelper::is_wc_admin_active_for( 10 * MINUTE_IN_SECONDS ) ) {
+			// Set the operation as completed if the store is active for more than 60 minutes.
+			if ( WCAdminHelper::is_wc_admin_active_for( 60 * MINUTE_IN_SECONDS ) ) {
 				update_option( $this->option_prefix . $operation, 'completed', 'no' );
-				$this->write_to_log( $operation, 'completed (10 minutes)' );
+				$this->write_to_log( $operation, 'completed (60 minutes)' );
 
 				return;
 			}
@@ -308,6 +308,13 @@ class WC_Calypso_Bridge_Setup {
 					} else {
 						$this->write_to_log( $operation, 'failed to delete option woocommerce_' . $key . '_page_id : ' . $value );
 					}
+
+					$result_cache = wp_cache_delete( "woocommerce_{$key}_page_id", 'options' );
+					if ( $result_cache ) {
+						$this->write_to_log( $operation, 'deleted cache for option woocommerce_' . $key . '_page_id : ' . $value );
+					} else {
+						$this->write_to_log( $operation, 'failed to delete cache for option woocommerce_' . $key . '_page_id : ' . $value );
+					}
 				}
 
 				/*
@@ -329,6 +336,12 @@ class WC_Calypso_Bridge_Setup {
 				// sleep for 0.5 second to give enough time to memcache to flush and revalidate.
 				wp_cache_flush();
 				usleep( 500000 );
+
+				$this->write_to_log( $operation, 'GETTING WOOCOMMERCE PAGE OPTIONS AFTER DELETION');
+				foreach ( $woocommerce_pages as $key => $page_slug ) {
+					$value = get_option( "woocommerce_{$key}_page_id" );
+					$this->write_to_log( $operation, 'getting option woocommerce_' . $key . '_page_id : ' . $value );
+				}
 
 				// Delete the following note, so it can be recreated with the correct refund page ID.
 				if ( class_exists( 'Automattic\WooCommerce\Admin\Notes\Notes' ) ) {
@@ -689,7 +702,7 @@ class WC_Calypso_Bridge_Setup {
 
 	/**
 	 * Maybe delete page by slug.
-	 * If the page is older than 10 minutes, it will be ignored.
+	 * If the page is older than 60 minutes, it will be ignored.
 	 *
 	 * @since 2.2.15
 	 *
@@ -714,13 +727,14 @@ class WC_Calypso_Bridge_Setup {
 		$current_time_gmt_ts = current_time( 'U', true );
 		$diff_ts             = $current_time_gmt_ts - $page_gmt_ts;
 
-		if ( $diff_ts > 10 * MINUTE_IN_SECONDS ) {
-			$this->write_to_log( $operation, 'ignored page deletion ' . $slug . ' diff: ' . $diff_ts / 60 . ' minutes (older than 10 minutes) ' );
+		if ( $diff_ts > 60 * MINUTE_IN_SECONDS ) {
+			$this->write_to_log( $operation, 'ignored page deletion ' . $slug . ' diff: ' . $diff_ts / 60 . ' minutes (older than 60 minutes) ' );
 
 			return;
 		}
 
 		$result = wp_delete_post( $page['ID'], true );
+		clean_post_cache( $page['ID'] );
 		if ( $result ) {
 			$this->write_to_log( $operation, 'deleted page ' . $slug );
 		} else {

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,10 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= unreleased = 
+* Introduce additional cache purging while creating WooCommerce related pages #xxx
+* Ensure existing WooCommerce related pages are deleted #xxx
+
 = 2.2.15 =
 * Revert all page deletion and delete only WooCommerce related pages #1304
 * Purge cache before creating WooCommerce related pages #1304


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1310.
- #1310  

TLDR;

Instead of deleting all pages except for `'faq', 'contact-us', 'blog'`, we now delete only WooCommerce related pages.

We're extra careful, and check if the Woo Page we're about to delete is old. 

For example, if we have a simple site with a page called `shop` , when an Ecommerce plan is purchased, this page won't be overwritten. but instead we instruct WooCommerce to create a new page 

"Old" pages, are considered those that are older than 60 minutes.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Create a new Free site and add some pages.
- [ ] Get blog id from store admin
https://wordpress.com/wp-admin/network/admin.php?page=store-admin&action=blog_id_search&id=https%3A%2F%2FYOURTESTSITE.wordpress.com
- [ ] Go to https://mc.a8c.com/atomic/wpcom-dev-blogs/ 
- [ ] Enter the blog id, check `Transfers to Atomic dev server pool` and click `Add dev blog` 
- [ ] Upgrade to Business 
- [ ] Go to `Settings > Hosting management` and activate SFTP/SSH access (keep the credentials handy for the SSH and SCP commands further down)
- [ ] On your laptop, checkout branch `fix/1310-ensure-pages-are-deleted` 
- [ ] CD into the local repo and `scp ./includes/class-wc-calypso-bridge-setup.php USERNAME@sftp.wp.com:/srv/htdocs/wp-content/mu-plugins/wpcomsh/vendor/automattic/wc-calypso-bridge/includes` to your WOA DEV site
- [ ] SSH into the new site and `tail -f -n1000 /tmp/php-errors` to see the logfile (keep it open)
- [ ] Click on `Upgrades` and upgrade to Ecommerce plan
- [ ] Check site that the pages created on the free site are DELETED (they are considered as old since they were created in the past hour)
- [ ] Check that you have all WooCommerce-related pages (shop, cart, checkout, my-account, refund-returns)
- [ ] Check that there are no duplicate pages


You would see something similar to in your terminal - Please copy/paste it in your comments when you wrap up the test.
```
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.4138) INITIALIZED
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.4141) START TRANSACTION
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.4149) DELETING WOOCOMMERCE PAGES
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.425) deleted page shop
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.4311) deleted page shop-2
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.4373) deleted page cart
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.4435) deleted page cart-2
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.4492) deleted page checkout
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.4551) deleted page checkout-2
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.4608) deleted page my-account
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.4664) deleted page my-account-2
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.4723) deleted page refund_returns
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.4727) DELETING WOOCOMMERCE PAGE OPTIONS
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.4851) deleted option woocommerce_shop_page_id : 634
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.4853) failed to delete cache for option woocommerce_shop_page_id : 634
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.5423) deleted option woocommerce_cart_page_id : 635
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.5425) failed to delete cache for option woocommerce_cart_page_id : 635
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.5945) deleted option woocommerce_checkout_page_id : 636
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.5946) failed to delete cache for option woocommerce_checkout_page_id : 636
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.6506) deleted option woocommerce_myaccount_page_id : 637
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.6508) failed to delete cache for option woocommerce_myaccount_page_id : 637
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.7064) deleted option woocommerce_refund_returns_page_id : 638
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.7066) failed to delete cache for option woocommerce_refund_returns_page_id : 638
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.7067) DELETING HEADSTART PAGES
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.7159) deleted page refund_returns
[28-Sep-2023 11:46:05 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901565.7164) FLUSH CACHE AND SLEEP
[28-Sep-2023 11:46:06 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901566.2167) GETTING WOOCOMMERCE PAGE OPTIONS AFTER DELETION
[28-Sep-2023 11:46:06 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901566.2707) getting option woocommerce_shop_page_id :
[28-Sep-2023 11:46:06 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901566.2712) getting option woocommerce_cart_page_id :
[28-Sep-2023 11:46:06 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901566.2716) getting option woocommerce_checkout_page_id :
[28-Sep-2023 11:46:06 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901566.272) getting option woocommerce_myaccount_page_id :
[28-Sep-2023 11:46:06 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901566.2724) getting option woocommerce_refund_returns_page_id :
[28-Sep-2023 11:46:06 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901566.2757) CREATING PAGES
[28-Sep-2023 11:46:06 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901566.2769) woocommerce_create_pages filter - updated content to use cart/checkout blocks
[28-Sep-2023 11:46:06 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901566.2777) woocommerce_create_pages filter - pages:shop, cart, checkout, myaccount, refund_returns
[28-Sep-2023 11:46:06 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901566.2782) woocommerce_create_page_id force create slug: shop
[28-Sep-2023 11:46:06 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901566.2868) woocommerce_page_created action - id: 641, slug: shop
[28-Sep-2023 11:46:06 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901566.3953) woocommerce_create_page_id force create slug: cart
[28-Sep-2023 11:46:06 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901566.4074) woocommerce_page_created action - id: 642, slug: cart
[28-Sep-2023 11:46:06 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901566.5152) woocommerce_create_page_id force create slug: checkout
[28-Sep-2023 11:46:06 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901566.5255) woocommerce_page_created action - id: 643, slug: checkout
[28-Sep-2023 11:46:06 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901566.6311) woocommerce_create_page_id force create slug: my-account
[28-Sep-2023 11:46:06 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901566.6387) woocommerce_page_created action - id: 644, slug: my-account
[28-Sep-2023 11:46:06 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901566.7433) woocommerce_create_page_id force create slug: refund_returns
[28-Sep-2023 11:46:06 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901566.7551) woocommerce_page_created action - id: 645, slug: refund_returns
[28-Sep-2023 11:46:06 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901566.8586) finished WC_Install::create_pages
[28-Sep-2023 11:46:06 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901566.9267) created menu items
[28-Sep-2023 11:46:06 UTC] WooExpress: Operation: woocommerce_create_pages: (1695901566.9277) COMMIT and cache deleted
```


<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.