### PR TITLE
Fix free trial banner missing border

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleased =
+* Fix free trial banner missing border #1421
+
 = 2.3.1 =
 * Render introductory offer banner on Woo Home #1397
 * Force remove "Need help?" spotlight in tasklist #1417

--- a/src/introductory-offer-banner/index.js
+++ b/src/introductory-offer-banner/index.js
@@ -46,7 +46,7 @@ export const CalypsoBridgeIntroductoryOfferBanner = () => {
 	return (
 		! isModalHidden && (
 			<Fill name="woocommerce_homescreen_experimental_header_banner_item">
-				<Card>
+				<Card className="wc-calypso-bridge-woocommerce-admin-introductory-offer-banner__container">
 					<div className="wc-calypso-bridge-woocommerce-admin-introductory-offer-banner">
 						<div className="wc-calypso-bridge-woocommerce-admin-introductory-offer-banner__text">
 							<p>

--- a/src/introductory-offer-banner/style.scss
+++ b/src/introductory-offer-banner/style.scss
@@ -49,8 +49,6 @@ button.wc-calypso-bridge-woocommerce-admin-introductory-offer-banner__dismiss-bu
 	}
 }
 
-.woocommerce-homescreen__header {
-	div:first-child {
-		box-shadow: none;
-	}
+.wc-calypso-bridge-woocommerce-admin-introductory-offer-banner__container.components-card {
+	box-shadow: none;
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes missing border in free trial banner.

Before:

<img width="702" alt="image" src="https://github.com/Automattic/wc-calypso-bridge/assets/3747241/07113796-8474-423e-84f9-e85dd801d184">

After:

<img width="703" alt="image" src="https://github.com/Automattic/wc-calypso-bridge/assets/3747241/9505466b-0564-4d78-bfe0-584682312340">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Comment out [this line](https://github.com/Automattic/wc-calypso-bridge/blob/7a7c31e808ed420a4dd18b9b927d772a181aac26/class-wc-calypso-bridge-shared.php#L133)
2. Refresh homescreen
3. Observe the free trial banner have borders

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
