### PR TITLE
[CYS] Hide free trial plan picker banner when viewing iframe

### DIFF
--- a/includes/class-wc-calypso-bridge-customize-store.php
+++ b/includes/class-wc-calypso-bridge-customize-store.php
@@ -84,7 +84,8 @@ class WC_Calypso_Bridge_Customize_Store {
 				#wpadminbar,
 				#wpcom-gifting-banner,
 				#wpcom-launch-banner-wrapper,
-				#atomic-proxy-bar { display: none !important; }
+				#atomic-proxy-bar,
+				#free-trial-plan-picker-banner { display: none !important; }
 				.woocommerce-store-notice { display: none !important; }
 				html { margin-top: 0 !important; }
 				body { overflow: hidden; }

--- a/readme.txt
+++ b/readme.txt
@@ -26,6 +26,7 @@ This section describes how to install the plugin and get it working.
 * Add tracks for homepage views for CYS #1390
 * Revert #1377 and fix init priority, to avoid the empty tab being added to the product data tabs #1395
 * Hide Jetpack JITM in CYS screen #1393
+* Hide free trial plan picker banner when viewing iframe #1404
 
 = 2.2.26 =
 * Fix missing free trial banner in orders page #1371


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->




<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

Before

![Screenshot 2023-12-22 at 15 13 41](https://github.com/Automattic/wc-calypso-bridge/assets/4344253/60174e85-408c-40bf-90c9-52f00860db8a)


After
![Screenshot 2023-12-22 at 15 13 17](https://github.com/Automattic/wc-calypso-bridge/assets/4344253/d11456b7-864a-46f1-8031-697d008af244)




### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Set up a latest WordPress according to this guide: p6q8Tx-3Je-p2
2. Make sure to enable customize-store feature flag
3. Make sure your site is in "coming soon" mode in Settings > General > Privacy
4. Go to https://yoursite/?cys-hide-admin-bar
5. Observe that the free trial plan picker banner is no longer shown

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.