### PR TITLE
Force Square payments sort order on the payment settings page 

### DIFF
--- a/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
+++ b/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
@@ -221,8 +221,8 @@ class WC_Calypso_Bridge_Partner_Square {
 		$order_option = get_option( 'woocommerce_gateway_order', false );
 		if ( ! $order_option ) {
 			update_option( 'woocommerce_gateway_order', array(
-				'square_cash_app_pay' => 0,
-				'square_credit_card' => 1
+				'square_credit_card' => 0,
+				'square_cash_app_pay' => 1,
 			) );
 		}
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -22,11 +22,11 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
-= 2.3.9 =
-* Force square_cash_app_pay and square_credit_card order on the payment settings page #1445
-
 = Unreleased =
 * Force square_cash_app_pay and square_credit_card order on the payment settings page #xxx
+
+= 2.3.9 =
+* Force square_cash_app_pay and square_credit_card order on the payment settings page #1445
 
 = 2.3.8 =
 * Update Square task copy changes #1443


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a follow-up PR for https://github.com/Automattic/wc-calypso-bridge/pull/1445 to display the Square app before Cash App.

### How to test the changes in this Pull Request:

1. Create a new site with this branch.
2. Complete onboarding wizard and make sure to choose United States as your store country.
3. Use WP Cli to update `woocommerce_onboarding_profile`

```
wp option update woocommerce_onboarding_profile --format=json '{  "business_choice": "im_just_starting_my_business",  "selling_online_answer": null,  "selling_platforms": null,  "is_store_country_set": true,  "industry": [null],  "is_agree_marketing": false,  "store_email": "test@gmail.com",  "completed": true,  "is_plugins_page_skipped": true,  "partner": "square"}'
```
4. Install and activate WooCommerce Square.
5. Go to `WooCommerce -> Settings -> Payments`
6. Confirm Square and Cash App are listed before other payment methods.


<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
