### PR TITLE
Hide Jetpack JITM in CYS screen

### DIFF
--- a/assets/css/customize-store.css
+++ b/assets/css/customize-store.css
@@ -1,0 +1,3 @@
+body.woocommerce-customize-store #jp-admin-notices {
+  display: none;
+}

--- a/includes/class-wc-calypso-bridge-customize-store.php
+++ b/includes/class-wc-calypso-bridge-customize-store.php
@@ -38,6 +38,7 @@ class WC_Calypso_Bridge_Customize_Store {
 		add_action( 'plugins_loaded', function() {
 			if ( class_exists( '\Automattic\WooCommerce\Admin\Features\Features' ) && \Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'customize-store' ) ) {
 				add_action( 'load-site-editor.php', array( $this, 'mark_customize_store_task_as_completed_on_site_editor' ) );
+				add_action( 'admin_enqueue_scripts', array( $this, 'add_customize_store_styles' ) );
 			}
 		});
 
@@ -106,6 +107,13 @@ class WC_Calypso_Bridge_Customize_Store {
 				WC_Tracks::record_event( 'store_homepage_view' );
 			}
 		}
+	}
+
+	/**
+	 * Enqueue Customize Store specific css file.
+	 */
+	public function add_customize_store_styles() {
+		wp_enqueue_style( 'wp-calypso-bridge-customize-store', WC_Calypso_Bridge_Instance()->get_asset_path() . '/assets/css/customize-store.css', array(), WC_CALYPSO_BRIDGE_CURRENT_VERSION );
 	}
 
 	public static function is_admin() {

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,7 @@ This section describes how to install the plugin and get it working.
 
 = Unreleased =
 * Add tracks for homepage views for CYS #1390
+* Hide Jetpack JITM in CYS screen #1393
 
 = 2.2.26 =
 * Fix missing free trial banner in orders page #1371


### PR DESCRIPTION
### Changes proposed in this Pull Request:


- Adds `customize-store.css` that is enqueued when CYS feature is enabled.
- Hide Jetpack JITM element in CYS screen that is shown in free trial sites (D125388-code)

<img width="1777" alt="image" src="https://github.com/Automattic/wc-calypso-bridge/assets/3747241/ca5555c7-ce96-410f-bdd1-19735fdc6df2">

### How to test the changes in this Pull Request:

1. Enable `customize-store` feature (Free trial sites can run the wp command: `wp plugin install https://gist.github.com/ilyasfoo/6c5900753edcf06faef9a4b04dca23a8/archive/0c3e3f4d3de60b84fe7e8b950ffcf753f7ec1ddf.zip --activate`)
2. Go to Homescreen
3. Open developer console and paste [this one liner](https://gist.githubusercontent.com/ilyasfoo/a2901efacd62f69be737778ba7721e69/raw/5e18c6fc82f52ecf4c552cec5bc3b092540338dd/jQueryJITM) to artificially add the JITM message
4. Observe the JITM is shown when in homescreen, above tasklist
5. Click on `Customize your store` task
6. Observe the JITM message is hidden when CYS screen has loaded

<img width="1247" alt="image" src="https://github.com/Automattic/wc-calypso-bridge/assets/3747241/953ec661-73b1-45b2-b167-e45063fdf0d8">

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.