### PR TITLE
Force Square payments sort order on the payment settings page

### DIFF
--- a/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
+++ b/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
@@ -37,15 +37,16 @@ class WC_Calypso_Bridge_Partner_Square {
 		if ( ! wc_calypso_bridge_is_ecommerce_trial_plan() ) {
 			return;
 		}
-		$onboarding_profile = get_option( 'woocommerce_onboarding_profile', array() );
-		if ( ! isset( $onboarding_profile['partner'] ) ) {
-			return;
-		}
+//		$onboarding_profile = get_option( 'woocommerce_onboarding_profile', array() );
+//		if ( ! isset( $onboarding_profile['partner'] ) ) {
+//			return;
+//		}
+//
+//		if ( $onboarding_profile['partner'] !== 'square' ) {
+//			return;
+//		}
 
-		if ( $onboarding_profile['partner'] !== 'square' ) {
-			return;
-		}
-
+		$this->force_square_payment_methods_order();
 		$this->add_square_setup_task();
 		$this->add_square_connect_url_to_js();
 		$this->remove_woo_payments_from_payments_suggestions_feed();
@@ -208,6 +209,22 @@ class WC_Calypso_Bridge_Partner_Square {
 			}
 			return $response;
 		}, 10, 3);
+	}
+
+	/**
+	 * Force square_cash_app_pay and square_credit_card order
+	 * IF user hans't customized the payment methods order yet.
+	 *
+	 * @return void
+	 */
+	private function force_square_payment_methods_order() {
+		$order_option = get_option( 'woocommerce_gateway_order', false );
+		if ( ! $order_option ) {
+			update_option( 'woocommerce_gateway_order', array(
+				'square_cash_app_pay' => 0,
+				'square_credit_card' => 1
+			) );
+		}
 	}
 }
 

--- a/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
+++ b/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
@@ -4,7 +4,7 @@
  * WC Calypso Bridge Partner Square
  *
  *	@since   2.3.5
- *	@version 2.3.7
+ *	@version 2.3.x
  *
  * This file includes customizations for the sites that were created through /start/square on woo.com.
  * woocommerce_onboarding_profile.partner must get 'square'

--- a/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
+++ b/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
@@ -37,14 +37,14 @@ class WC_Calypso_Bridge_Partner_Square {
 		if ( ! wc_calypso_bridge_is_ecommerce_trial_plan() ) {
 			return;
 		}
-//		$onboarding_profile = get_option( 'woocommerce_onboarding_profile', array() );
-//		if ( ! isset( $onboarding_profile['partner'] ) ) {
-//			return;
-//		}
-//
-//		if ( $onboarding_profile['partner'] !== 'square' ) {
-//			return;
-//		}
+		$onboarding_profile = get_option( 'woocommerce_onboarding_profile', array() );
+		if ( ! isset( $onboarding_profile['partner'] ) ) {
+			return;
+		}
+
+		if ( $onboarding_profile['partner'] !== 'square' ) {
+			return;
+		}
 
 		$this->force_square_payment_methods_order();
 		$this->add_square_setup_task();

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleased =
+* Force square_cash_app_pay and square_credit_card order on the payment settings page #xxx
+
 = 2.3.8 =
 * Update Square task copy changes #1443
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This PR forces order of square_cash_app_pay and square_credit_card. Both should be listed before any other payment methods.

### How to test the changes in this Pull Request:

1. Create a new site with this branch.
2. Complete onboarding wizard and make sure to choose United States as your store country.
3. Use WP Cli to update `woocommerce_onboarding_profile`

```
wp option update woocommerce_onboarding_profile --format=json '{  "business_choice": "im_just_starting_my_business",  "selling_online_answer": null,  "selling_platforms": null,  "is_store_country_set": true,  "industry": [null],  "is_agree_marketing": false,  "store_email": "test@gmail.com",  "completed": true,  "is_plugins_page_skipped": true,  "partner": "square"}'
```
4. Install and activate WooCommerce Square.
5. Go to `WooCommerce -> Settings -> Payments`
6. Confirm Square and Cash App are listed before other payment methods.


<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
