### PR TITLE
Force remove "Need help?" spotlight in tasklist

### DIFF
--- a/includes/class-wc-calypso-bridge-setup-tasks.php
+++ b/includes/class-wc-calypso-bridge-setup-tasks.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   2.0.0
- * @version 2.2.24
+ * @version x.x.x
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -44,6 +44,7 @@ class WC_Calypso_Bridge_Setup_Tasks {
 		add_action( 'wp_ajax_launch_store', array( $this, 'handle_ajax_launch_endpoint' ) );
 		add_action( 'init', array( $this, 'add_tasks' ) );
 		add_filter( 'woocommerce_admin_experimental_onboarding_tasklists', [ $this, 'replace_tasks' ] );
+		add_filter( 'get_user_metadata', array( $this, 'override_user_meta_field' ), 10, 4 );
 	}
 
 	/**
@@ -177,6 +178,24 @@ class WC_Calypso_Bridge_Setup_Tasks {
 		if ( ! empty( $store_address ) && ! empty( $store_city ) && ! empty( $store_postcode ) ) {
 			wp_safe_redirect( admin_url( 'admin.php?page=wc-admin' ) );
 		}
+	}
+
+	/**
+	 * Modify user data fields.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param mixed  $meta_value Meta value to return.
+	 * @param int    $object_id  Object ID.
+	 * @param string $meta_key   Meta key.
+	 */
+	public function override_user_meta_field( $meta_value, $object_id, $meta_key ) {
+		// Force disable setup task help panel as a hotfix.
+		// Can remove when https://github.com/woocommerce/woocommerce/issues/43300 is fixed and released.
+		if ( 'woocommerce_admin_help_panel_highlight_shown' === $meta_key ) {
+			return array( '"yes"' );
+		}
+		return $meta_value;
 	}
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,7 @@ This section describes how to install the plugin and get it working.
 
 = Unreleased
 * Hide free trial plan picker banner when viewing iframe #1404
+* Force remove "Need help?" spotlight in tasklist #1417
 
 = 2.3.0 =
 * Add tracks for homepage views for CYS #1390


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1416.

This PR removes "Need help?" spotlight by forcing the relevant user meta value. CSS wasn't safe to use since there was no unique identifier to target.

### How to test the changes in this Pull Request:

1. In your Woo Express site, go to Homescreen
2. Click on `Add products` task
3. Go back
4. Click on `Add products` task again
5. Observe no `Need help?` overlay and popup shown

<img width="1059" alt="image" src="https://github.com/Automattic/wc-calypso-bridge/assets/3747241/972ac780-d31f-4b4e-a466-3a53101e70f0">

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
