### PR TITLE
Fix missing free trial banner in orders page

### DIFF
--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-notice.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-notice.php
@@ -36,7 +36,7 @@ class WC_Calypso_Bridge_Free_Trial_Orders_Notice  {
 
 		add_action('admin_notices', function() {
 			$screen = get_current_screen();
-			if ( in_array( $screen->id, array( 'woocommerce_page_wc-orders' ), true ) ) {
+			if ( in_array( $screen->id, array( 'edit-shop_order', 'woocommerce_page_wc-orders' ), true ) ) {
 				?>
 				<div class="free-trial-orders-notice notice">
                     <div>

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-notice.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-notice.php
@@ -36,7 +36,7 @@ class WC_Calypso_Bridge_Free_Trial_Orders_Notice  {
 
 		add_action('admin_notices', function() {
 			$screen = get_current_screen();
-			if ( 'edit-shop_order' === $screen->id ) {
+			if ( in_array( $screen->id, array( 'woocommerce_page_wc-orders' ), true ) ) {
 				?>
 				<div class="free-trial-orders-notice notice">
                     <div>

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-notice.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-notice.php
@@ -4,7 +4,7 @@
  * Class WC_Calypso_Bridge_Free_Trial_Orders_Notice.
  *
  * @since   2.0.5
- * @version 2.0.16
+ * @version x.x.x
  *
  * Renders an admin notice on Orders page.
  */

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleased =
+* Fix missing free trial banner in orders page #1371
+
 = 2.2.25 =
 * Mitigate object cache issue while creating Woo related pages #1368
 * Remove code defaulting to cart/checkout blocks #1368


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes an issue identified in a meetup. Currently, free trial banner is not shown in orders page.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Test this in a free trial site
2. Go to Orders page
3. Observe the free trial banner is shown
4. Go to Orders > Add new page
3. Observe the free trial banner is shown
4. Navigate to Settings > WooCommerce > Advanced > Features and toggle HPOS (If it's enabled, disable. Otherwise, enable)
5. Re-test steps 2 - 6 with the updated settings)

<!-- End testing instructions -->

### Other information:

Orders list page:

<img width="1395" alt="image" src="https://github.com/Automattic/wc-calypso-bridge/assets/3747241/dd087454-1c76-41ff-8944-1eaabd38dd05">

New orders page:

<img width="1389" alt="image" src="https://github.com/Automattic/wc-calypso-bridge/assets/3747241/b892a036-4352-42a2-b242-ff0bd02304d4">


### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
