### PR TITLE
Show launch your site missing page for entrepreneur trial plan

### DIFF
--- a/includes/tasks/class-wc-calypso-task-launch-site.php
+++ b/includes/tasks/class-wc-calypso-task-launch-site.php
@@ -93,13 +93,4 @@ class LaunchSite extends Task {
 		);
 		return in_array( $launch_status, $launched_values, true );
 	}
-
-	/**
-	 * The task should not be displayed if the site is on the eCommerce trial.
-	 *
-	 * @return bool
-	 */
-	public function can_view() {
-		return ! wc_calypso_bridge_is_ecommerce_trial_plan();
-	}
 }


### PR DESCRIPTION
☢️☢️☢️ Don't merge yet ☢️☢️☢️

### Changes proposed in this Pull Request:
This PR makes visible the launch site page for sites with the Entrepreneur Trial plan.

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Apply these changes locally.
2. Follow these instructions to sync with your staging site: pdDOJh-3ob-p2 . Note: instead of a proper entrepreneur plan, you should assign a WooCommerce Trial plan.
3. Go to https://wordpress.com/home/[yoursitehere].wpcomstaging.com?flags=entrepreneur-my-home
4. You should go to Calypso My Home with a feature flag. Click on "Launch your store" in the launch pad. You should see the `Before you launch` screen.
<img width="723" alt="Screenshot 2024-05-13 at 21 59 36" src="https://github.com/Automattic/wc-calypso-bridge/assets/3832570/6934aa51-1259-4566-ba8f-d9c69cb572f1">


<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.