### PR TITLE
Hide launch banner when viewing iframe from the intro screen

### DIFF
--- a/includes/class-wc-calypso-bridge-customize-store.php
+++ b/includes/class-wc-calypso-bridge-customize-store.php
@@ -80,12 +80,10 @@ class WC_Calypso_Bridge_Customize_Store {
 			<style type="text/css">
 				#wpadminbar,
 				#wpcom-gifting-banner,
-				#atomic-proxy-bar { display: none; }
-
+				#wpcom-launch-banner-wrapper,
+				#atomic-proxy-bar { display: none !important; }
 				.woocommerce-store-notice { display: none !important; }
-
 				html { margin-top: 0 !important; }
-
 				body { overflow: hidden; }
 			</style>';
 			echo '

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,7 @@ This section describes how to install the plugin and get it working.
 
 = Unreleased =
 * Remove wpcom elements when viewing cys iframe from intro screen #1344
+* Hide launch banner when viewing iframe from the intro screen #1348
 
 = 2.2.20 =
 * Introduced an Inbox allow-list for Free Trial plan users #1268


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes launch banner from the CYS intro screen iframe:

<img width="500" alt="image" src="https://github.com/Automattic/wc-calypso-bridge/assets/3747241/c72787c9-a9ac-4abf-9754-e79dee03f2ef">


### How to test the changes in this Pull Request:

1. Set up a latest WordPress according to this guide: p6q8Tx-3Je-p2
1. Make sure to enable `customize-store` feature flag
2. Make sure your site is in "coming soon" mode in `Settings > General > Privacy`
3. Go to `https://yoursite/?cys-hide-admin-bar`
4. Observe that the launch banner is no longer shown

<img width="500" alt="image" src="https://github.com/Automattic/wc-calypso-bridge/assets/3747241/ffc53701-599d-40dd-8899-a52db94e304d">


### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
