### PR TITLE
Add `woocommerce_admin_customize_store_completed_theme_id` option to Jetpack sync

### DIFF
--- a/includes/class-wc-calypso-bridge-filters.php
+++ b/includes/class-wc-calypso-bridge-filters.php
@@ -78,7 +78,7 @@ class WC_Calypso_Bridge_Filters {
 	 * @return void
 	 */
 	public function on_plugins_loaded() {
-		add_filter( 'jetpack_sync_options_whitelist', array( $this, 'add_woocommerce_task_list_options_to_jetpack_sync' ) );
+		add_filter( 'jetpack_sync_options_whitelist', array( $this, 'add_woocommerce_options_to_jetpack_sync' ) );
 	}
 
 	/**
@@ -115,21 +115,22 @@ class WC_Calypso_Bridge_Filters {
 	 * @param array $allowed_options
 	 * @return array
 	 */
-	public function add_woocommerce_task_list_options_to_jetpack_sync( $allowed_options ) {
+	public function add_woocommerce_options_to_jetpack_sync( $allowed_options ) {
 		if ( ! is_array( $allowed_options ) ) {
 			return $allowed_options;
 		}
 
-		$woocommerce_task_list_options = array(
+		$woocommerce_options = array(
 			'woocommerce_task_list_complete',
 			'woocommerce_task_list_completed_lists',
 			'woocommerce_task_list_dismissed_tasks',
 			'woocommerce_task_list_hidden_lists',
 			'woocommerce_task_list_keep_completed',
 			'woocommerce_task_list_tracked_completed_tasks',
+			'woocommerce_admin_customize_store_completed_theme_id',
 		);
 
-		return array_merge( $allowed_options, $woocommerce_task_list_options );
+		return array_merge( $allowed_options, $woocommerce_options );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -28,6 +28,7 @@ This section describes how to install the plugin and get it working.
 * Remove the empty Product Data > Get more options tab #xxx
 * With HPOS enabled, the empty state CTA button should be secondary if a primary button exists #xxx
 * Fix free trial banner upgrade now button class #xxx
+* Add woocommerce_admin_customize_store_completed_theme_id option to Jepack sync #1384
 
 = 2.2.25 =
 * Mitigate object cache issue while creating Woo related pages #1368

--- a/readme.txt
+++ b/readme.txt
@@ -28,7 +28,7 @@ This section describes how to install the plugin and get it working.
 * Remove the empty Product Data > Get more options tab #xxx
 * With HPOS enabled, the empty state CTA button should be secondary if a primary button exists #xxx
 * Fix free trial banner upgrade now button class #xxx
-* Add woocommerce_admin_customize_store_completed_theme_id option to Jepack sync #1384
+* Add woocommerce_admin_customize_store_completed_theme_id option to Jetpack sync #1384
 
 = 2.2.25 =
 * Mitigate object cache issue while creating Woo related pages #1368


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Related to https://github.com/Automattic/wp-calypso/pull/84894, D131047-code

This PR ensures that the `woocommerce_admin_customize_store_completed_theme_id` option is synchronized to WordPress.com from eCommerce sites

Note: this PR depends on D131047-code, which adds the option to the Jetpack sync allow-list.


<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Follow the instructions on  D131047-code but do not add the filter to your dev site.
2. Apply this patch to wc-calypso-bridge on your site. You can do this by modifying the file directly using a text editor, or by using SFTP.
3. Now, find the WPCOM blog ID for your test Atomic site
4. Run the following commands to delete and then re-add the option:
    - `wp option delete woocommerce_admin_customize_store_completed_theme_id`
    - `wp option add woocommerce_admin_customize_store_completed_theme_id 'twentytwentyfour//home'`
  
5. Open up `wpsh` on your WPCOM sandbox, and run the following code after at least some time has elapsed (you can use the Incremental sync subsection of the Pc9OEs-v-p2 to confirm whether your site has been synched):
```
> $dev_blog_id = 123456; // replace with your WoA site's blog_id
> switch_to_blog( $dev_blog_id );
> $replica_store = Jetpack_Sync_WPCOM_Shadow_Replicastore::getInstance();
> $woo_options = [ 'woocommerce_admin_customize_store_completed_theme_id' ];
> foreach ( $woo_options as $woo_option ) { echo "\n$woo_option: " . var_export( $replica_store->get_option( $woo_option ), true ); }
```

6. Verify that you get the following data written out:
```
woocommerce_admin_customize_store_completed_theme_id: 'twentytwentyfour//home'
```


<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.