### PR TITLE
Bring back choose your theme for stores ineligible for CYS

### DIFF
--- a/includes/class-wc-calypso-bridge-setup-tasks.php
+++ b/includes/class-wc-calypso-bridge-setup-tasks.php
@@ -143,6 +143,13 @@ class WC_Calypso_Bridge_Setup_Tasks {
 						break;
 				}
 			}
+
+			if ( ! Features::is_enabled( 'customize-store' ) ) {
+				// Insert appearance task after products task if customize-store feature is not enabled.
+				require_once __DIR__ . '/tasks/class-wc-calypso-task-appearance.php';
+				$appearance_task = array( new \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\WCBridgeAppearance( $lists['setup'] ) );
+				array_splice( $lists['setup']->tasks, $product_task_index, 0, $appearance_task );
+			}
 		}
 		return $lists;
 	}

--- a/includes/class-wc-calypso-bridge-setup-tasks.php
+++ b/includes/class-wc-calypso-bridge-setup-tasks.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   2.0.0
- * @version 2.3.1
+ * @version x.x.x
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/tasks/class-wc-calypso-task-appearance.php
+++ b/includes/tasks/class-wc-calypso-task-appearance.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks;
+
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
+
+/**
+ * WCBridgeAppearance Task
+ *
+ * @since   2.0.11
+ * @version 2.1.10
+ */
+class WCBridgeAppearance extends Task {
+	/**
+	 * ID.
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+		return 'appearance';
+	}
+
+	/**
+	 * Title.
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		return __( 'Choose your theme', 'woocommerce' );
+	}
+
+	/**
+	 * Content.
+	 *
+	 * @return string
+	 */
+	public function get_content() {
+		return __(
+			"Choose a theme that best fits your brand's look and feel, then make it your own. Change the colors, add your logo, and create pages.",
+			'woocommerce'
+		);
+	}
+
+	/**
+	 * Time.
+	 *
+	 * @return string
+	 */
+	public function get_time() {
+		return __( '2 minutes', 'woocommerce' );
+	}
+
+	/**
+	 * Action label.
+	 *
+	 * @return string
+	 */
+	public function get_action_label() {
+		return __( 'Choose theme', 'woocommerce' );
+	}
+}

--- a/readme.txt
+++ b/readme.txt
@@ -25,6 +25,7 @@ This section describes how to install the plugin and get it working.
 = Unreleased =
 * Replace hardcoded HTML with the wc_print_notice helper in the free trial's checkout notice #1424
 * Fire calypso_wooexpress_one_dollar_offer on Woo Home when there is $1 dollar offer
+* Bring back choose your theme for stores ineligible for CYS #1431
 
 = 2.3.2 =
 * Fix free trial banner missing border #1421

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,7 @@
  */
 import { addFilter, addAction } from '@wordpress/hooks';
 import { WooOnboardingTask } from '@woocommerce/onboarding';
-import {
-	registerPlugin,
-	unregisterPlugin,
-	getPlugins,
-} from '@wordpress/plugins';
+import { registerPlugin, unregisterPlugin } from '@wordpress/plugins';
 import { render, lazy } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -27,6 +23,7 @@ import {
 } from './homescreen-progress-header';
 import './index.scss';
 import { CalypsoBridgeHomescreenBanner } from './homescreen-banner';
+import { AppearanceFill } from './task-fills';
 import './task-headers';
 import './track-menu-item';
 import { CalypsoBridgeIntroductoryOfferBanner } from './introductory-offer-banner';
@@ -82,7 +79,13 @@ registerPlugin( 'wc-calypso-bridge', {
 
 // Unregister task fills from WooCommerce Core
 // Otherwise we'll have both the original and new fills rendered.
-const pluginsToRemove = [ 'wc-admin-onboarding-task-appearance' ];
+const oldTaskNames = [ 'wc-admin-onboarding-task-appearance' ];
+
+// Appearance task fill.
+registerPlugin( 'wc-calypso-bridge-task-appearance', {
+	scope: 'woocommerce-tasks',
+	render: AppearanceFill,
+} );
 
 if ( !! window.wcCalypsoBridge.isWooExpress ) {
 	registerPlugin( 'wc-calypso-bridge-homescreen-progress-header', {
@@ -104,7 +107,7 @@ if ( !! window.wcCalypsoBridge.isEcommercePlanTrial ) {
 		scope: 'woocommerce-admin',
 	} );
 
-	pluginsToRemove.push(
+	oldTaskNames.push(
 		'wc-admin-onboarding-task-payments',
 		'woocommerce-admin-task-wcpay', // WCPay task item which handles direct click on the task. (Not needed in free trial)
 		'woocommerce-admin-task-wcpay-page', // WCPay task page which handles URL navigation to the task.
@@ -234,19 +237,11 @@ if ( !! window.wcCalypsoBridge.isEcommercePlan ) {
 	}
 }
 
-// Remove plugins that had already been added.
-const taskPlugins = getPlugins( 'woocommerce-tasks' );
-taskPlugins.forEach( ( plugin ) => {
-	if ( pluginsToRemove.includes( plugin.name ) ) {
-		unregisterPlugin( plugin.name );
-	}
-} );
-
 addAction(
 	'plugins.pluginRegistered',
 	'wc-calypso-bridge',
 	function ( _settings, name ) {
-		if ( pluginsToRemove.includes( name ) ) {
+		if ( oldTaskNames.includes( name ) ) {
 			unregisterPlugin( name );
 		}
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,11 @@
  */
 import { addFilter, addAction } from '@wordpress/hooks';
 import { WooOnboardingTask } from '@woocommerce/onboarding';
-import { registerPlugin, unregisterPlugin } from '@wordpress/plugins';
+import {
+	registerPlugin,
+	unregisterPlugin,
+	getPlugins,
+} from '@wordpress/plugins';
 import { render, lazy } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -79,7 +83,7 @@ registerPlugin( 'wc-calypso-bridge', {
 
 // Unregister task fills from WooCommerce Core
 // Otherwise we'll have both the original and new fills rendered.
-const oldTaskNames = [ 'wc-admin-onboarding-task-appearance' ];
+const pluginsToRemove = [ 'wc-admin-onboarding-task-appearance' ];
 
 // Appearance task fill.
 registerPlugin( 'wc-calypso-bridge-task-appearance', {
@@ -107,7 +111,7 @@ if ( !! window.wcCalypsoBridge.isEcommercePlanTrial ) {
 		scope: 'woocommerce-admin',
 	} );
 
-	oldTaskNames.push(
+	pluginsToRemove.push(
 		'wc-admin-onboarding-task-payments',
 		'woocommerce-admin-task-wcpay', // WCPay task item which handles direct click on the task. (Not needed in free trial)
 		'woocommerce-admin-task-wcpay-page', // WCPay task page which handles URL navigation to the task.
@@ -237,11 +241,19 @@ if ( !! window.wcCalypsoBridge.isEcommercePlan ) {
 	}
 }
 
+// Remove plugins that had already been added.
+const taskPlugins = getPlugins( 'woocommerce-tasks' );
+taskPlugins.forEach( ( plugin ) => {
+	if ( pluginsToRemove.includes( plugin.name ) ) {
+		unregisterPlugin( plugin.name );
+	}
+} );
+
 addAction(
 	'plugins.pluginRegistered',
 	'wc-calypso-bridge',
 	function ( _settings, name ) {
-		if ( oldTaskNames.includes( name ) ) {
+		if ( pluginsToRemove.includes( name ) ) {
 			unregisterPlugin( name );
 		}
 	}

--- a/src/task-fills/appearance.js
+++ b/src/task-fills/appearance.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { WooOnboardingTaskListItem } from '@woocommerce/onboarding';
+import { useAppearanceClick } from '../utils/hooks/use-appearance-click';
+
+export const AppearanceFill = () => {
+	const { onClick } = useAppearanceClick();
+	return (
+		<WooOnboardingTaskListItem id="appearance">
+			{ ( { defaultTaskItem: DefaultTaskItem } ) => (
+				<DefaultTaskItem
+					// Override task click so it doesn't navigate to a task component.
+					onClick={ onClick }
+				/>
+			) }
+		</WooOnboardingTaskListItem>
+	);
+};

--- a/src/task-fills/index.js
+++ b/src/task-fills/index.js
@@ -1,0 +1,1 @@
+export * from './appearance.js';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In https://github.com/Automattic/wc-calypso-bridge/pull/1399, I've accidentally removed `Choose your theme` task, stores ineligible for CYS did not have a replacement.

### How to test the changes in this Pull Request:

#### If you're using an existing store:
1. Run `wp option delete woocommerce_task_list_tracked_completed_actions`
1. Run `wp option delete woocommerce_task_list_completed_lists`
1. Run `wp option delete woocommerce_task_list_tracked_completed_tasks`

#### Instructions:
1. Go to CLI, run `wp option set woocommerce_admin_install_timestamp 1704254300`
1. Refresh homescreen
2. Observe `Choose your theme` task is shown, ensure the task details are ok
3. Click on `Choose theme` task, observe you're redirected to WPCOM themes screen
1. Go to CLI, `wp option set woocommerce_admin_install_timestamp 1704254400`
1. Refresh homescreen
2. Observe `Customize your store` task is shown, ensure the task details are ok
3. Click on `Customize your store` task, observe that you're redirected to CYS

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
