### PR TITLE
Removed the empty Product Data > Get more options tab

### DIFF
--- a/includes/class-wc-calypso-bridge-filters.php
+++ b/includes/class-wc-calypso-bridge-filters.php
@@ -240,6 +240,8 @@ class WC_Calypso_Bridge_Filters {
 	 * Function to hook into the `woocommerce_product_data_tabs` filter
 	 * and remove the empty Product Data > Get more options tab.
 	 *
+	 * @since x.x.x
+	 *
 	 * @param array $tabs
 	 * @return array
 	 */

--- a/includes/class-wc-calypso-bridge-filters.php
+++ b/includes/class-wc-calypso-bridge-filters.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.1.6
- * @version 2.2.18
+ * @version x.x.x
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -65,6 +65,11 @@ class WC_Calypso_Bridge_Filters {
 		 * Filter recommended themes
 		 */
 		add_filter( '__experimental_woocommerce_rest_get_recommended_themes', array( $this, 'woocommerce_filter_get_recommended_themes'), 10, 3);
+
+		/**
+		 * Remove the empty Product Data > Get more options tab.
+		 */
+		add_filter( 'woocommerce_product_data_tabs', array( $this, 'remove_marketplace_suggestions_product_tab' ) );
 	}
 
 	/**
@@ -229,6 +234,21 @@ class WC_Calypso_Bridge_Filters {
 		$result['_links']['browse_all']['href'] = 'https://wordpress.com/themes/' . $site_slug;
 
 		return $result;
+	}
+
+	/**
+	 * Function to hook into the `woocommerce_product_data_tabs` filter
+	 * and remove the empty Product Data > Get more options tab.
+	 *
+	 * @param array $tabs
+	 * @return array
+	 */
+	public function remove_marketplace_suggestions_product_tab( $tabs ) {
+		if ( isset( $tabs['marketplace-suggestions'] ) ) {
+			unset( $tabs['marketplace-suggestions'] );
+		}
+
+		return $tabs;
 	}
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -25,6 +25,7 @@ This section describes how to install the plugin and get it working.
 = Unreleased =
 * Fix missing free trial banner in orders page #1371
 * Override task progress header and title for all Woo Express sites #1372
+* Remove the empty Product Data > Get more options tab #xxx
 
 = 2.2.25 =
 * Mitigate object cache issue while creating Woo related pages #1368


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR removes the **Product Data > Get more options** tab, as it is empty -- we do not offer any Marketplace suggestions in Woo Express/Ecommerce sites.

Before the fix: 

![KjCxxh.png](https://github.com/Automattic/wc-calypso-bridge/assets/25955483/e33f9199-fd0e-410a-b563-2b66c7049545)

After the fix: 

![Z2Dasf.png](https://github.com/Automattic/wc-calypso-bridge/assets/25955483/3e2636cd-3e2c-4d11-bf26-6a8db9a55122)

Closes #1333 

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Open a new site -- the plan doesn't change this behavior.
2. Create a new product.
3. Notice the "Get more options" tab under **Product Data**.
4. Click on it and make sure it is empty. 
5. Apply the patch. 
6. Refresh the page -- the "Get more options" tab should now be removed. 

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.