### PR TITLE
Revert #1377 and fix init priority to properly hide the empty get more options tab

### DIFF
--- a/includes/class-wc-calypso-bridge-filters.php
+++ b/includes/class-wc-calypso-bridge-filters.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.1.6
- * @version 2.2.26
+ * @version x.x.x
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -65,11 +65,6 @@ class WC_Calypso_Bridge_Filters {
 		 * Filter recommended themes
 		 */
 		add_filter( '__experimental_woocommerce_rest_get_recommended_themes', array( $this, 'woocommerce_filter_get_recommended_themes'), 10, 3);
-
-		/**
-		 * Remove the empty Product Data > Get more options tab.
-		 */
-		add_filter( 'woocommerce_product_data_tabs', array( $this, 'remove_marketplace_suggestions_product_tab' ) );
 	}
 
 	/**
@@ -237,22 +232,6 @@ class WC_Calypso_Bridge_Filters {
 		return $result;
 	}
 
-	/**
-	 * Function to hook into the `woocommerce_product_data_tabs` filter
-	 * and remove the empty Product Data > Get more options tab.
-	 *
-	 * @since 2.2.26
-	 *
-	 * @param array $tabs
-	 * @return array
-	 */
-	public function remove_marketplace_suggestions_product_tab( $tabs ) {
-		if ( isset( $tabs['marketplace-suggestions'] ) ) {
-			unset( $tabs['marketplace-suggestions'] );
-		}
-
-		return $tabs;
-	}
 }
 
 WC_Calypso_Bridge_Filters::get_instance();

--- a/includes/class-wc-calypso-bridge-hide-alerts.php
+++ b/includes/class-wc-calypso-bridge-hide-alerts.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 2.2.20
+ * @version x.x.x
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -45,8 +45,8 @@ class WC_Calypso_Bridge_Hide_Alerts {
 		// Includes.
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/notes/data/class-wc-calypso-bridge-admin-note-data-store.php';
 
-		// Hooks.
-		add_action( 'init', array( $this, 'init' ) );
+		// Hooks. Init is called on priority 1 to ensure it runs before other init hooks.
+		add_action( 'init', array( $this, 'init' ), 1 );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,7 @@ This section describes how to install the plugin and get it working.
 
 = Unreleased =
 * Add tracks for homepage views for CYS #1390
+* Revert #1377 and fix init priority, to avoid the empty tab being added to the product data tabs #xxx
 
 = 2.2.26 =
 * Fix missing free trial banner in orders page #1371


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Discussed with @jimjasson about this, and he correctly pointed out that there is race condition.

WooCommerce is hooking class `WC_Marketplace_Suggestions` on `init` on priority 10, and we also hook with priority 10.

We need to lower the priority on our class

Closes #1394  .
- #1394 

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->


See testing instructions 👇 
- https://github.com/Automattic/wc-calypso-bridge/pull/1377


### Future discussion

Should we treat the same `init` with lower priorities? If so, let's open a new PR to address them

![image](https://github.com/Automattic/wc-calypso-bridge/assets/2484390/aad4ecf9-1186-4062-b4a7-fb2c268ba22f)
