### PR TITLE
Add ExPlat logic around customize-store feature

### DIFF
--- a/class-wc-calypso-bridge-shared.php
+++ b/class-wc-calypso-bridge-shared.php
@@ -113,6 +113,7 @@ class WC_Calypso_Bridge_Shared {
 			'isEcommercePlanTrial'         => (bool) wc_calypso_bridge_is_ecommerce_trial_plan(), // This is true for ecommerce trial only.
 			'isWooExpress'                 => (bool) wc_calypso_bridge_is_woo_express_plan(),
 			'isWooNavigationEnabled'       => (bool) apply_filters( 'ecommerce_new_woo_atomic_navigation_enabled', 'yes' === get_option( 'wooexpress_navigation_enabled', 'yes' ) ) && class_exists('\Jetpack') && \Jetpack::is_module_active( 'sso' ),
+			'isCustomizeStoreEnabled'      => (bool) \Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'customize-store' ),
 			'isWooPage'                    => $is_woo_page,
 			'homeUrl'                      => esc_url( get_home_url() ),
 			'siteSlug'                     => $site_suffix,

--- a/class-wc-calypso-bridge-shared.php
+++ b/class-wc-calypso-bridge-shared.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 2.2.26
+ * @version x.x.x
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,7 @@ This section describes how to install the plugin and get it working.
 
 = Unreleased =
 * Add tracks for homepage views for CYS #1390
+* Add ExPlat logic around customize-store feature #1392
 
 = 2.2.26 =
 * Fix missing free trial banner in orders page #1371

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,11 @@
  */
 import { addFilter, addAction } from '@wordpress/hooks';
 import { WooOnboardingTask } from '@woocommerce/onboarding';
-import { registerPlugin, unregisterPlugin } from '@wordpress/plugins';
+import {
+	registerPlugin,
+	unregisterPlugin,
+	getPlugins,
+} from '@wordpress/plugins';
 import { render, lazy } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -78,13 +82,15 @@ registerPlugin( 'wc-calypso-bridge', {
 
 // Unregister task fills from WooCommerce Core
 // Otherwise we'll have both the original and new fills rendered.
-const oldTaskNames = [ 'wc-admin-onboarding-task-appearance' ];
+const pluginsToRemove = [ 'wc-admin-onboarding-task-appearance' ];
 
 // Appearance task fill.
-registerPlugin( 'wc-calypso-bridge-task-appearance', {
-	scope: 'woocommerce-tasks',
-	render: AppearanceFill,
-} );
+if ( ! window.wcCalypsoBridge.isCustomizeStoreEnabled ) {
+	registerPlugin( 'wc-calypso-bridge-task-appearance', {
+		scope: 'woocommerce-tasks',
+		render: AppearanceFill,
+	} );
+}
 
 if ( !! window.wcCalypsoBridge.isWooExpress ) {
 	registerPlugin( 'wc-calypso-bridge-homescreen-progress-header', {
@@ -106,7 +112,7 @@ if ( !! window.wcCalypsoBridge.isEcommercePlanTrial ) {
 		scope: 'woocommerce-admin',
 	} );
 
-	oldTaskNames.push(
+	pluginsToRemove.push(
 		'wc-admin-onboarding-task-payments',
 		'woocommerce-admin-task-wcpay', // WCPay task item which handles direct click on the task. (Not needed in free trial)
 		'woocommerce-admin-task-wcpay-page', // WCPay task page which handles URL navigation to the task.
@@ -229,11 +235,19 @@ if ( !! window.wcCalypsoBridge.isEcommercePlan ) {
 	}
 }
 
+// Remove plugins that had already been added.
+const taskPlugins = getPlugins( 'woocommerce-tasks' );
+taskPlugins.forEach( ( plugin ) => {
+	if ( pluginsToRemove.includes( plugin.name ) ) {
+		unregisterPlugin( plugin.name );
+	}
+} );
+
 addAction(
 	'plugins.pluginRegistered',
 	'wc-calypso-bridge',
 	function ( _settings, name ) {
-		if ( oldTaskNames.includes( name ) ) {
+		if ( pluginsToRemove.includes( name ) ) {
 			unregisterPlugin( name );
 		}
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR:
- Adds ExPlat logic and code to enable `customize-store` feature
- Improves task removal code via JS since appearance plugin was added before our removal filter is added
- Adds `isCustomizeStoreEnabled` global variable to access CYS flag via JS

### How to test the changes in this Pull Request:

#### Verify control experience
1. If testing in old site, make sure `customize-store` feature flag is disabled
1. Go to Homescreen
2. Observe `Choose your theme` task in tasklist
3. Ensure there's no duplicate `Choose your theme` task
4. Click on the task
5. Ensure you're redirected to WPCOM `Themes` page.

#### Verify treatment
1. Open up CLI for your site, i.e: `https://yoursite.wpcomstaging.com/_cli`
2. Run `option set woocommerce_admin_install_timestamp 1703116800`
3. Run `transient set abtest_variation_woocommerce_wooexpress_cys_launch_v1 treatment`
4. Go to Homescreen
2. Observe `Customize your store` task in tasklist


<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
