### PR TITLE
Add tracks for homepage views for CYS

### DIFF
--- a/includes/class-wc-calypso-bridge-customize-store.php
+++ b/includes/class-wc-calypso-bridge-customize-store.php
@@ -3,8 +3,8 @@
  * Adds Customize Store task related functionalities
  *
  * @package WC_Calypso_Bridge/Classes
- * @since   1.0.0
- * @version 2.2.24
+ * @since  1.0.0
+ * @version x.x.x
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -50,6 +50,8 @@ class WC_Calypso_Bridge_Customize_Store {
 		}, 9999);
 
 		add_action( 'wp_head', array( $this, 'possibly_remove_wpcom_ui_elements' ) );
+
+		add_action( 'wp_head', array( $this, 'possibly_add_track_homepage_view' ) );
 	}
 
 	/**
@@ -97,6 +99,18 @@ class WC_Calypso_Bridge_Customize_Store {
 		}
 	}
 
+	public function possibly_add_track_homepage_view() {
+		if ( self::is_admin() ) {
+			if ( is_front_page() || is_home() ) {
+				// This is tracked via backend.
+				WC_Tracks::record_event( 'store_homepage_view' );
+			}
+		}
+	}
+
+	public static function is_admin() {
+		return wc_current_user_has_role( 'administrator' );
+	}
 }
 
 WC_Calypso_Bridge_Customize_Store::get_instance();

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleased =
+* Add tracks for homepage views for CYS #1390
+
 = 2.2.26 =
 * Fix missing free trial banner in orders page #1371
 * Override task progress header and title for all Woo Express sites #1372


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds track necessary to track homepage views by admin when measuring CYS experiment impact:

pbxNRc-3sj-p2

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Open up live tracks view in mc, filter your username (alternatively, use WC testing tool to view backend track)
2. Make sure you're logged in as an admin of the site
3. View the store front facing homepage
4. Wait for around 15 minutes for the tracks to show up in the live tracks view
5. Observe the track `store_homepage_view` is tracked

**Optional: Test regular visitor**

1. Launch your site
2. In an incognito site, view the store front facing homepage
3. Ensure you're not tracked

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.