### PR TITLE
Ecommerce Admin Menu: Apply changes to the site with nav redesign

### DIFF
--- a/includes/class-wc-calypso-bridge-base-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-base-admin-menu.php
@@ -44,7 +44,7 @@ abstract class WC_Calypso_Bridge_Base_Admin_Menu {
 	 */
 	protected function __construct() {
 		$this->is_api_request = defined( 'REST_REQUEST' ) && REST_REQUEST || isset( $_SERVER['REQUEST_URI'] ) && str_starts_with( filter_var( wp_unslash( $_SERVER['REQUEST_URI'] ) ), '/?rest_route=%2Fwpcom%2Fv2%2Fadmin-menu' );
-		$this->domain         = ( new Status() )->get_site_suffix();
+		$this->domain         = WC_Calypso_Bridge_Instance()->get_site_slug();
 
 		add_action( 'admin_menu', array( $this, 'reregister_menu_items' ), 99999 );
 	}

--- a/includes/class-wc-calypso-bridge-base-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-base-admin-menu.php
@@ -1,0 +1,396 @@
+<?php
+
+use Automattic\Jetpack\Status;
+
+/**
+ * Base Admin Menu file.
+ *
+ * @since   x.x.x
+ * @version x.x.x
+ *
+ * The base admin menu controller for Ecommerce WoA sites.
+ */
+abstract class WC_Calypso_Bridge_Base_Admin_Menu {
+	/**
+	 * Holds class instances.
+	 *
+	 * @var array
+	 */
+	protected static $instances;
+
+	/**
+	 * Whether the current request is a REST API request.
+	 *
+	 * @var bool
+	 */
+	protected $is_api_request = false;
+
+	/**
+	 * Domain of the current site.
+	 *
+	 * @var string
+	 */
+	protected $domain;
+
+	/**
+	 * The CSS classes used to hide the submenu items in navigation.
+	 *
+	 * @var string
+	 */
+	const HIDE_CSS_CLASS = 'hide-if-js';
+
+	/**
+	 * Base_Admin_Menu constructor.
+	 */
+	protected function __construct() {
+		$this->is_api_request = defined( 'REST_REQUEST' ) && REST_REQUEST || isset( $_SERVER['REQUEST_URI'] ) && str_starts_with( filter_var( wp_unslash( $_SERVER['REQUEST_URI'] ) ), '/?rest_route=%2Fwpcom%2Fv2%2Fadmin-menu' );
+		$this->domain         = ( new Status() )->get_site_suffix();
+
+		add_action( 'admin_menu', array( $this, 'reregister_menu_items' ), 99999 );
+	}
+
+	/**
+	 * Returns class instance.
+	 *
+	 * @return Admin_Menu
+	 */
+	public static function get_instance() {
+		$class = static::class;
+
+		if ( empty( static::$instances[ $class ] ) ) {
+			static::$instances[ $class ] = new $class();
+		}
+
+		return static::$instances[ $class ];
+	}
+
+	/**
+	 * Updates the menu data of the given menu slug.
+	 *
+	 * @param string $slug Slug of the menu to update.
+	 * @param string $url New menu URL.
+	 * @param string $title New menu title.
+	 * @param string $cap New menu capability.
+	 * @param string $icon New menu icon.
+	 * @param int    $position New menu position.
+	 * @return bool Whether the menu has been updated.
+	 */
+	public function update_menu( $slug, $url = null, $title = null, $cap = null, $icon = null, $position = null ) {
+		global $menu, $submenu;
+
+		$menu_item     = null;
+		$menu_position = null;
+
+		foreach ( $menu as $i => $item ) {
+			if ( $slug === $item[2] ) {
+				$menu_item     = $item;
+				$menu_position = $i;
+				break;
+			}
+		}
+
+		if ( ! $menu_item ) {
+			return false;
+		}
+
+		if ( $title ) {
+			$menu_item[0] = $title;
+			$menu_item[3] = esc_attr( $title );
+		}
+
+		if ( $cap ) {
+			$menu_item[1] = $cap;
+		}
+
+		// Change parent slug only if there are no submenus (the slug of the 1st submenu will be used if there are submenus).
+		if ( $url ) {
+			$this->hide_submenu_page( $slug, $slug );
+
+			if ( ! isset( $submenu[ $slug ] ) || ! $this->has_visible_items( $submenu[ $slug ] ) ) {
+				$menu_item[2] = $url;
+			}
+		}
+
+		if ( $icon ) {
+			$menu_item[4] = 'menu-top';
+			$menu_item[6] = $icon;
+		}
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		unset( $menu[ $menu_position ] );
+		if ( $position ) {
+			$menu_position = $position;
+		}
+		$this->set_menu_item( $menu_item, $menu_position );
+
+		// Only add submenu when there are other submenu items.
+		if ( $url && isset( $submenu[ $slug ] ) && $this->has_visible_items( $submenu[ $slug ] ) ) {
+			add_submenu_page( $slug, $menu_item[3], $menu_item[0], $menu_item[1], $url, null, 0 );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Updates the submenus of the given menu slug.
+	 *
+	 * It hides the menu by adding the `hide-if-js` css class and duplicates the submenu with the new slug.
+	 *
+	 * @param string $slug Menu slug.
+	 * @param array  $submenus_to_update Array of new submenu slugs.
+	 */
+	public function update_submenus( $slug, $submenus_to_update ) {
+		global $submenu;
+
+		if ( ! isset( $submenu[ $slug ] ) ) {
+			return;
+		}
+
+		// This is needed for cases when the submenus to update have the same new slug.
+		$submenus_to_update = array_filter(
+			$submenus_to_update,
+			static function ( $item, $old_slug ) {
+				return $item !== $old_slug;
+			},
+			ARRAY_FILTER_USE_BOTH
+		);
+
+		/**
+		 * Iterate over all submenu items and add the hide the submenus with CSS classes.
+		 * This is done separately of the second foreach because the position of the submenu might change.
+		 */
+		foreach ( $submenu[ $slug ] as $index => $item ) {
+			if ( ! array_key_exists( $item[2], $submenus_to_update ) ) {
+				continue;
+			}
+
+			$this->hide_submenu_element( $index, $slug, $item );
+		}
+
+		$submenu_items = array_values( $submenu[ $slug ] );
+
+		/**
+		 * Iterate again over the submenu array. We need a copy of the array because add_submenu_page will add new elements
+		 * to submenu array that might cause an infinite loop.
+		 */
+		foreach ( $submenu_items as $i => $submenu_item ) {
+			if ( ! array_key_exists( $submenu_item[2], $submenus_to_update ) ) {
+				continue;
+			}
+
+			add_submenu_page(
+				$slug,
+				isset( $submenu_item[3] ) ? $submenu_item[3] : '',
+				isset( $submenu_item[0] ) ? $submenu_item[0] : '',
+				isset( $submenu_item[1] ) ? $submenu_item[1] : 'read',
+				$submenus_to_update[ $submenu_item[2] ],
+				'',
+				0 === $i ? 0 : $i + 1
+			);
+		}
+	}
+
+	/**
+	 * Adds a menu separator.
+	 *
+	 * @param int    $position The position in the menu order this item should appear.
+	 * @param string $cap Optional. The capability required for this menu to be displayed to the user.
+	 *                         Default: 'read'.
+	 */
+	public function add_admin_menu_separator( $position = null, $cap = 'read' ) {
+		$menu_item = array(
+			'',                                  // Menu title (ignored).
+			$cap,                                // Required capability.
+			wp_unique_id( 'separator-custom-' ), // URL or file (ignored, but must be unique).
+			'',                                  // Page title (ignored).
+			'wp-menu-separator',                 // CSS class. Identifies this item as a separator.
+		);
+
+		$this->set_menu_item( $menu_item, $position );
+	}
+
+	/**
+	 * Hide the submenu page based on slug and return the item that was hidden.
+	 *
+	 * Instead of actually removing the submenu item, a safer approach is to hide it and filter it in the API response.
+	 * In this manner we'll avoid breaking third-party plugins depending on items that no longer exist.
+	 *
+	 * A false|array value is returned to be consistent with remove_submenu_page() function
+	 *
+	 * @param string $menu_slug The parent menu slug.
+	 * @param string $submenu_slug The submenu slug that should be hidden.
+	 * @return false|array
+	 */
+	public function hide_submenu_page( $menu_slug, $submenu_slug ) {
+		global $submenu;
+
+		if ( ! isset( $submenu[ $menu_slug ] ) ) {
+			return false;
+		}
+
+		foreach ( $submenu[ $menu_slug ] as $i => $item ) {
+			if ( $submenu_slug !== $item[2] ) {
+				continue;
+			}
+
+			$this->hide_submenu_element( $i, $menu_slug, $item );
+
+			return $item;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Apply the hide-if-js CSS class to a submenu item.
+	 *
+	 * @param int    $index The position of a submenu item in the submenu array.
+	 * @param string $parent_slug The parent slug.
+	 * @param array  $item The submenu item.
+	 */
+	public function hide_submenu_element( $index, $parent_slug, $item ) {
+		global $submenu;
+
+		$css_classes = empty( $item[4] ) ? self::HIDE_CSS_CLASS : $item[4] . ' ' . self::HIDE_CSS_CLASS;
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$submenu [ $parent_slug ][ $index ][4] = $css_classes;
+	}
+
+	/**
+	 * Check if the menu has submenu items visible
+	 *
+	 * @param array $submenu_items The submenu items.
+	 * @return bool
+	 */
+	public function has_visible_items( $submenu_items ) {
+		$visible_items = array_filter(
+			$submenu_items,
+			array( $this, 'is_item_visible' )
+		);
+
+		return array() !== $visible_items;
+	}
+
+	/**
+	 * Return the number of existing submenu items under the supplied parent slug.
+	 *
+	 * @param string $parent_slug The slug of the parent menu.
+	 * @return int The number of submenu items under $parent_slug.
+	 */
+	public function get_submenu_item_count( $parent_slug ) {
+		global $submenu;
+
+		if ( empty( $parent_slug ) || empty( $submenu[ $parent_slug ] ) || ! is_array( $submenu[ $parent_slug ] ) ) {
+			return 0;
+		}
+
+		return count( $submenu[ $parent_slug ] );
+	}
+
+	/**
+	 * Adds the given menu item in the specified position.
+	 *
+	 * @param array $item The menu item to add.
+	 * @param int   $position The position in the menu order this item should appear.
+	 */
+	public function set_menu_item( $item, $position = null ) {
+		global $menu;
+
+		// Handle position (avoids overwriting menu items already populated in the given position).
+		// Inspired by https://core.trac.wordpress.org/browser/trunk/src/wp-admin/menu.php?rev=49837#L160.
+		if ( null === $position ) {
+			$menu[] = $item; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		} elseif ( isset( $menu[ "$position" ] ) ) {
+			$position            = $position + substr( base_convert( md5( $item[2] . $item[0] ), 16, 10 ), -5 ) * 0.00001;
+			$menu[ "$position" ] = $item; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		} else {
+			$menu[ $position ] = $item; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
+	}
+
+	/**
+	 * Hide menus that are unauthorized and don't have visible submenus and cases when the menu has the same slug
+	 * as the first submenu item.
+	 *
+	 * This must be done at the end of menu and submenu manipulation in order to avoid performing this check each time
+	 * the submenus are altered.
+	 */
+	public function hide_parent_of_hidden_submenus() {
+		global $menu, $submenu;
+
+		$this->sort_hidden_submenus();
+
+		foreach ( $menu as $menu_index => $menu_item ) {
+			$has_submenus = isset( $submenu[ $menu_item[2] ] );
+
+			// Skip if the menu doesn't have submenus.
+			if ( ! $has_submenus ) {
+				continue;
+			}
+
+			// If the first submenu item is hidden then we should also hide the parent.
+			// Since the submenus are ordered by self::HIDE_CSS_CLASS (hidden submenus should be at the end of the array),
+			// we can say that if the first submenu is hidden then we should also hide the menu.
+			$first_submenu_item       = array_values( $submenu[ $menu_item[2] ] )[0];
+			$is_first_submenu_visible = $this->is_item_visible( $first_submenu_item );
+
+			// if the user does not have access to the menu and the first submenu is hidden, then hide the menu.
+			if ( ! current_user_can( $menu_item[1] ) && ! $is_first_submenu_visible ) {
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$menu[ $menu_index ][4] = self::HIDE_CSS_CLASS;
+			}
+
+			// if the menu has the same slug as the first submenu then hide the submenu.
+			if ( $menu_item[2] === $first_submenu_item[2] && ! $is_first_submenu_visible ) {
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$menu[ $menu_index ][4] = self::HIDE_CSS_CLASS;
+			}
+		}
+	}
+
+	/**
+	 * Sort the hidden submenus by moving them at the end of the array in order to avoid WP using them as default URLs.
+	 *
+	 * This operation has to be done at the end of submenu manipulation in order to guarantee that the hidden submenus
+	 * are at the end of the array.
+	 */
+	public function sort_hidden_submenus() {
+		global $submenu;
+
+		foreach ( $submenu as $menu_slug => $submenu_items ) {
+			foreach ( $submenu_items as $submenu_index => $submenu_item ) {
+				if ( $this->is_item_visible( $submenu_item ) ) {
+					continue;
+				}
+
+				unset( $submenu[ $menu_slug ][ $submenu_index ] );
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$submenu[ $menu_slug ][] = $submenu_item;
+			}
+		}
+	}
+
+	/**
+	 * Check if the given item is visible or not in the admin menu.
+	 *
+	 * @param array $item A menu or submenu array.
+	 */
+	public function is_item_visible( $item ) {
+		return ! isset( $item[4] ) || ! str_contains( $item[4], self::HIDE_CSS_CLASS );
+	}
+
+	/**
+	 * Whether the current user has indicated they want to use the wp-admin interface for the given screen.
+	 *
+	 * @return bool
+	 */
+	public function use_wp_admin_interface() {
+		return 'wp-admin' === get_option( 'wpcom_admin_interface' );
+	}
+
+	/**
+	 * Create the desired menu output.
+	 */
+	abstract public function reregister_menu_items();
+}

--- a/includes/class-wc-calypso-bridge-base-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-base-admin-menu.php
@@ -1,7 +1,5 @@
 <?php
 
-use Automattic\Jetpack\Status;
-
 /**
  * Base Admin Menu file.
  *
@@ -9,6 +7,7 @@ use Automattic\Jetpack\Status;
  * @version x.x.x
  *
  * The base admin menu controller for Ecommerce WoA sites.
+ * Copied from https://github.com/Automattic/jetpack/blob/45c299dc82c265f627328899697cfab154d2fa04/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php#L15
  */
 abstract class WC_Calypso_Bridge_Base_Admin_Menu {
 	/**

--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -239,6 +239,28 @@ class WC_Calypso_Bridge_Ecommerce_Admin_Menu extends WC_Calypso_Bridge_Base_Admi
 		if ( ! function_exists( 'wpcom_is_nav_redesign_enabled' ) || ! wpcom_is_nav_redesign_enabled() ) {
 			remove_submenu_page( 'index.php', 'https://wordpress.com/home/' . $this->domain );
 		}
+
+		// Replace "Hosting" (/home) link with "Hosting" (/plans).
+		$this->update_menu(
+			'wpcom-hosting-menu',
+			esc_url( "https://wordpress.com/plans/{$this->domain}" ),
+			esc_attr__( 'Hosting', 'wc-calypso-bridge' ),
+			'manage_options',
+			'dashicons-cloud',
+			3
+		);
+
+		// Remove "Hosting" submenu item created by the above.
+		remove_submenu_page(
+			'wpcom-hosting-menu',
+			esc_url( "https://wordpress.com/plans/{$this->domain}" )
+		);
+
+		// Remove "My Home" submenu item.
+		remove_submenu_page(
+			'wpcom-hosting-menu',
+			esc_url( "https://wordpress.com/home/{$this->domain}" )
+		);
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -608,10 +608,13 @@ class WC_Calypso_Bridge_Ecommerce_Admin_Menu extends WC_Calypso_Bridge_Base_Admi
 		// Move Akismet under Settings
 		$this->hide_submenu_page( 'jetpack', 'akismet-key-config' );
 
-		// Move Jetpack status screen from 'Settings > Jetpack' to 'Tools > Jetpack Status'.
-		add_submenu_page( 'tools.php', esc_attr__( 'Jetpack Status', 'wc-calypso-bridge' ), __( 'Jetpack Status', 'wc-calypso-bridge' ), 'manage_options', 'https://wordpress.com/settings/jetpack/' . $this->domain, null, 100 );
+		if ( function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled() ) {
+			// Move Jetpack status screen from 'Settings > Jetpack' to 'Tools > Jetpack Status'.
+			add_submenu_page( 'tools.php', esc_attr__( 'Jetpack Status', 'wc-calypso-bridge' ), __( 'Jetpack Status', 'wc-calypso-bridge' ), 'manage_options', 'https://wordpress.com/settings/jetpack/' . $this->domain, null, 100 );
 
-		add_submenu_page( 'jetpack', esc_attr__( 'Jetpack Stats', 'wc-calypso-bridge' ), __( 'Stats', 'wc-calypso-bridge' ), 'manage_options', 'https://wordpress.com/stats/day/' . $this->domain, null, 100 );
+			// Add Jetpack Stats to 'Jetpack > Stats'.
+			add_submenu_page( 'jetpack', esc_attr__( 'Jetpack Stats', 'wc-calypso-bridge' ), __( 'Stats', 'wc-calypso-bridge' ), 'manage_options', 'https://wordpress.com/stats/day/' . $this->domain, null, 100 );
+		}
 
 		// Order Jetpack submenu to have Dashboard first followed by Stats.
 		if ( ! empty( $submenu['jetpack'] ) && is_array( $submenu['jetpack'] ) ) {

--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -29,8 +29,9 @@ class WC_Calypso_Bridge_Ecommerce_Admin_Menu extends WC_Calypso_Bridge_Base_Admi
 	 * Override constructor and add custom actions.
 	 */
 	public function __construct() {
+		parent::__construct();
+
 		add_action( 'admin_menu', array( $this, 'maybe_hide_payments_menu' ), 10 );
-		add_action( 'admin_menu', array( $this, 'reregister_menu_items' ), 99999 );
 		add_action( 'admin_bar_menu', array( $this, 'maybe_remove_customizer_admin_bar_menu' ), 99999 );
 		add_filter( 'menu_order', array( $this, 'menu_order' ), 100 );
 
@@ -66,21 +67,6 @@ class WC_Calypso_Bridge_Ecommerce_Admin_Menu extends WC_Calypso_Bridge_Base_Admi
 				'woocommerce-express-dummy-menu-item'
 			);
 		}, 49);
-	}
-
-	/**
-	 * Returns class instance.
-	 *
-	 * @return Ecommerce_Atomic_Admin_Menu
-	 */
-	public static function get_instance() {
-		$class = static::class;
-
-		if ( empty( static::$instances[ $class ] ) ) {
-			static::$instances[ $class ] = new $class();
-		}
-
-		return static::$instances[ $class ];
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -587,7 +587,8 @@ class WC_Calypso_Bridge_Ecommerce_Admin_Menu extends WC_Calypso_Bridge_Base_Admi
 			// Move Jetpack status screen from 'Settings > Jetpack' to 'Tools > Jetpack Status'.
 			add_submenu_page( 'tools.php', esc_attr__( 'Jetpack Status', 'wc-calypso-bridge' ), __( 'Jetpack Status', 'wc-calypso-bridge' ), 'manage_options', 'https://wordpress.com/settings/jetpack/' . $this->domain, null, 100 );
 
-			// Add Jetpack Stats to 'Jetpack > Stats'.
+			// Move Jetpack Stats to 'Jetpack > Stats'.
+			remove_menu_page( 'https://wordpress.com/stats/day/' . $this->domain );
 			add_submenu_page( 'jetpack', esc_attr__( 'Jetpack Stats', 'wc-calypso-bridge' ), __( 'Stats', 'wc-calypso-bridge' ), 'manage_options', 'https://wordpress.com/stats/day/' . $this->domain, null, 100 );
 		}
 

--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -87,7 +87,6 @@ class WC_Calypso_Bridge_Ecommerce_Admin_Menu extends WC_Calypso_Bridge_Base_Admi
 	 * Create the desired menu output.
 	 */
 	public function reregister_menu_items() {
-		$this->add_plugins_menu();
 		$this->add_options_menu();
 		$this->add_jetpack_menu();
 		$this->add_my_home_menu();
@@ -114,9 +113,15 @@ class WC_Calypso_Bridge_Ecommerce_Admin_Menu extends WC_Calypso_Bridge_Base_Admi
 		add_submenu_page( 'jetpack', __( 'Feedback', 'wc-calypso-bridge' ), __( 'Feedback', 'wc-calypso-bridge' ), 'manage_woocommerce', 'edit.php?post_type=feedback', '', 10 );
 
 		// Hide Tools > Marketing and Tools > Earn submenus.
-		$site_suffix  = WC_Calypso_Bridge_Instance()->get_site_slug();
-		$this->hide_submenu_page( 'tools.php', sprintf( 'https://wordpress.com/marketing/tools/%s', $site_suffix ) );
-		$this->hide_submenu_page( 'tools.php', sprintf( 'https://wordpress.com/earn/%s', $site_suffix ) );
+		$this->hide_submenu_page( 'tools.php', sprintf( 'https://wordpress.com/marketing/tools/%s', $this->domain ) );
+		$this->hide_submenu_page( 'tools.php', sprintf( 'https://wordpress.com/earn/%s', $this->domain ) );
+
+		// Hide Plugins
+		if ( function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled() ) {
+			remove_menu_page( 'plugins.php' );
+		} else {
+			remove_menu_page( 'https://wordpress.com/plugins/' . $this->domain );
+		}
 	}
 
 	/**
@@ -164,22 +169,6 @@ class WC_Calypso_Bridge_Ecommerce_Admin_Menu extends WC_Calypso_Bridge_Base_Admi
 				}
 			}
 		}
-	}
-
-	/**
-	 * Override the base implementation of add_plugins_menu() to avoid
-	 * adding the Plugins menu for eCommerce trials.
-	 *
-	 * @since   2.0.8
-	 *
-	 * @return void
-	 */
-	public function add_plugins_menu() {
-		if ( ! wc_calypso_bridge_is_ecommerce_trial_plan() ) {
-			return;
-		}
-
-		remove_menu_page( 'https://wordpress.com/plugins/' . $this->domain );
 	}
 
 	/**
@@ -608,7 +597,7 @@ class WC_Calypso_Bridge_Ecommerce_Admin_Menu extends WC_Calypso_Bridge_Base_Admi
 		// Move Akismet under Settings
 		$this->hide_submenu_page( 'jetpack', 'akismet-key-config' );
 
-		if ( function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled() ) {
+		if ( ! function_exists( 'wpcom_is_nav_redesign_enabled' ) || ! wpcom_is_nav_redesign_enabled() ) {
 			// Move Jetpack status screen from 'Settings > Jetpack' to 'Tools > Jetpack Status'.
 			add_submenu_page( 'tools.php', esc_attr__( 'Jetpack Status', 'wc-calypso-bridge' ), __( 'Jetpack Status', 'wc-calypso-bridge' ), 'manage_options', 'https://wordpress.com/settings/jetpack/' . $this->domain, null, 100 );
 

--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -103,11 +103,7 @@ class WC_Calypso_Bridge_Ecommerce_Admin_Menu extends WC_Calypso_Bridge_Base_Admi
 		$this->hide_submenu_page( 'tools.php', sprintf( 'https://wordpress.com/earn/%s', $this->domain ) );
 
 		// Hide Plugins
-		if ( function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled() ) {
-			remove_menu_page( 'plugins.php' );
-		} else {
-			remove_menu_page( 'https://wordpress.com/plugins/' . $this->domain );
-		}
+		remove_menu_page( 'plugins.php' );
 	}
 
 	/**
@@ -124,6 +120,7 @@ class WC_Calypso_Bridge_Ecommerce_Admin_Menu extends WC_Calypso_Bridge_Base_Admi
 
 			// Create the toplevel menu from scratch.
 			$this->hide_submenu_page( 'woocommerce', 'wc-orders' );
+			$this->hide_submenu_page( 'woocommerce', 'edit.php?post_type=shop_order' );
 			add_menu_page( __( 'Orders', 'woocommerce' ), __( 'Orders', 'woocommerce' ), 'edit_shop_orders', 'admin.php?page=wc-orders', null, 'dashicons-cart', 40 );
 			add_submenu_page( 'admin.php?page=wc-orders', __( 'Orders', 'woocommerce' ), __( 'Orders', 'woocommerce' ), 'edit_shop_orders', 'admin.php?page=wc-orders', null, 1 );
 			add_submenu_page( 'admin.php?page=wc-orders', __( 'Add New Order', 'woocommerce' ), __( 'Add New', 'woocommerce' ), 'edit_shop_orders', 'admin.php?page=wc-orders&action=new', null, 2 );
@@ -239,6 +236,9 @@ class WC_Calypso_Bridge_Ecommerce_Admin_Menu extends WC_Calypso_Bridge_Base_Admi
 		}
 
 		$this->update_menu( 'index.php', 'admin.php?page=wc-admin', $label, 'edit_posts', 'dashicons-admin-home' );
+		if ( ! function_exists( 'wpcom_is_nav_redesign_enabled' ) || ! wpcom_is_nav_redesign_enabled() ) {
+			remove_submenu_page( 'index.php', 'https://wordpress.com/home/' . $this->domain );
+		}
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-jetpack.php
+++ b/includes/class-wc-calypso-bridge-jetpack.php
@@ -50,35 +50,27 @@ class WC_Calypso_Bridge_Jetpack {
 	 * Initialize hooks.
 	 */
 	public function init() {
-
 		/**
-		 * Inject the Ecommerce admin menu controller into Jetpack.
+		 * `ecommerce_new_woo_atomic_navigation_enabled` filter.
 		 *
-		 * @since 1.9.8
+		 * This filter is used to revert the ecommerce menu back to the atomic one. It's also useful for debugging purposes.
 		 *
-		 * @param  string $menu_controller_class The name of the menu controller class.
-		 * @return string
+		 * @since 1.9.12
+		 *
+		 * @param  bool $enabled
+		 * @return bool
 		 */
-		add_filter( 'jetpack_admin_menu_class', function ( $menu_controller_class ) {
+		$is_wooexpress_navigation_enabled = (bool) apply_filters( 'ecommerce_new_woo_atomic_navigation_enabled', 'yes' === get_option( 'wooexpress_navigation_enabled', 'yes' ) );
+		if ( $is_wooexpress_navigation_enabled && class_exists( '\Jetpack' ) && \Jetpack::is_module_active( 'sso' ) ) {
+			require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php';
 
 			/**
-			 * `ecommerce_new_woo_atomic_navigation_enabled` filter.
+			 * Apply the Ecommerce admin menu.
 			 *
-			 * This filter is used to revert the ecommerce menu back to the atomic one. It's also useful for debugging purposes.
-			 *
-			 * @since 1.9.12
-			 *
-			 * @param  bool $enabled
-			 * @return bool
+			 * @since 1.9.8
 			 */
-
-			if ( (bool) apply_filters( 'ecommerce_new_woo_atomic_navigation_enabled', 'yes' === get_option( 'wooexpress_navigation_enabled', 'yes' ) ) && class_exists( '\Automattic\Jetpack\Dashboard_Customizations\Atomic_Admin_Menu' ) && class_exists('\Jetpack') && \Jetpack::is_module_active( 'sso' ) ) {
-				require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php';
-				return Ecommerce_Atomic_Admin_Menu::class;
-			}
-
-			return $menu_controller_class;
-		} );
+			WC_Calypso_Bridge_Ecommerce_Admin_Menu::get_instance();
+		}
 
 		/**
 		 * Limits Jetpack Modules to those relevant to Ecommerce Plan users.

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleased =
+* Fix the Woo Express navigation is missing when the wpcom_is_nav_redesign_enabled is enabled #xxx
+
 = 2.3.10 =
 * Force square_cash_app_pay and square_credit_card order on the payment settings page -- follow up issue #1447 
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/Automattic/dotcom-forge/issues/5919

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

The feature, Ecommerce Admin Menu, relies on the `Atomic_Admin_Menu` class from Jetpack and hook the new navigation class to the `jetpack_admin_menu_class` filter. However, both class and filter won't be loaded after the nav redesign. So, this PR proposes to restore the Ecommerce Admin Menu when the nav redesign is enabled.

| | Before | After |
| - | - | - |
| Top Level | ![image](https://github.com/Automattic/wc-calypso-bridge/assets/13596067/44de72f8-44dd-432f-9177-081a49906597) | ![image](https://github.com/Automattic/wc-calypso-bridge/assets/13596067/199ded51-408f-46ab-b05c-2d165dac5fd8) |
| Jetpack | ![image](https://github.com/Automattic/wc-calypso-bridge/assets/13596067/b11c1f7d-79e2-4532-bc93-5d42484a5e30) | ![image](https://github.com/Automattic/wc-calypso-bridge/assets/13596067/dac525cb-0a5e-4191-abd5-7f2e320ca454) |
| Woo | ![image](https://github.com/Automattic/wc-calypso-bridge/assets/13596067/fecb739a-9ec1-4060-a3a5-6717468f73c1) | ![image](https://github.com/Automattic/wc-calypso-bridge/assets/13596067/bd28d65c-ca7a-4ccc-b262-6bc8bf88dc3b) |
| Tools | ![image](https://github.com/Automattic/wc-calypso-bridge/assets/13596067/d0adb6b4-1e18-43cd-84f5-fe45c5681c2b) | ![image](https://github.com/Automattic/wc-calypso-bridge/assets/13596067/d3cd4a90-b740-4a61-9e72-9fff9d1b465b) |
| Settings | ![image](https://github.com/Automattic/wc-calypso-bridge/assets/13596067/b8ad054b-1cf7-40ed-aef6-f105d21237e6) | ![image](https://github.com/Automattic/wc-calypso-bridge/assets/13596067/d547478a-dfa2-4187-bdf4-c2345d317b0b) |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Create a new WoA site with Entrepreneur plan
2. Build and sync changes from your local to the WoA site
    ```bash
    npm install
    npm run build
    rsync -azP --delete --delete-after --exclude={'.config','.idea','.git','node_modules/'} ${WCCALYPSOBRIDGE_LOCAL_DIR} ${REMOTE_SSH_HOST}:/srv/htdocs/wp-content/mu-plugins/wpcomsh/vendor/automattic/wc-calypso-bridge/
    ```
4. Enable the nav redesign on your site, e.g.: turning on your proxy or seting the `wpcom_classic_early_release` option to `1` on your site
5. Make sure the menu works as expected
   * You can see the "My Home" menu, and it displays the "Welcome to your Woo Express store" page
   * You can see the 
   * You can see the "Orders" menu
   * The "WooCommerce" menu is renamed to "Extensions"
     * The submenu "Orders" is moved to the top level
     * The submenu "Customers" is moved to the top level
     * The submenu "Extensions" is renamed to "Discover"
     * The submenu "Home" is hidden
     * The submenu "Settings" is moved to "Settings > WooCommerce" menu, and it's right before "Settings > General"
     * The submenu "Status" is moved to "Tools > WooCommerce Status"
   * The "Settings > Jetpack" menu is removed
   * The "Jetpack > Search" menu is removed
   * The "Jetpack > Akismet" menu is moved to "Settings > Anti-Spam"
6. Follow peapX7-1D4-p2 to create another WoA site with eCommerce trial plan. Or mark your site as a free trial site by mocking the return value of `wc_calypso_bridge_is_ecommerce_trial_plan` to true
7. Make sure the following items work as expected
   * The "Plugins" displays the "WC Plugins Upgrade" page
   * The "Feedback" menu is moved to "Jetpack > Feedback"
8. Disable the nav redesign on your site, e.g.: turning off your proxy or unsetting the `wpcom_classic_early_release` option
9. Review the menu items, and it should be the same as before

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.