### PR TITLE
Remove wpcom elements when viewing cys iframe from intro screen

### DIFF
--- a/includes/class-wc-calypso-bridge-customize-store.php
+++ b/includes/class-wc-calypso-bridge-customize-store.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 2.2.14
+ * @version x.x.x
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -48,6 +48,8 @@ class WC_Calypso_Bridge_Customize_Store {
 				wp_dequeue_script( 'wpcom-block-editor-wpcom-editor-script' );
 			}
 		}, 9999);
+
+		add_action( 'wp_head', array( $this, 'possibly_hide_wp_admin_bar' ) );
 	}
 
 	/**
@@ -63,6 +65,40 @@ class WC_Calypso_Bridge_Customize_Store {
 			update_option( 'woocommerce_admin_customize_store_completed', 'yes' );
 		}
 	}
+
+	/**
+	 * Runs script and add styles to remove WPCOM elements such as admin bar, proxy banner, gift banner, store notice
+	 * and hide scrollbar when users are viewing with ?cys-hide-admin-bar=true.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return void
+	 */
+	public function possibly_hide_wp_admin_bar() {
+		if ( isset( $_GET['cys-hide-admin-bar'] ) ) {
+			echo '
+			<style type="text/css">
+				#wpadminbar,
+				#wpcom-gifting-banner,
+				#atomic-proxy-bar { display: none; }
+
+				.woocommerce-store-notice { display: none !important; }
+
+				html { margin-top: 0 !important; }
+
+				body { overflow: hidden; }
+			</style>';
+			echo '
+			<script type="text/javascript">
+			( function() {
+				document.addEventListener( "DOMContentLoaded", function() {
+					document.documentElement.style.setProperty( "margin-top", "0px", "important" );
+				} );
+			} )();
+			</script>';
+		}
+	}
+
 }
 
 WC_Calypso_Bridge_Customize_Store::get_instance();

--- a/includes/class-wc-calypso-bridge-customize-store.php
+++ b/includes/class-wc-calypso-bridge-customize-store.php
@@ -49,7 +49,7 @@ class WC_Calypso_Bridge_Customize_Store {
 			}
 		}, 9999);
 
-		add_action( 'wp_head', array( $this, 'possibly_hide_wp_admin_bar' ) );
+		add_action( 'wp_head', array( $this, 'possibly_remove_wpcom_ui_elements' ) );
 	}
 
 	/**
@@ -74,7 +74,7 @@ class WC_Calypso_Bridge_Customize_Store {
 	 *
 	 * @return void
 	 */
-	public function possibly_hide_wp_admin_bar() {
+	public function possibly_remove_wpcom_ui_elements() {
 		if ( isset( $_GET['cys-hide-admin-bar'] ) ) {
 			echo '
 			<style type="text/css">

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleased =
+* Remove wpcom elements when viewing cys iframe from intro screen #1344
+
 = 2.2.20 =
 * Introduced an Inbox allow-list for Free Trial plan users #1268
 * Updated the existing messages/notes block-list based on the findings of our recent Inbox audit #1268


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Related to https://github.com/woocommerce/woocommerce/issues/41149

Additional context: CYS intro screen displaying iframe with unwanted WPCOM UI, p1698803585602019/1698803237.183139-slack-C01SFMVEYAK

> Front-end render iframe needs scrollbar and Dotcom overlay bars removed

### How to test the changes in this Pull Request:

1. Set up a latest WordPress according to this guide: p6q8Tx-3Je-p2
1. Make sure to enable `customize-store` feature flag
1. Go to `WooCommerce -> Home` and click `Customize Store` task
2. Observe that no site preview is displayed
3. Go through the AI steps until it completes creating the site
4. Click on `Save` to ensure CYS task is marked as complete
1. Go back to `WooCommerce -> Home` and click `Customize Store` task
1. Observe that the iframe preview is displayed
1. Observe that the following are not displayed in the iframe preview:
    - Admin bar
    - WPCOM proxied bar
    - WPCOM gifting banner
    - Store notice
    - Scrollbar

<img width="1331" alt="image" src="https://github.com/Automattic/wc-calypso-bridge/assets/3747241/8265503c-4325-4fc0-be30-0794167a0026">


<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.