### PR TITLE
Use the wc-admin version of the marketplace under Extensions > Discover menu item

### DIFF
--- a/includes/class-wc-calypso-bridge-addons.php
+++ b/includes/class-wc-calypso-bridge-addons.php
@@ -5,8 +5,10 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.6
- * @version 2.0.0
+ * @version x.x.x
  */
+
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -54,9 +56,11 @@ class WC_Calypso_Bridge_Addons {
 	 * Initialize.
 	 */
 	public function init() {
+
+		// Hide the default marketplace.
 		add_filter( 'woocommerce_show_addons_page', '__return_false' );
+		// Handle the addons legacy page.
 		add_action( 'admin_menu', array( $this, 'addons_menu' ), 70 );
-		add_action( 'woocommerce_loaded', array( $this, 'load_modified_addons_menu' ) );
 
 		// Add admin body class for the free trial landing page.
 		if ( wc_calypso_bridge_is_ecommerce_trial_plan() ) {
@@ -72,11 +76,8 @@ class WC_Calypso_Bridge_Addons {
 		}
 	}
 
-	/**
-	 * Load the class for the modified Addons menu.
-	 */
-	public function load_modified_addons_menu() {
-		require 'class-wc-modified-admin-addons.php';
+	public function get_menu_slug() {
+		return class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) && FeaturesUtil::feature_is_enabled( 'marketplace' ) && ! wc_calypso_bridge_is_ecommerce_trial_plan() ? 'wc-admin&path=/extensions' : 'wc-addons';
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-addons.php
+++ b/includes/class-wc-calypso-bridge-addons.php
@@ -8,8 +8,6 @@
  * @version x.x.x
  */
 
-use Automattic\WooCommerce\Utilities\FeaturesUtil;
-
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -77,7 +75,7 @@ class WC_Calypso_Bridge_Addons {
 	}
 
 	public function get_menu_slug() {
-		return class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) && FeaturesUtil::feature_is_enabled( 'marketplace' ) && ! wc_calypso_bridge_is_ecommerce_trial_plan() ? 'wc-admin&path=/extensions' : 'wc-addons';
+		return class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) && \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'marketplace' ) && ! wc_calypso_bridge_is_ecommerce_trial_plan() ? 'wc-admin&path=/extensions' : 'wc-addons';
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -295,7 +295,7 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 			);
 		}
 
-		if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) && \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'analytics' ) ) {
+		if ( class_exists( '\Automattic\WooCommerce\Admin\Features\Features' ) && \Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'analytics' ) ) {
 			// Move Customers to root menu.
 			$this->hide_submenu_page( 'woocommerce', 'wc-admin&path=/customers' );
 			add_menu_page( __( 'Customers', 'woocommerce' ), __( 'Customers', 'woocommerce' ), 'manage_woocommerce', 'admin.php?page=wc-admin&path=/customers', null, 'dashicons-money', 100 );

--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -75,7 +75,7 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 
 		add_action( 'admin_menu', function() {
 
-			// Hide Extensions > Manage.
+			// Hide Extensions > Manage and the new Extensions page.
 			$this->hide_submenu_page( 'woocommerce', 'admin.php?page=wc-addons&section=helper' );
 			$this->hide_submenu_page( 'woocommerce', 'wc-admin&path=/extensions' );
 

--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -4,12 +4,10 @@
  * Class Ecommerce_Atomic_Admin_Menu.
  *
  * @since   1.9.8
- * @version 2.2.0
+ * @version x.x.x
  *
  * The admin menu controller for Ecommerce WoA sites.
  */
-
-use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customizations\Atomic_Admin_Menu {
 
@@ -297,7 +295,7 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 			);
 		}
 
-		if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) && FeaturesUtil::feature_is_enabled( 'analytics' ) ) {
+		if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) && \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'analytics' ) ) {
 			// Move Customers to root menu.
 			$this->hide_submenu_page( 'woocommerce', 'wc-admin&path=/customers' );
 			add_menu_page( __( 'Customers', 'woocommerce' ), __( 'Customers', 'woocommerce' ), 'manage_woocommerce', 'admin.php?page=wc-admin&path=/customers', null, 'dashicons-money', 100 );
@@ -522,16 +520,6 @@ class Ecommerce_Atomic_Admin_Menu extends \Automattic\Jetpack\Dashboard_Customiz
 				return ( $A < $B ) ? -1 : 1;
 			} );
 		}
-	}
-
-	/**
-	 * Addons menu item.
-	 */
-	public function add_addons_menu() {
-		$count_html = \WC_Helper_Updater::get_updates_count_html();
-		/* translators: %s: extensions count */
-		$menu_title = sprintf( __( 'Extensions %s', 'wc-calypso-bridge' ), $count_html );
-		add_submenu_page( 'woocommerce', __( 'WooCommerce extensions', 'wc-calypso-bridge' ), $menu_title, 'manage_woocommerce', 'wc-addons', array( $this, 'addons_page' ) );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleashed =
+* Enable the reactified WC Admin Marketplace under the "Extensions > Discover" menu item #1318
+
 = 2.2.16 =
 * Introduce additional cache purging while creating WooCommerce related pages #1311
 * Ensure existing WooCommerce related pages are deleted #1311

--- a/src/index.js
+++ b/src/index.js
@@ -176,6 +176,15 @@ if ( !! window.wcCalypsoBridge.isEcommercePlan ) {
 
 			// Override marketing page.
 			if ( !! window.wcCalypsoBridge.isEcommercePlanTrial ) {
+
+				// Remove the marketplace page from the list.
+				for ( let i = 0; i < pages.length; i++ ) {
+					if ( pages[ i ].path === '/extensions' ) {
+						pages.splice( i, 1 );
+						break;
+					}
+				}
+
 				pages = pages.map( ( page ) => {
 					if ( page.path === '/marketing' ) {
 						page.container = Marketing;

--- a/src/index.js
+++ b/src/index.js
@@ -174,7 +174,6 @@ if ( !! window.wcCalypsoBridge.isEcommercePlan ) {
 				);
 			}
 
-			// Override marketing page.
 			if ( !! window.wcCalypsoBridge.isEcommercePlanTrial ) {
 
 				// Remove the marketplace page from the list.
@@ -185,6 +184,7 @@ if ( !! window.wcCalypsoBridge.isEcommercePlan ) {
 					}
 				}
 
+				// Override marketing page.
 				pages = pages.map( ( page ) => {
 					if ( page.path === '/marketing' ) {
 						page.container = Marketing;
@@ -192,6 +192,7 @@ if ( !! window.wcCalypsoBridge.isEcommercePlan ) {
 					return page;
 				} );
 
+				// Add the Plugins landing page.
 				pages.push( {
 					container: Plugins,
 					path: '/plugins-upgrade',


### PR DESCRIPTION
### Specification

This PR aims to refactor the ecommerce menu structure to accommodate the new rectified marketplace version. 

#### Notes on the changes:
- A new `WC_Calypso_Bridge_Addons::get_menu_slug()` method is introduced that would return the menu slug to use based on the context. The new marketplace will only be used when (a) the feature is enabled and (b) the site is not a free trial site. The latter is required because the landing page is hosted on the legacy page. 
- The `get_menu_slug()` helper is later used in the menu controller to identify the item that needs renaming and reordering.

Closes #1317 

### Validation

Please ensure that the changeset in this https://github.com/woocommerce/woocommerce/pull/40549 is included in your WC installation before testing.

To test the changes on WX sites follow the steps below:

**Testing on Ecommerce/Essential/Performance WX sites with the feature enabled:**

- Use a WX site (not a free trial.)
- Check that the "Extensions > Discover" menu item appears twice, and both point to the legacy page _(wp-admin/admin.php?page=wc-addons)_
- Apply this patch.
- Ensure that you only see one "Extensions > Discover" item, and it points to the rectified version.
- Ensure that the "Extensions > Manage" continues to work as expected.

**Testing on Ecommerce/Essential/Performance WX sites with the feature disabled:**

- Now, on the same site, head over to "Settings > WooCommerce > Advanced > Features" and disable the "Marketplace" feature. 
- Visit the "Extensions > Discover" item and ensure the legacy template gets loaded as expected. 
- Ensure that the "Extensions > Manage" page is still working.

**Testing on WX free trials:**

- Use a WX free trial
- Visit the "Extensions > Discover" item and ensure the landing page is loaded correctly.
- Head over to "Settings > WooCommerce > Advanced > Features" and disable the "Marketplace" feature.
- Visit the "Extensions > Discover" item and ensure the landing page is loaded correctly _again_.
- Ensure that the "Extensions > Manage" page is still working.
- Manually navigate to `wp-admin/admin.php?page=wc-admin&path=%2Fextensions` and ensure you cannot access the page while in the free trial.