### PR TITLE
Prepare for release 2.3.5

### DIFF
--- a/class-wc-calypso-bridge-shared.php
+++ b/class-wc-calypso-bridge-shared.php
@@ -130,7 +130,7 @@ class WC_Calypso_Bridge_Shared {
 		 *
 		 * This filter is used to add additional shared params to the bridge.
 		 *
-		 * @since x.x.x
+		 * @since 2.3.5
 		 *
 		 * @param  array $params
 		 * @return array

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/wc-calypso-bridge",
-  "version": "v2.3.4",
+  "version": "v2.3.5",
   "autoload": {
     "files": [
       "wc-calypso-bridge.php"

--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -4,7 +4,7 @@
  * Class Ecommerce_Atomic_Admin_Menu.
  *
  * @since   1.9.8
- * @version x.x.x
+ * @version 2.3.5
  *
  * The admin menu controller for Ecommerce WoA sites.
  */

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version x.x.x
+ * @version 2.3.5
  */
 
 use Automattic\WooCommerce\Admin\WCAdminHelper;
@@ -735,7 +735,7 @@ class WC_Calypso_Bridge_Setup {
 	/**
 	 * Update default WooCommerce options
 	 *
-	 * @since x.x.x
+	 * @since 2.3.5
 	 */
 	public function woocommerce_set_default_options_callback() {
 

--- a/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
+++ b/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
@@ -3,8 +3,8 @@
 /**
  * WC Calypso Bridge Partner Square
  *
- *	@since   x.x.x
- *	@version x.x.x
+ *	@since   2.3.5
+ *	@version 2.3.5
  *
  * This file includes customizations for the sites that were created through /start/square on woo.com.
  * woocommerce_onboarding_profile.partner must get 'square'

--- a/includes/tasks/class-wc-calypso-task-get-paid-with-square.php
+++ b/includes/tasks/class-wc-calypso-task-get-paid-with-square.php
@@ -7,8 +7,8 @@ use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
 /**
  * WCBridgeSetupWooCommerceSquare Task
  *
- * @since   x.x.x
- * @version x.x.x
+ * @since   2.3.5
+ * @version 2.3.5
  */
 class WCBridgeGetPaidWithSquare extends Task {
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -22,10 +22,10 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
-= Unreleased =
+= 2.3.5 =
 * Add a new class to customize for Square from Partner Aware Onboarding #1426
-* Remove the Customizer from the admin menu and the admin bar, if a block theme is used #xxx
-* Delete woocommerce_demo_store option to hide the demo store notice #xxx
+* Remove the Customizer from the admin menu and the admin bar, if a block theme is used #1433
+* Delete woocommerce_demo_store option to hide the demo store notice #1433
 
 = 2.3.4 =
 * Deactivate TikTok for WooCommerce if both TikTok for WooCommerce and Business are active #1430

--- a/wc-calypso-bridge.php
+++ b/wc-calypso-bridge.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Calypso Bridge
  * Plugin URI: https://wordpress.com/
  * Description: A feature plugin to provide ux enhancements for users of Store on WordPress.com.
- * Version: 2.3.4
+ * Version: 2.3.5
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * Requires at least: 4.4
@@ -47,7 +47,7 @@ if ( ! defined( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH' ) ) {
 	define( 'WC_CALYPSO_BRIDGE_PLUGIN_PATH', dirname( __FILE__ ) );
 }
 if ( ! defined( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION' ) ) {
-	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.3.4' );
+	define( 'WC_CALYPSO_BRIDGE_CURRENT_VERSION', '2.3.5' );
 }
 if ( ! defined( 'WC_MIN_VERSION' ) ) {
 	define( 'WC_MIN_VERSION', '7.3' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Preparation for release of 2.3.5

### Changelog

```
= 2.3.5 =
* Add a new class to customize for Square from Partner Aware Onboarding #1426
* Remove the Customizer from the admin menu and the admin bar, if a block theme is used #1433
* Delete woocommerce_demo_store option to hide the demo store notice #1433
```

- [Partner Aware Onboarding - Customizations for Square](https://github.com/Automattic/wc-calypso-bridge/pull/1426#top)
- [Remove customizer when block themes are used - Remove the Woo store notice](https://github.com/Automattic/wc-calypso-bridge/pull/1433#top)