### PR TITLE
Replace WCS&T tax onboarding with Woo Tax onboarding.

### DIFF
--- a/includes/class-wc-calypso-bridge-addons-screen.php
+++ b/includes/class-wc-calypso-bridge-addons-screen.php
@@ -110,6 +110,8 @@ class WC_Calypso_Bridge_Addons_Screen extends WC_Admin_Addons {
 
 	/**
 	 * Install Woo Tax from Extensions screens.
+	 *
+	 * @since x.x.x
 	 */
 	public static function install_woo_tax_addon() {
 		check_admin_referer( 'install-addon_woocommerce-tax' );
@@ -128,6 +130,8 @@ class WC_Calypso_Bridge_Addons_Screen extends WC_Admin_Addons {
 
 	/**
 	 * Install Woo Shipping from Extensions screens.
+	 *
+	 * @since x.x.x
 	 */
 	public static function install_woo_shipping_addon() {
 		check_admin_referer( 'install-addon_woocommerce-shipping' );

--- a/includes/class-wc-calypso-bridge-addons-screen.php
+++ b/includes/class-wc-calypso-bridge-addons-screen.php
@@ -68,8 +68,12 @@ class WC_Calypso_Bridge_Addons_Screen extends WC_Admin_Addons {
 			return;
 		}
 
-		if ( isset( $_GET['install-addon'] ) && 'woocommerce-services' === $_GET['install-addon'] ) { // WPCS: CSRF ok.
-			self::install_woocommerce_services_addon();
+		if ( isset( $_GET['install-addon'] ) && 'woocommerce-tax' === $_GET['install-addon'] ) { // WPCS: CSRF ok.
+			self::install_woo_tax_addon();
+		}
+
+		if ( isset( $_GET['install-addon'] ) && 'woocommerce-shipping' === $_GET['install-addon'] ) { // WPCS: CSRF ok.
+			self::install_woo_shipping_addon();
 		}
 
 		$sections        = self::get_sections();
@@ -102,5 +106,41 @@ class WC_Calypso_Bridge_Addons_Screen extends WC_Admin_Addons {
 		 * @uses $current_section
 		 */
 		include_once WC_ABSPATH . 'includes/admin/views/html-admin-page-addons.php';
+	}
+
+	/**
+	 * Install Woo Tax from Extensions screens.
+	 */
+	public static function install_woo_tax_addon() {
+		check_admin_referer( 'install-addon_woocommerce-tax' );
+
+		$services_plugin_id = 'woocommerce-tax';
+		$services_plugin    = array(
+			'name'      => __( 'Woo Tax', 'woocommerce' ),
+			'repo-slug' => 'woocommerce-tax',
+		);
+
+		WC_Install::background_installer( $services_plugin_id, $services_plugin );
+
+		wp_safe_redirect( remove_query_arg( array( 'install-addon', '_wpnonce' ) ) );
+		exit;
+	}
+
+	/**
+	 * Install Woo Shipping from Extensions screens.
+	 */
+	public static function install_woo_shipping_addon() {
+		check_admin_referer( 'install-addon_woocommerce-shipping' );
+
+		$services_plugin_id = 'woocommerce-shipping';
+		$services_plugin    = array(
+			'name'      => __( 'Woo Shipping', 'woocommerce' ),
+			'repo-slug' => 'woocommerce-shipping',
+		);
+
+		WC_Install::background_installer( $services_plugin_id, $services_plugin );
+
+		wp_safe_redirect( remove_query_arg( array( 'install-addon', '_wpnonce' ) ) );
+		exit;
 	}
 }

--- a/includes/class-wc-calypso-bridge-plugins.php
+++ b/includes/class-wc-calypso-bridge-plugins.php
@@ -22,7 +22,8 @@ class WC_Calypso_Bridge_Plugins {
 	const WPCOM_ECOMMERCE_PLUGINS = array(
 		'woocommerce/woocommerce.php',
 		'facebook-for-woocommerce/facebook-for-woocommerce.php',
-		'woocommerce-services/woocommerce-services.php',
+		'woocommerce-tax/woocommerce-tax.php',
+		'woocommerce-shipping/woocommerce-shipping.php',
 		'woocommerce-product-addons/woocommerce-product-addons.php',
 		'woocommerce-product-bundles/woocommerce-product-bundles.php',
 		'woocommerce-gift-cards/woocommerce-gift-cards.php',

--- a/includes/notes/data/class-wc-calypso-bridge-admin-note-data-store.php
+++ b/includes/notes/data/class-wc-calypso-bridge-admin-note-data-store.php
@@ -164,6 +164,8 @@ class WC_Calypso_Bridge_Admin_Note_Data_Store extends DataStore {
 			'wc-admin-selling-online-courses', // suppress for now, to be revisited.
 			// Extensions.
 			'woocommerce-services',
+			'woocommerce-tax',
+			'woocommerce-shipping',
 			'gla-invalid-php-version',
 			'gla-64-bit',
 			'gla-wc-admin',

--- a/src/free-trial/tax/index.tsx
+++ b/src/free-trial/tax/index.tsx
@@ -112,7 +112,7 @@ export const Tax: React.FC< TaxProps > = ( { onComplete, query, task } ) => {
 			updateAndPersistSettingsForGroup( 'tax', {
 				tax: {
 					...taxSettings,
-					wc_connect_taxes_enabled: 'no',
+					woo_tax_taxes_enabled: 'no',
 				},
 			} );
 			updateAndPersistSettingsForGroup( 'general', {
@@ -138,7 +138,7 @@ export const Tax: React.FC< TaxProps > = ( { onComplete, query, task } ) => {
 				updateAndPersistSettingsForGroup( 'tax', {
 					tax: {
 						...taxSettings,
-						wc_connect_taxes_enabled: 'yes',
+						woo_tax_taxes_enabled: 'yes',
 					},
 				} ),
 				updateAndPersistSettingsForGroup( 'general', {

--- a/src/free-trial/tax/utils.ts
+++ b/src/free-trial/tax/utils.ts
@@ -7,7 +7,7 @@ import { TaskType } from '@woocommerce/data';
 /**
  * Plugins required to automate taxes.
  */
-export const AUTOMATION_PLUGINS = [ 'jetpack', 'woocommerce-services' ];
+export const AUTOMATION_PLUGINS = [ 'woocommerce-tax' ];
 
 /**
  * Check if a store has a complete address given general settings.

--- a/src/free-trial/tax/woocommerce-tax/card.tsx
+++ b/src/free-trial/tax/woocommerce-tax/card.tsx
@@ -17,7 +17,7 @@ import { TaxChildProps } from '../utils';
 export const Card: React.FC< TaxChildProps > = () => {
 	return (
 		<PartnerCard
-			name={ __( 'WooCommerce Tax', 'woocommerce' ) }
+			name={ __( 'WooC Tax', 'woocommerce' ) }
 			logo={ logo }
 			description={ __( 'Best for new stores', 'woocommerce' ) }
 			benefits={ [
@@ -31,29 +31,12 @@ export const Card: React.FC< TaxChildProps > = () => {
 						strong: <strong />,
 					},
 				} ),
-				interpolateComponents( {
-					mixedString: __(
-						'Powered by {{link}}Jetpack{{/link}}',
-						'woocommerce'
-					),
-					components: {
-						link: (
-							<Link
-								type="external"
-								href="https://woocommerce.com/products/jetpack/?utm_medium=product"
-								target="_blank"
-							>
-								<></>
-							</Link>
-						),
-					},
-				} ),
 				// eslint-disable-next-line @wordpress/i18n-translator-comments
 				__( '100% free', 'woocommerce' ),
 			] }
 			terms={ interpolateComponents( {
 				mixedString: __(
-					'By installing WooCommerce Tax and Jetpack you agree to the {{link}}Terms of Service{{/link}}.',
+					'By installing Woo Tax you agree to the {{link}}Terms of Service{{/link}}.',
 					'woocommerce'
 				),
 				components: {

--- a/src/free-trial/tax/woocommerce-tax/card.tsx
+++ b/src/free-trial/tax/woocommerce-tax/card.tsx
@@ -17,7 +17,7 @@ import { TaxChildProps } from '../utils';
 export const Card: React.FC< TaxChildProps > = () => {
 	return (
 		<PartnerCard
-			name={ __( 'WooC Tax', 'woocommerce' ) }
+			name={ __( 'Woo Tax', 'woocommerce' ) }
 			logo={ logo }
 			description={ __( 'Best for new stores', 'woocommerce' ) }
 			benefits={ [

--- a/src/free-trial/tax/woocommerce-tax/plugins.tsx
+++ b/src/free-trial/tax/woocommerce-tax/plugins.tsx
@@ -57,9 +57,9 @@ export const Plugins: React.FC< SetupStepProps > = ( {
 		nextStep();
 	}, [ isResolving ] );
 
-	const agreementText = pluginsToActivate.includes( 'woocommerce-services' )
+	const agreementText = pluginsToActivate.includes( 'woocommerce-tax' )
 		? __(
-				'By installing Jetpack and WooCommerce Tax you agree to the {{link}}Terms of Service{{/link}}.',
+				'By installing Woo Tax you agree to the {{link}}Terms of Service{{/link}}.',
 				'woocommerce'
 		  )
 		: __(

--- a/src/free-trial/tax/woocommerce-tax/setup.tsx
+++ b/src/free-trial/tax/woocommerce-tax/setup.tsx
@@ -106,7 +106,7 @@ export const Setup: React.FC< SetupProps > = ( {
 			key: 'connect',
 			label: __( 'Automate Taxes', 'woocommerce' ),
 			description: __(
-				'WooCommerce Tax can automate your sales tax calculations for you.',
+				'Woo Tax can automate your sales tax calculations for you.',
 				'woocommerce'
 			),
 			content: <AutomatedTaxes { ...stepProps } />,


### PR DESCRIPTION
### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Replace the WCS&T Tax onboarding with just Woo Tax.
- Remove the jetpack requirement from the tax onboarding and update wording in step.
- Added functionality to the addons screen override to handle installing Woo Tax and Woo Shipping for when we start supporting it via the addons screen.
- Added functionality to suppress any future Woo Shipping and Woo Tax messaging that will get added to WC core.

These changes form part of the work to roll out the new Woo Shipping and Woo Tax to WooExpress sites.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Testing instructions taken from #975 

**Test Woo Tax**

Click on "Yes please" and observe that you're redirected to Homescreen with Tax task completed
Go to WooCommerce > Settings > Tax
Observe that you have Enable automated taxes selected in the Automated taxes dropdown
Go to WooCommerce > Home > Tax task
Click on No thanks, I'll set up manually and observe that you're redirected to tax settings screen
Go to WooCommerce > Home > Tax task
Click on I don't charge sales tax
Observe that you're redirected to Homescreen with Tax task completed

**Test manual configuration**

Go to WooCommerce > Settings > General
Remove all address fields, set store country to "Malaysia - Johor" and save
Go to WooCommerce > Home > Tax task
Fill in all store address fields in Set store location and click on continue
Click on Configure and observe that you're redirected to tax settings
Go to WooCommerce > Settings > General
Observe that the store address values are saved from the values inserted in the previous form

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
