### PR TITLE
Entrepreneur my home goes to Calypso instead

### DIFF
--- a/.sshyncignore
+++ b/.sshyncignore
@@ -1,0 +1,7 @@
+.git
+node_modules/
+tests/
+vendor/
+.cache/
+.idea
+.config

--- a/.sshyncignore
+++ b/.sshyncignore
@@ -1,7 +1,0 @@
-.git
-node_modules/
-tests/
-vendor/
-.cache/
-.idea
-.config

--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -664,6 +664,18 @@ class WC_Calypso_Bridge_Ecommerce_Admin_Menu extends WC_Calypso_Bridge_Base_Admi
 	 */
 	protected function has_entrepreneur_plan() {
 		$current_plan = get_option( 'jetpack_active_plan',  array() );
-		return ! empty( $current_plan ) && 'ecommerce-bundle' === $current_plan['product_slug'];
+		if ( empty( $current_plan ) ) {
+			return false;
+		}
+
+		$entrepreneur_plans = [
+			'ecommerce-bundle-monthly',
+			'ecommerce-bundle',
+			'ecommerce-bundle-2y',
+			'ecommerce-bundle-3y',
+			'ecommerce-trial-bundle-monthly',
+		];
+
+		return in_array( $current_plan['product_slug'], $entrepreneur_plans, true );
 	}
 }

--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -262,6 +262,18 @@ class WC_Calypso_Bridge_Ecommerce_Admin_Menu extends WC_Calypso_Bridge_Base_Admi
 			'wpcom-hosting-menu',
 			esc_url( "https://wordpress.com/home/{$this->domain}" )
 		);
+
+		// If we have entrepreneur plan, we change the url of home
+		if ( $this->has_entrepreneur_plan() ) {
+			$this->update_menu(
+				'index.php',
+				'https://wordpress.com/home/' . $this->domain . '?flags=entrepreneur-my-home',
+				$label,
+				'edit_posts',
+				'dashicons-admin-home'
+			);
+			remove_submenu_page( 'index.php', 'admin.php?page=wc-admin' );
+		}
 	}
 
 	/**
@@ -643,5 +655,15 @@ class WC_Calypso_Bridge_Ecommerce_Admin_Menu extends WC_Calypso_Bridge_Base_Admi
 				return ( $A < $B ) ? -1 : 1;
 			} );
 		}
+	}
+
+	/**
+	 * Check if the site has Entrepreneur plan
+	 *
+	 * @return bool
+	 */
+	protected function has_entrepreneur_plan() {
+		$current_plan = get_option( 'jetpack_active_plan',  array() );
+		return ! empty( $current_plan ) && 'ecommerce-bundle' === $current_plan['product_slug'];
 	}
 }


### PR DESCRIPTION
☢️☢️☢️ Don't merge yet ☢️☢️☢️

### Changes proposed in this Pull Request:

This PR changes the URL of My Home link in the main menu. If the site plan is Entrepreneur, that link will go to Calypso My Home instead.

Closes https://github.com/Automattic/dotcom-forge/issues/6932

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Apply these changes locally.
2. Follow these instructions to sync with your staging site: pdDOJh-3ob-p2
3. Go to your staging site and click My Home in the main menu.
4. You should go to Calypso My Home with a feature flag. Note: the feature flag won't be required once all the changes related to the new Entrepreneur plan are merged and deployed to production. 

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.