### PR TITLE
Change tracks `calypso_wooexpress_one_dollar_offer` to use calypso analytics

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,7 @@ This section describes how to install the plugin and get it working.
 
 = Unreleased =
 * Deactivate TikTok for WooCommerce if both TikTok for WooCommerce and Business are active #1430
+* Change tracks calypso_wooexpress_one_dollar_offer to use calypso analytics #1434
 
 = 2.3.3 =
 * Replace hardcoded HTML with the wc_print_notice helper in the free trial's checkout notice #1424

--- a/src/introductory-offer-banner/index.js
+++ b/src/introductory-offer-banner/index.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { recordEvent } from '@woocommerce/tracks';
+import { recordTracksEvent as calypsoRecordTracksEvent } from '@automattic/calypso-analytics'
 import { useEffect } from '@wordpress/element';
 import { getScreenFromPath, parseAdminUrl } from '@woocommerce/navigation';
 
@@ -50,7 +51,7 @@ export const CalypsoBridgeIntroductoryOfferBanner = () => {
 
 	useEffect( () => {
 		if ( screenPath === 'homescreen' && taskIsNull ) {
-			recordEvent( 'calypso_wooexpress_one_dollar_offer', {
+			calypsoRecordTracksEvent( 'calypso_wooexpress_one_dollar_offer', {
 				location: 'homescreen',
 			} );
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up to https://github.com/Automattic/wc-calypso-bridge/pull/1156

The existing tracks, `calypso_wooexpress_one_dollar_offer` is recorded as `wcadmin_calypso_wooexpress_one_dollar_offer` with woocommerce's analytics library.

We need to use the same tracks name, `calypso_wooexpress_one_dollar_offer`.

Prior art: https://github.com/Automattic/wc-calypso-bridge/pull/1156/files#diff-608ca47328e3bc70c2cd987b36a85fbb8f8c26b00907ba8dd073cef7435155c2R31

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Using a free trial site, go to WooCommerce homescreen
1. In browser console, run `localStorage.setItem('debug', 'calypso:analytics');`
2. Refresh homescreen with console on
3. Observe `Record event "calypso_wooexpress_one_dollar_offer"` called with props `{location: 'homescreen'}`


<img width="974" alt="image" src="https://github.com/Automattic/wc-calypso-bridge/assets/3747241/ef12e838-18cc-4733-8204-9964f0cda92e">

