### PR TITLE
HPOS enabled, empty state button should be secondary if a primary exists

### DIFF
--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-changes.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-orders-changes.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   2.0.1
- * @version 2.0.1
+ * @version x.x.x
  */
 
 class WC_Calypso_Bridge_Free_Trial_Orders_Changes {
@@ -47,7 +47,7 @@ class WC_Calypso_Bridge_Free_Trial_Orders_Changes {
 
 		$screen = get_current_screen();
 
-		if ( $screen->id === 'edit-shop_order' ) {
+		if ( in_array( $screen->id, array( 'edit-shop_order', 'woocommerce_page_wc-orders' ), true ) ) {
 			?>
 			<script>
 				const woocommerceBlankStateButton = document.querySelector('.woocommerce-BlankState-cta.button');

--- a/readme.txt
+++ b/readme.txt
@@ -25,6 +25,7 @@ This section describes how to install the plugin and get it working.
 = Unreleased =
 * Fix missing free trial banner in orders page #1371
 * Override task progress header and title for all Woo Express sites #1372
+* With HPOS enabled, the empty state CTA button should be secondary if a primary button exists #xxx
 
 = 2.2.25 =
 * Mitigate object cache issue while creating Woo related pages #1368


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1380  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. First this PR has to be merged https://github.com/Automattic/wc-calypso-bridge/pull/1379
2. Enable HPOS
3. On a free trial site, where there are no orders, visit the Orders page
4. See that the empty state CTA button is secondary

## Before

![image](https://github.com/Automattic/wc-calypso-bridge/assets/2484390/0df04723-7e36-45e7-8df8-c695f362dff8)


## After
![image](https://github.com/Automattic/wc-calypso-bridge/assets/2484390/ff580441-31b0-480a-8e9b-36ae49c26941)


<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
