### PR TITLE
Improve partner aware onboarding customizations

### DIFF
--- a/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
+++ b/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
@@ -196,6 +196,12 @@ class WC_Calypso_Bridge_Partner_Square {
 				foreach( $data as $key=>$note ) {
 					if ( isset( $note['name'] ) && $note['name'] === 'wc-admin-onboarding-payments-reminder' ) {
 						unset( $data[$key] );
+						$headers = $response->get_headers();
+						if ( isset( $headers['X-WP-Total'] ) ) {
+							$headers['X-WP-Total'] = (int) $headers['X-WP-Total'] - 1;
+							$response->set_headers( $headers );
+						}
+						break;
 					}
 				}
 				$response->set_data( array_values( $data ) );

--- a/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
+++ b/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
@@ -49,6 +49,7 @@ class WC_Calypso_Bridge_Partner_Square {
 		$this->add_square_setup_task();
 		$this->add_square_connect_url_to_js();
 		$this->remove_woo_payments_from_payments_suggestions_feed();
+		$this->remove_payments_note();
 	}
 
 	/**
@@ -181,6 +182,26 @@ class WC_Calypso_Bridge_Partner_Square {
 
 			return $params;
 		});
+	}
+
+	/**
+	 * Remove wc-admin-onboarding-payments-reminder note from the notes api endpoint.
+	 *
+	 * @return void
+	 */
+	private function remove_payments_note() {
+		add_filter( 'rest_request_after_callbacks', function( $response, $handler, $request ) {
+			if ( $request->get_route() === '/wc-analytics/admin/notes' ) {
+				$data = $response->get_data();
+				foreach( $data as $key=>$note ) {
+					if ( isset( $note['name'] ) && $note['name'] === 'wc-admin-onboarding-payments-reminder' ) {
+						unset( $data[$key] );
+					}
+				}
+				$response->set_data( array_values( $data ) );
+			}
+			return $response;
+		}, 10, 3);
 	}
 }
 

--- a/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
+++ b/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
@@ -4,7 +4,7 @@
  * WC Calypso Bridge Partner Square
  *
  *	@since   2.3.5
- *	@version 2.3.6
+ *	@version 2.3.x
  *
  * This file includes customizations for the sites that were created through /start/square on woo.com.
  * woocommerce_onboarding_profile.partner must get 'square'

--- a/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
+++ b/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
@@ -84,6 +84,20 @@ class WC_Calypso_Bridge_Partner_Square {
 		add_filter( 'woocommerce_admin_experimental_onboarding_tasklists', function( $lists ) {
 			if ( isset( $lists['setup'] ) ) {
 				require_once __DIR__ . '/../../tasks/class-wc-calypso-task-get-paid-with-square.php';
+
+				$removeTasks = [
+					'Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\TrialPayments',
+					'Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\WooCommercePayments'
+				];
+
+				$lists['setup']->tasks = array_filter( $lists['setup']->tasks,  function( $task ) use ($removeTasks) {
+					if ( in_array( get_class( $task ), $removeTasks ) ) {
+						return false;
+					}
+
+					return true;
+				});
+
 				// Place it at the third position.
 				array_splice( $lists['setup']->tasks, 2, 0, array( new \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\WCBridgeGetPaidWithSquare( $lists['setup'] ) ) );
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleased =
+* Improve Partner Aware Onboarding customiations #xxx
+
 = 2.3.6 =
 * This PR removes unintended space before the php tag, which was adding a space to the JSON endpoint and resulting in invalid JSON #1439
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR aims to fix bugs reported from pdibGW-2Ml-p2

I wasn't able to perfectly reproduce the reported bugs. However, it appears that both issues are linked to the Square class not being detected. I suspect there might be timing issues arising from the initial loading of the plugins.

1. The updated code generates the connection URL even without Square class. 
2. Removes `wc-admin-onboarding-payments-reminder` note.
3. Removes `Set up payments` task.


<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

**Square task** 
1. Start with a fresh site with this branch. Do not include WooCommerce Square plugin.
2. Make sure you're in a trial plan.
3. Use wp cli to update `woocommerce_onboarding_profile` option value with `a:10:{s:15:"business_choice";s:28:"im_just_starting_my_business";s:21:"selling_online_answer";N;s:17:"selling_platforms";N;s:20:"is_store_country_set";b:1;s:8:"industry";a:1:{i:0;N;}s:18:"is_agree_marketing";b:0;s:11:"store_email";s:17:"test@gmail.com";s:9:"completed";b:1;s:23:"is_plugins_page_skipped";b:1;s:7:"partner";s:6:"square";}` It includes `partner=square`
4. Navigate to `WooCommerce -> Home`
5. Confirm you still have `Get paid with Square` task.
6. Click on it.
7. You should be redirected to Square setup page.

**wc-admin-onboarding-payments-reminder note**

1. Start with a fresh site.
2. Make sure you're in a trial plan.
3. Execute the following query to insert the note
```
INSERT INTO `wp_wc_admin_notes` (`name`, `type`, `locale`, `title`, `content`, `content_data`, `status`, `source`, `date_created`, `date_reminder`, `is_snoozable`, `layout`, `image`, `is_deleted`, `is_read`, `icon`)
VALUES
	('wc-admin-onboarding-payments-reminder', 'info', 'en_US', 'Start accepting payments on your store!', 'Take payments with the provider that’s right for you - choose from 100+ payment gateways for WooCommerce.', '{}', 'unactioned', 'woocommerce-admin', '2024-02-08 18:29:35', NULL, 0, 'plain', '', 0, 1, 'info');
```
4. Navigate to `WooCommerce -> Home`
5. Confirm there isn't a note with title `Start accepting payments on your store!`
6. Confirm `Set up payments` task is hidden

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.