### PR TITLE
Hide "Choose your theme" task when `customize-store` feature flag is enabled

### DIFF
--- a/includes/class-wc-calypso-bridge-setup-tasks.php
+++ b/includes/class-wc-calypso-bridge-setup-tasks.php
@@ -10,6 +10,7 @@
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\WooCommerce\Admin\Features\Features;
 
 /**
  * WC Calypso Bridge Setup Tasks Controller
@@ -142,10 +143,12 @@ class WC_Calypso_Bridge_Setup_Tasks {
 				}
 			}
 
-			// Insert appearance task after products task.
-			require_once __DIR__ . '/tasks/class-wc-calypso-task-appearance.php';
-			$appearance_task = array( new \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\WCBridgeAppearance( $lists['setup'] ) );
-			array_splice( $lists['setup']->tasks, $product_task_index, 0, $appearance_task );
+			if ( !Features::is_enabled( 'customize-store' ) ) {
+				// Insert appearance task after products task if customize-store feature is not enabled.
+				require_once __DIR__ . '/tasks/class-wc-calypso-task-appearance.php';
+				$appearance_task = array( new \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\WCBridgeAppearance( $lists['setup'] ) );
+				array_splice( $lists['setup']->tasks, $product_task_index, 0, $appearance_task );
+			}
 		}
 		return $lists;
 	}

--- a/includes/class-wc-calypso-bridge-setup-tasks.php
+++ b/includes/class-wc-calypso-bridge-setup-tasks.php
@@ -143,7 +143,7 @@ class WC_Calypso_Bridge_Setup_Tasks {
 				}
 			}
 
-			if ( !Features::is_enabled( 'customize-store' ) ) {
+			if ( ! Features::is_enabled( 'customize-store' ) ) {
 				// Insert appearance task after products task if customize-store feature is not enabled.
 				require_once __DIR__ . '/tasks/class-wc-calypso-task-appearance.php';
 				$appearance_task = array( new \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\WCBridgeAppearance( $lists['setup'] ) );

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleased =
+* Hide "Choose your theme" task when customize-store feature flag is enabled #1356
+
 = 2.2.23 =
 * Add parameter to go back for theme links in cys intro screen #1351
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Partially fix #1305 

Hide "Choose your theme" task when `customize-store` feature flag is enabled

![Screenshot 2023-11-09 at 14 50 07](https://github.com/Automattic/wc-calypso-bridge/assets/4344253/f69d020b-c62c-4f5d-9d0f-9aec618d2fd1)


<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?


1. Set up a latest WordPress according to this guide: p6q8Tx-3Je-p2
1. Make sure to enable `customize-store` feature flag
2. Go to `Home`
3. Observe that `Customize your store` task is shown while "Choose your theme" task is not.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
