### PR TITLE
Ecommerce Admin Menu: Remove the duplicate My Home menu

### DIFF
--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -238,6 +238,7 @@ class WC_Calypso_Bridge_Ecommerce_Admin_Menu extends WC_Calypso_Bridge_Base_Admi
 		$this->update_menu( 'index.php', 'admin.php?page=wc-admin', $label, 'edit_posts', 'dashicons-admin-home' );
 		if ( ! function_exists( 'wpcom_is_nav_redesign_enabled' ) || ! wpcom_is_nav_redesign_enabled() ) {
 			remove_submenu_page( 'index.php', 'https://wordpress.com/home/' . $this->domain );
+			remove_menu_page( 'https://wordpress.com/home/' . $this->domain );
 		}
 
 		// Replace "Hosting" (/home) link with "Hosting" (/plans).


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/Automattic/wp-calypso/issues/89398.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

The https://github.com/Automattic/wc-calypso-bridge/pull/1449 created a side effect so that there are duplicate `My Home` menu on the Woo Express site with the classic interface. Before that patch, the `jetpack_admin_menu_class` returned the `Ecommerce_Atomic_Admin_Menu`, and then the `My Home` menu that pointed to the Calypso wasn't added. However, after that patch, the filter returned the `Admin_Menu` from Jetpack and it registered the `My Home` menu [here](https://github.com/Automattic/jetpack/blob/284a702a83577ff5798a85d149a754dc0f11b489/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php#L109). As it's the side effect from that PR, I think it would be better to remove the menu by Woo Express.

In the future, we can discuss whether to avoid the `Admin_Menu` from Jetpack registering the `My Home` menu since the menu doesn't seem to be necessary on the classic view.

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wc-calypso-bridge/assets/13596067/70417c30-195d-4888-9f92-b9611f91084d) | ![image](https://github.com/Automattic/wc-calypso-bridge/assets/13596067/34764809-07e7-4b43-bd88-650f81d17559) |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Create a new WoA site with Entrepreneur plan
2. Build and sync changes from your local to the WoA site
    ```bash
    npm install
    npm run build
    rsync -azP --delete --delete-after --exclude={'.config','.idea','.git','node_modules/'} ${WCCALYPSOBRIDGE_LOCAL_DIR} ${REMOTE_SSH_HOST}:/srv/htdocs/wp-content/mu-plugins/wpcomsh/vendor/automattic/wc-calypso-bridge/
    ```
3. Go to https://wordpress.com/settings/general/<your_site>
4. Make sure there is only a single `My Home` menu that points to /wp-admin/admin.php?page=wc-admin

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
