### PR TITLE
Entrepreneur Signup Flow: Update `is_woo_express` logic to consider eCommerce plan

### DIFF
--- a/class-wc-calypso-bridge-dotcom-features.php
+++ b/class-wc-calypso-bridge-dotcom-features.php
@@ -116,7 +116,7 @@ if ( ! function_exists( 'wc_calypso_bridge_is_woo_express_plan' ) ) {
 	 * @return bool True if the site is on the Woo Express plan.
 	 */
 	function wc_calypso_bridge_is_woo_express_plan() {
-		return wc_calypso_bridge_is_ecommerce_trial_plan() || wc_calypso_bridge_is_woo_express_essential_plan() || wc_calypso_bridge_is_woo_express_performance_plan();
+		return wc_calypso_bridge_is_ecommerce_plan() || wc_calypso_bridge_is_ecommerce_trial_plan() || wc_calypso_bridge_is_woo_express_essential_plan() || wc_calypso_bridge_is_woo_express_performance_plan();
 	}
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- make `wc_calypso_bridge_is_woo_express_plan()` return `true` even `wc_calypso_bridge_is_ecommerce_plan()` is `true` (i.e. when the site is upgraded to the normal eCommerce plan); this allows the user to the AI assembler.

| Before | After |
|--------|--------|
| ![Markup on 2024-04-25 at 11:18:56](https://github.com/Automattic/wc-calypso-bridge/assets/25105483/3df88f97-c815-423f-8e6c-da841a5eec86) | ![Markup on 2024-04-25 at 11:17:58](https://github.com/Automattic/wc-calypso-bridge/assets/25105483/014c2d8b-9915-48ba-9904-6d73ce14f51a) | 

ℹ️ Later (once the new flow is launched) we may want to update the naming of `wc_calypso_bridge_is_woo_express_plan()`; that's something we touched on briefly with @yansern when discussing the changes.

Post-merge TODO:

- [x] make sure the change is available in production in wpcomsh

---

Related PT: pdDOJh-3iE-p2.
Closes https://github.com/Automattic/wp-calypso/issues/89893.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Follow the steps outlined in pdDOJh-3ob-p2 and create a test site with Entrepreneur plan (the plan can be added through SA).
2. Navigate to the WooCommerce Admin page at `/wp-admin/admin.php?page=wc-admin` and check that the AI tool is not available in the launchpad (_Before_ screenshot above).
3. Check out the changes proposed in this PR and sync them to your test site (pdDOJh-3ob-p2 → section titled "Sync to your WoA test site").
4. Reload the WooCommerce Admin page at `/wp-admin/admin.php?page=wc-admin`.
5. The AI tool should now be available in the launchpad (_After_ screenshot above). Try to click the CTA button and use the AI tool. It should work correctly.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.