### PR TITLE
eCommerce Signup Flow: Update eCommerce plan Welcome note

### DIFF
--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -127,11 +127,6 @@ class WC_Calypso_Bridge_Setup {
 
 				$wp_admin_bar->remove_menu( 'ab-new-post' );
 			}, PHP_INT_MAX );
-
-			add_action( 'wp_before_admin_bar_render', function () {
-				include_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/notes/class-wc-calypso-bridge-free-trial-welcome.php';
-				WC_Calypso_Bridge_Free_Trial_Welcome_Note::possibly_add_note();
-			}, PHP_INT_MAX );
 		}
 	}
 

--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -127,6 +127,11 @@ class WC_Calypso_Bridge_Setup {
 
 				$wp_admin_bar->remove_menu( 'ab-new-post' );
 			}, PHP_INT_MAX );
+
+			add_action( 'wp_before_admin_bar_render', function () {
+				include_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/notes/class-wc-calypso-bridge-free-trial-welcome.php';
+				WC_Calypso_Bridge_Free_Trial_Welcome_Note::possibly_add_note();
+			}, PHP_INT_MAX );
 		}
 	}
 

--- a/includes/notes/class-wc-calypso-bridge-free-trial-welcome.php
+++ b/includes/notes/class-wc-calypso-bridge-free-trial-welcome.php
@@ -78,8 +78,6 @@ class WC_Calypso_Bridge_Free_Trial_Welcome_Note {
 			return;
 		}
 
-		self::possibly_delete_note();
-
 		if ( self::note_exists() ) {
 			return false;
 		}

--- a/includes/notes/class-wc-calypso-bridge-free-trial-welcome.php
+++ b/includes/notes/class-wc-calypso-bridge-free-trial-welcome.php
@@ -70,7 +70,7 @@ class WC_Calypso_Bridge_Free_Trial_Welcome_Note {
 	 */
 	public static function can_be_added() {
 		// Temporarily disable Welcome note; context: p1715940056147799/1715859215.173039-slack-C06RQ4EQ7V2.
-		return true;
+		return false;
 
 		$note = self::get_note();
 

--- a/includes/notes/class-wc-calypso-bridge-free-trial-welcome.php
+++ b/includes/notes/class-wc-calypso-bridge-free-trial-welcome.php
@@ -34,14 +34,21 @@ class WC_Calypso_Bridge_Free_Trial_Welcome_Note {
 	 */
 	public static function get_note() {
 
-		$note = new Note();
-		$note->set_title( __( 'Your Woo Express free trial has just started', 'wc-calypso-bridge' ) );
-		$note->set_content(
-			__(
-				'Welcome to your 14-day free trial of Woo Express – everything you need to start and grow a successful online business, all in one place. The journey toward your first sale has just begun! Ready to explore?',
-				'wc-calypso-bridge'
-			)
+		$current_plan       = get_option( 'jetpack_active_plan',  array() );
+		$product_name_short = $current_plan[ 'product_name_short' ];
+
+		/* translators: %s: trial plan name, e.g. Entrepreneur */
+		$note_title = sprintf( __( 'Your %s free trial has just started', 'wc-calypso-bridge' ), $product_name_short );
+
+		/* translators: %s: trial plan name, e.g. Entrepreneur */
+		$note_content = sprintf(
+			__( 'Welcome to your 14-day free trial of the %s plan – everything you need to start and grow a successful online business, all in one place. The journey toward your first sale has just begun! Ready to explore?', 'wc-calypso-bridge' ),
+			$product_name_short
 		);
+
+		$note = new Note();
+		$note->set_title( $note_title );
+		$note->set_content( $note_content );
 		$note->set_content_data( (object) array() );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );

--- a/includes/notes/class-wc-calypso-bridge-free-trial-welcome.php
+++ b/includes/notes/class-wc-calypso-bridge-free-trial-welcome.php
@@ -70,13 +70,15 @@ class WC_Calypso_Bridge_Free_Trial_Welcome_Note {
 	 */
 	public static function can_be_added() {
 		// Temporarily disable Welcome note; context: p1715940056147799/1715859215.173039-slack-C06RQ4EQ7V2.
-		return false;
+		return true;
 
 		$note = self::get_note();
 
 		if ( ! $note instanceof Note && ! $note instanceof WC_Admin_Note ) {
 			return;
 		}
+
+		self::possibly_delete_note();
 
 		if ( self::note_exists() ) {
 			return false;

--- a/includes/notes/class-wc-calypso-bridge-free-trial-welcome.php
+++ b/includes/notes/class-wc-calypso-bridge-free-trial-welcome.php
@@ -69,6 +69,9 @@ class WC_Calypso_Bridge_Free_Trial_Welcome_Note {
 	 * @return bool
 	 */
 	public static function can_be_added() {
+		// Temporarily disable Welcome note; context: p1715940056147799/1715859215.173039-slack-C06RQ4EQ7V2.
+		return false;
+
 		$note = self::get_note();
 
 		if ( ! $note instanceof Note && ! $note instanceof WC_Admin_Note ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- change the copy of the eCommerce plan Welcome note
- disable the Welcome note until the translations are finished; we are going to create a subsequent PR that will enable the Welcome note again in about two weeks (more context and reasoning: p1715940056147799/1715859215.173039-slack-C06RQ4EQ7V2)

![Markup on 2024-05-17 at 16:33:16](https://github.com/Automattic/wc-calypso-bridge/assets/25105483/a4fbe1d7-386c-4ffb-9b12-e96442d0a532)

Related to https://github.com/Automattic/dotcom-forge/issues/7220

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

The changes proposed in this PR are targeting Entrepreneur Trial plan, however, due to technical limitations, we will only perform a partial test on a "full" Entrepreneur plan site.

If you don't have your WoA test site yet, please follow the steps outlined in pdDOJh-3ob-p2 and create a test site with Entrepreneur plan (the plan can be added through the SA).

1. Check out the PR and sync it with your WoA test site on an Entrepreneur plan.
2. Revert the last two commits to apply the temporary test code:
  - `git revert 063b1660714c917fa0f78b45c9a0fe4152c4c5e3`
  - `git revert 6352e53ed72aa98eef473ef156991f2c8af42183`
(I wanted to keep the changes in one commit, but forgot one line)
3. Navigate to `/wp-admin/admin.php?page=wc-admin` and review the Welcome note. It should include correct copy - as can be seen in the screenshot above.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.