### PR TITLE
Enable cys feature flag

### DIFF
--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -152,6 +152,11 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 			$features['analytics'] = true;
 		}
 
+		// Enable customize store feature.
+		if ( isset( $features['customize-store'] ) ) {
+			$features['customize-store'] = true;
+		}
+
 		return $features;
 	}
 

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -152,8 +152,10 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 			$features['analytics'] = true;
 		}
 
-		// Enable customize store feature.
-		if ( isset( $features['customize-store'] ) ) {
+		$timestamp = get_option( 'woocommerce_admin_install_timestamp', false );
+
+		// Enable customize store feature if the install timestamp is set and is after Jan 2, 8pm PT.
+		if ( isset( $features['customize-store'] ) && $timestamp && $timestamp >= 1704254400 ) {
 			$features['customize-store'] = true;
 		}
 

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -154,7 +154,7 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 
 		$timestamp = get_option( 'woocommerce_admin_install_timestamp', false );
 
-		// Enable customize store feature if the install timestamp is set and is after Jan 2, 8pm PT.
+		// Enable customize store feature if the install timestamp is set and is after 2024-01-02 8:00pm PT.
 		if ( isset( $features['customize-store'] ) && $timestamp && $timestamp >= 1704254400 ) {
 			$features['customize-store'] = true;
 		}

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 2.2.12
+ * @version x.x.x
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/readme.txt
+++ b/readme.txt
@@ -26,7 +26,7 @@ This section describes how to install the plugin and get it working.
 * Add tracks for homepage views for CYS #1390
 * Revert #1377 and fix init priority, to avoid the empty tab being added to the product data tabs #1395
 * Hide Jetpack JITM in CYS screen #1393
-* Enable customize-store feature flag. #1357
+* Enable customize-store feature flag #1357
 * Hide free trial plan picker banner when viewing iframe #1404
 
 = 2.2.26 =

--- a/readme.txt
+++ b/readme.txt
@@ -26,6 +26,7 @@ This section describes how to install the plugin and get it working.
 * Add tracks for homepage views for CYS #1390
 * Revert #1377 and fix init priority, to avoid the empty tab being added to the product data tabs #1395
 * Hide Jetpack JITM in CYS screen #1393
+* Enable customize-store feature flag. #1357
 
 = 2.2.26 =
 * Fix missing free trial banner in orders page #1371


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1305.

 Enable customize-store feature flag.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Set up a Woo Express testing site: p6q8Tx-3Je-p2 (Do not turn on CYS feature flag via beta tester)
2. Go to Homescreen
2. Observe `Choose your theme` task in tasklist
3. Run `option set woocommerce_admin_install_timestamp 1704254400 `
4. Go to Homescreen
5. Observe that `Customize your store` task is shown

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
