### PR TITLE
Fix CYS conflict with wpcom.editor

### DIFF
--- a/includes/class-wc-calypso-bridge-customize-store.php
+++ b/includes/class-wc-calypso-bridge-customize-store.php
@@ -40,6 +40,14 @@ class WC_Calypso_Bridge_Customize_Store {
 				add_action( 'load-site-editor.php', array( $this, 'mark_customize_store_task_as_completed_on_site_editor' ) );
 			}
 		});
+
+		// wpcom.editor.js conflicts with CYS scripts due to double registration of the private-apis
+		// dequeue it on CYS pages.
+		add_action( 'admin_print_scripts', function() {
+			if ( str_contains( $_GET['path'], '/customize-store/' ) ) {
+				wp_dequeue_script( 'wpcom-block-editor-wpcom-editor-script' );
+			}
+		}, 9999);
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-customize-store.php
+++ b/includes/class-wc-calypso-bridge-customize-store.php
@@ -44,7 +44,7 @@ class WC_Calypso_Bridge_Customize_Store {
 		// wpcom.editor.js conflicts with CYS scripts due to double registration of the private-apis
 		// dequeue it on CYS pages.
 		add_action( 'admin_print_scripts', function() {
-			if ( str_contains( wp_unslash( $_GET['path'] ), '/customize-store/' ) ) {
+			if ( isset( $_GET['path'] ) && str_contains( wp_unslash( $_GET['path'] ), '/customize-store/' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				wp_dequeue_script( 'wpcom-block-editor-wpcom-editor-script' );
 			}
 		}, 9999);

--- a/includes/class-wc-calypso-bridge-customize-store.php
+++ b/includes/class-wc-calypso-bridge-customize-store.php
@@ -44,7 +44,7 @@ class WC_Calypso_Bridge_Customize_Store {
 		// wpcom.editor.js conflicts with CYS scripts due to double registration of the private-apis
 		// dequeue it on CYS pages.
 		add_action( 'admin_print_scripts', function() {
-			if ( str_contains( $_GET['path'], '/customize-store/' ) ) {
+			if ( str_contains( wp_unslash( $_GET['path'] ), '/customize-store/' ) ) {
 				wp_dequeue_script( 'wpcom-block-editor-wpcom-editor-script' );
 			}
 		}, 9999);

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleased =
+* Fix CYS conflict with wpcom.editor #1336
+
 = 2.2.18 =
 * Fix the "Orders" menu position when using HPOS #1330
 * Preconfigure product measurement units #1309


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Related to https://github.com/woocommerce/woocommerce/pull/41052

[dequeue wpcom.editor on cys pages](https://github.com/Automattic/wc-calypso-bridge/commit/0c3ef5a640f53e11d5925295663806979a5f34ee) Removes wpcom.editor.js on CYS pages. This script registers edit-post private APIs first, which can cause an error. Since we don’t use anything from wpcom.editor.js on CYS pages, removing it makes sense, in my opinion.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

wpcom.editor.js test

1. Start CYS and confirm everything works as expected.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.