### PR TITLE
i18n: Load script translations

### DIFF
--- a/class-wc-calypso-bridge-shared.php
+++ b/class-wc-calypso-bridge-shared.php
@@ -106,7 +106,7 @@ class WC_Calypso_Bridge_Shared {
 			return $relative;
 		});
 
-		wp_set_script_translations( 'wc-calypso-bridge', 'wc-calypso-bridge'  );
+		wp_set_script_translations( 'wc-calypso-bridge', 'wc-calypso-bridge', WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/languages' );
 
 		$style_path     = 'build/style-index.css';
 		$style_path_url = plugins_url( $style_path, __FILE__ );

--- a/class-wc-calypso-bridge-shared.php
+++ b/class-wc-calypso-bridge-shared.php
@@ -97,6 +97,17 @@ class WC_Calypso_Bridge_Shared {
 			true
 		);
 
+		// Rewrite script relative path when used as dependency to calculate the right filename.
+		add_filter( 'load_script_textdomain_relative_path', function( $relative ) {
+			if ( $relative === 'vendor/automattic/wc-calypso-bridge/build/index.js' ) {
+				return 'build/index.js';
+			}
+
+			return $relative;
+		});
+
+		wp_set_script_translations( 'wc-calypso-bridge', 'wc-calypso-bridge'  );
+
 		$style_path     = 'build/style-index.css';
 		$style_path_url = plugins_url( $style_path, __FILE__ );
 		$res            = wp_register_style(

--- a/class-wc-calypso-bridge-shared.php
+++ b/class-wc-calypso-bridge-shared.php
@@ -134,6 +134,10 @@ class WC_Calypso_Bridge_Shared {
 			'wcpayConnectUrl'              => 'admin.php?page=wc-admin&path=%2Fpayments%2Fconnect&wcpay-connect=1&_wpnonce=' . wp_create_nonce( 'wcpay-connect' ),
 			'hasViewedPayments'            => get_option( 'wc_calypso_bridge_payments_view_welcome_timestamp', false ) !== false,
 			'version'                      => WC_CALYPSO_BRIDGE_CURRENT_VERSION,
+			'i18n'                         => array(
+				'baseUrl' => plugins_url( '/languages', __FILE__ ),
+				'locale' => get_user_locale(),
+			),
 		);
 
 		/**

--- a/languages/wc-calypso-bridge.pot
+++ b/languages/wc-calypso-bridge.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2024-05-21T16:06:16+00:00\n"
+"POT-Creation-Date: 2024-05-23T09:16:18+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.10.0\n"
 
@@ -101,7 +101,6 @@ msgstr ""
 
 #: includes/class-wc-calypso-bridge-ecommerce-admin-menu.php:390
 #: build/payment-gateway-suggestions.js:1
-#: src/payment-gateway-suggestions/components/Action.js:76
 msgid "Manage"
 msgstr ""
 
@@ -281,7 +280,6 @@ msgstr ""
 #: build/index.js:11
 #: build/marketing.js:1
 #: build/plugins.js:1
-#: src/introductory-offer-banner/index.js:87
 msgid "Upgrade now"
 msgstr ""
 
@@ -295,7 +293,6 @@ msgstr ""
 #: includes/free-trial/class-wc-calypso-bridge-free-trial-plugins-screen.php:59
 #: includes/free-trial/class-wc-calypso-bridge-free-trial-plugins-screen.php:61
 #: build/index.js:11
-#: src/index.js:220
 msgid "Plugins"
 msgstr ""
 
@@ -336,9 +333,6 @@ msgstr ""
 #: includes/tasks/class-wc-calypso-task-add-domain.php:94
 #: build/index.js:1
 #: build/index.js:3
-#: src/launch-store/index.js:322
-#: src/task-headers/add-domain.js:31
-#: src/task-headers/add-domain.js:44
 msgid "Add a domain"
 msgstr ""
 
@@ -354,7 +348,6 @@ msgstr ""
 #: includes/tasks/class-wc-calypso-task-appearance.php:50
 #: includes/tasks/class-wc-calypso-task-get-paid-with-square.php:50
 #: build/index.js:3
-#: src/task-headers/products.js:46
 msgid "2 minutes"
 msgstr ""
 
@@ -411,7 +404,6 @@ msgstr ""
 #: includes/tasks/class-wc-calypso-task-launch-site.php:38
 #: includes/tasks/class-wc-calypso-task-launch-site.php:68
 #: build/index.js:1
-#: src/launch-store/index.js:155
 msgid "Launch your store"
 msgstr ""
 
@@ -623,36 +615,26 @@ msgstr ""
 
 #: build/53.js:1
 #: build/index.js:3
-#: src/free-trial/fills/task-headers/payments.js:22
-#: src/free-trial/fills/task-headers/woocommerce-payments.js:29
-#: src/task-headers/get-paid-with-square.js:22
 msgid "Payment illustration"
 msgstr ""
 
 #: build/53.js:1
-#: src/free-trial/fills/task-headers/payments.js:34
-#: src/free-trial/fills/task-headers/woocommerce-payments.js:41
 msgid "It’s time to test payments"
 msgstr ""
 
 #: build/53.js:1
-#: src/free-trial/fills/task-headers/payments.js:40
 msgid "Give your customers an easy and convenient way to pay! Set up and test some of our fast and secure online or in person payment methods."
 msgstr ""
 
 #: build/53.js:1
-#: src/free-trial/fills/task-headers/payments.js:50
-#: src/free-trial/fills/task-headers/woocommerce-payments.js:84
 msgid "Test payments"
 msgstr ""
 
 #: build/53.js:1
-#: src/free-trial/fills/task-headers/woocommerce-payments.js:54
 msgid "Power your payments with a simple, all-in-one option. Verify your business details to start testing transactions with WooCommerce Payments."
 msgstr ""
 
 #: build/53.js:1
-#: src/free-trial/fills/task-headers/woocommerce-payments.js:62
 msgid "By clicking \"Test payments\", you agree to the {{tosLink}}Terms of Service{{/tosLink}}"
 msgstr ""
 
@@ -681,94 +663,74 @@ msgid "Setup required"
 msgstr ""
 
 #: build/index.js:1
-#: src/launch-store/index.js:71
 msgid "Copied"
 msgstr ""
 
 #: build/index.js:1
-#: src/launch-store/index.js:142
 msgid "Launching your store"
 msgstr ""
 
 #: build/index.js:1
-#: src/launch-store/index.js:182
 msgid "Woo! You did it!"
 msgstr ""
 
 #: build/index.js:1
-#: src/launch-store/index.js:186
 msgid "Congratulations on launching your WooCommerce store. Take a moment to celebrate and share the news!"
 msgstr ""
 
 #: build/index.js:1
-#: src/launch-store/index.js:206
 msgid "View your store"
 msgstr ""
 
 #: build/index.js:1
-#: src/launch-store/index.js:212
 msgid "Changed your mind? You can make your store private again by updating your <a>Privacy</a> settings."
 msgstr ""
 
 #: build/index.js:1
-#: src/launch-store/index.js:247
 msgid "Ready to launch your store?"
 msgstr ""
 
 #: build/index.js:1
-#: src/launch-store/index.js:250
 msgid "It's time to celebrate – you're ready to launch your store! Woo!"
 msgstr ""
 
 #: build/index.js:1
-#: src/launch-store/index.js:262
-#: src/launch-store/index.js:398
 msgid "You can always revert this under <a>Settings</a>."
 msgstr ""
 
 #: build/index.js:1
-#: src/launch-store/index.js:300
-#: src/launch-store/index.js:305
 msgid "Get paid"
 msgstr ""
 
 #: build/index.js:1
-#: src/launch-store/index.js:301
 msgid "Give your customers an easy and convenient way to pay! Set up one (or more!) of our fast and secure online or in person payment methods."
 msgstr ""
 
 #: build/index.js:1
-#: src/launch-store/index.js:309
 msgid "List your products"
 msgstr ""
 
 #: build/index.js:1
-#: src/launch-store/index.js:310
 msgid "Start selling by adding products or services to your store. Create your products manually, or import them from an existing store."
 msgstr ""
 
 #: build/index.js:1
-#: src/launch-store/index.js:314
 msgid "List products"
 msgstr ""
 
 #: build/index.js:1
-#: src/launch-store/index.js:318
 msgid "Choose an address for your new website or transfer a domain you already own."
 msgstr ""
 
 #: build/index.js:1
-#: src/launch-store/index.js:379
 msgid "Before you launch"
 msgstr ""
 
 #: build/index.js:1
-#: src/launch-store/index.js:382
 msgid "A few things to check before launching your store"
 msgstr ""
 
 #: build/index.js:1
-#: src/launch-store/index.js:392
 msgid "Launch anyway"
 msgstr ""
 
@@ -776,40 +738,30 @@ msgstr ""
 #: build/payment-gateway-suggestions.js:1
 #: build/payment-gateway-suggestions.js:2
 #: build/payment-gateway-suggestions.js:3
-#: src/payment-gateway-suggestions/components/Action.js:27
-#: src/payment-gateway-suggestions/components/Setup/Configure.js:159
-#: src/payment-gateway-suggestions/components/WCPay/Suggestion.js:134
-#: src/welcome-modal/index.js:59
 msgid "Get started"
 msgstr ""
 
 #: build/index.js:1
-#: src/welcome-modal/index.js:64
 msgid "Welcome modal navigation illustration 2"
 msgstr ""
 
 #: build/index.js:1
-#: src/welcome-modal/index.js:77
 msgid "Meet your new Home"
 msgstr ""
 
 #: build/index.js:1
-#: src/welcome-modal/index.js:83
 msgid "Get tips and insights on your store’s performance every time you jump back into your WordPress.com dashboard."
 msgstr ""
 
 #: build/index.js:1
-#: src/welcome-modal/index.js:94
 msgid "Welcome modal navigation illustration 1"
 msgstr ""
 
 #: build/index.js:1
-#: src/welcome-modal/index.js:107
 msgid "Move faster with our new navigation"
 msgstr ""
 
 #: build/index.js:1
-#: src/welcome-modal/index.js:114
 msgid "Getting things done with WooCommerce just got faster. <a>Learn more</a> about our new navigation — or go ahead and explore on your own."
 msgstr ""
 
@@ -882,12 +834,10 @@ msgid "City"
 msgstr ""
 
 #: build/index.js:1
-#: src/free-trial/tax/components/location.js:23
 msgid "Continue"
 msgstr ""
 
 #: build/index.js:1
-#: src/free-trial/tax/components/location.js:56
 msgid "There was a problem saving your store location"
 msgstr ""
 
@@ -1018,42 +968,34 @@ msgid "Everything is looking great, keep it up!"
 msgstr ""
 
 #: build/index.js:3
-#: src/task-headers/add-domain.js:22
 msgid "Add a domain illustration"
 msgstr ""
 
 #: build/index.js:3
-#: src/task-headers/add-domain.js:34
 msgid "Choose a new website address for your store or transfer one you already own."
 msgstr ""
 
 #: build/index.js:3
-#: src/task-headers/products.js:26
 msgid "Products illustration"
 msgstr ""
 
 #: build/index.js:3
-#: src/task-headers/appearance.js:29
 msgid "Appearance illustration"
 msgstr ""
 
 #: build/index.js:3
-#: src/task-headers/get-paid-with-square.js:34
 msgid "It's time to get paid"
 msgstr ""
 
 #: build/index.js:3
-#: src/task-headers/get-paid-with-square.js:40
 msgid "Accepting payments is easy with Square. Sell online and in person, and sync all payments, customers, items, and inventory."
 msgstr ""
 
 #: build/index.js:3
-#: src/task-headers/get-paid-with-square.js:53
 msgid "Set up Square"
 msgstr ""
 
 #: build/index.js:3
-#: src/introductory-offer-banner/index.js:69
 msgid "Start selling — for less!"
 msgstr ""
 
@@ -1094,27 +1036,22 @@ msgid "Upgrade your plan for %(formattedPrice)s for your first %(intervalCount)s
 msgstr ""
 
 #: build/index.js:11
-#: src/introductory-offer-banner/index.js:91
 msgid "Dismiss this banner."
 msgstr ""
 
 #: build/index.js:11
-#: src/homescreen-banner/index.js:45
 msgid "This is your free trial test store where you can start exploring what's available! To find out more about the free trial, click \"Learn more\"."
 msgstr ""
 
 #: build/index.js:11
-#: src/homescreen-banner/index.js:57
 msgid "Learn more"
 msgstr ""
 
 #: build/index.js:11
-#: src/homescreen-banner/index.js:61
 msgid "Dismiss this free trial informational banner."
 msgstr ""
 
 #: build/index.js:11
-#: src/payment-gateway-suggestions/components/WCPay/utils.js:15
 msgid "There was an error connecting to WooCommerce Payments. Please try again or connect later in store settings."
 msgstr ""
 
@@ -1175,80 +1112,64 @@ msgid "Create digital gift cards"
 msgstr ""
 
 #: build/payment-gateway-suggestions.js:1
-#: src/payment-gateway-suggestions/components/Action.js:99
 msgid "Enable"
 msgstr ""
 
 #: build/payment-gateway-suggestions.js:1
-#: src/payment-gateway-suggestions/components/Action.js:138
 msgid "Finish setup"
 msgstr ""
 
 #: build/payment-gateway-suggestions.js:1
-#: src/payment-gateway-suggestions/components/List/Item.js:80
 msgid "Local Partner"
 msgstr ""
 
 #: build/payment-gateway-suggestions.js:1
-#: src/payment-gateway-suggestions/components/List/Item.js:81
 msgid "Recommended"
 msgstr ""
 
 #. translators: %s = title of the payment gateway
 #: build/payment-gateway-suggestions.js:2
-#: src/payment-gateway-suggestions/components/Setup/Configure.js:75
 msgid "%s configured successfully"
 msgstr ""
 
 #: build/payment-gateway-suggestions.js:2
-#: src/payment-gateway-suggestions/components/Setup/Configure.js:84
-#: src/payment-gateway-suggestions/plugins/Bacs.js:63
 msgid "There was a problem saving your payment settings"
 msgstr ""
 
 #: build/payment-gateway-suggestions.js:2
-#: src/payment-gateway-suggestions/components/Setup/Configure.js:100
 msgid "Proceed"
 msgstr ""
 
 #: build/payment-gateway-suggestions.js:2
-#: src/payment-gateway-suggestions/components/Setup/Configure.js:133
 msgid "Connect"
 msgstr ""
 
 #: build/payment-gateway-suggestions.js:2
-#: src/payment-gateway-suggestions/components/Setup/Configure.js:152
 msgid "You can manage this payment gateway's settings by clicking the button below"
 msgstr ""
 
 #. translators: %s = title of the payment gateway to install
 #: build/payment-gateway-suggestions.js:3
-#: src/payment-gateway-suggestions/components/Setup/Setup.js:88
 msgid "Install %s"
 msgstr ""
 
 #: build/payment-gateway-suggestions.js:3
-#: src/payment-gateway-suggestions/components/Setup/Setup.js:120
 msgid "Configure your %(title)s account"
 msgstr ""
 
 #: build/payment-gateway-suggestions.js:3
-#: src/payment-gateway-suggestions/components/WCPay/Suggestion.js:36
 msgid "Get ready to accept payments"
 msgstr ""
 
 #: build/payment-gateway-suggestions.js:3
-#: src/payment-gateway-suggestions/components/WCPay/Suggestion.js:46
 msgid "By using WooCommerce Payments you agree to be bound by our {{tosLink}}Terms of Service{{/tosLink}} and acknowledge that you have read our {{privacyLink}}Privacy Policy{{/privacyLink}} "
 msgstr ""
 
 #: build/payment-gateway-suggestions.js:3
-#: src/payment-gateway-suggestions/components/WCPay/Modal.js:50
 msgid "There was a problem updating your preferences"
 msgstr ""
 
 #: build/payment-gateway-suggestions.js:3
-#: src/payment-gateway-suggestions/components/WCPay/Modal.js:109
 msgid "Build a better WooCommerce"
 msgstr ""
 
@@ -1257,59 +1178,46 @@ msgid "Get improved features and faster fixes by sharing non-sensitive data via 
 msgstr ""
 
 #: build/payment-gateway-suggestions.js:3
-#: src/payment-gateway-suggestions/components/WCPay/Modal.js:126
-#: src/payment-gateway-suggestions/components/WCPay/UsageModal.js:55
 msgid "No thanks"
 msgstr ""
 
 #: build/payment-gateway-suggestions.js:3
-#: src/payment-gateway-suggestions/components/WCPay/Modal.js:127
 msgid "Yes, count me in!"
 msgstr ""
 
 #: build/payment-gateway-suggestions.js:3
-#: src/payment-gateway-suggestions/index.js:213
 msgid "Choose a payment provider"
 msgstr ""
 
 #: build/payment-gateway-suggestions.js:3
-#: src/payment-gateway-suggestions/index.js:217
 msgid "To get ready to accept online payments"
 msgstr ""
 
 #: build/payment-gateway-suggestions.js:3
-#: src/payment-gateway-suggestions/index.js:223
 msgid "Additional payment options"
 msgstr ""
 
 #: build/payment-gateway-suggestions.js:3
-#: src/payment-gateway-suggestions/index.js:227
 msgid "Give your customers additional choices in ways to pay."
 msgstr ""
 
 #: build/payment-gateway-suggestions.js:3
-#: src/payment-gateway-suggestions/index.js:232
-#: src/payment-gateway-suggestions/index.js:311
 msgid "Other payment providers"
 msgstr ""
 
 #: build/payment-gateway-suggestions.js:3
-#: src/payment-gateway-suggestions/index.js:236
 msgid "Try one of the alternative payment providers."
 msgstr ""
 
 #: build/payment-gateway-suggestions.js:3
-#: src/payment-gateway-suggestions/index.js:257
 msgid "See more"
 msgstr ""
 
 #: build/payment-gateway-suggestions.js:3
-#: src/payment-gateway-suggestions/index.js:266
 msgid "Offline payment methods"
 msgstr ""
 
 #: build/payment-gateway-suggestions.js:3
-#: src/payment-gateway-suggestions/index.js:285
 msgid "Only Administrators and Store Managers can place orders during the free trial. {{link}}Upgrade to a paid plan{{/link}} to accept payments from customers and explore more payment options."
 msgstr ""
 
@@ -1355,60 +1263,4 @@ msgstr ""
 
 #: build/plugins.js:1
 msgid "Hire an expert"
-msgstr ""
-
-#: src/payment-gateway-suggestions/components/WCPay/UsageModal.js:29
-msgid "Help us build a better WooCommerce Payments experience"
-msgstr ""
-
-#: src/payment-gateway-suggestions/components/WCPay/UsageModal.js:34
-msgid "By agreeing to share non-sensitive {{link}}usage data{{/link}}, you’ll help us improve features and optimize the WooCommerce Payments experience. You can opt out at any time."
-msgstr ""
-
-#: src/payment-gateway-suggestions/components/WCPay/UsageModal.js:54
-msgid "I agree"
-msgstr ""
-
-#: src/payment-gateway-suggestions/plugins/Bacs.js:32
-msgid "Please enter an account number or IBAN"
-msgstr ""
-
-#: src/payment-gateway-suggestions/plugins/Bacs.js:53
-msgid "Direct bank transfer details added successfully"
-msgstr ""
-
-#: src/payment-gateway-suggestions/plugins/Bacs.js:86
-msgid "Add your bank details"
-msgstr ""
-
-#: src/payment-gateway-suggestions/plugins/Bacs.js:92
-msgid "These details are required to receive payments via bank transfer"
-msgstr ""
-
-#: src/payment-gateway-suggestions/plugins/Bacs.js:99
-msgid "Account name"
-msgstr ""
-
-#: src/payment-gateway-suggestions/plugins/Bacs.js:109
-msgid "Account number"
-msgstr ""
-
-#: src/payment-gateway-suggestions/plugins/Bacs.js:119
-msgid "Bank name"
-msgstr ""
-
-#: src/payment-gateway-suggestions/plugins/Bacs.js:129
-msgid "Sort code"
-msgstr ""
-
-#: src/payment-gateway-suggestions/plugins/Bacs.js:139
-msgid "IBAN"
-msgstr ""
-
-#: src/payment-gateway-suggestions/plugins/Bacs.js:147
-msgid "BIC / Swift"
-msgstr ""
-
-#: src/payment-gateway-suggestions/plugins/Bacs.js:160
-msgid "Save"
 msgstr ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,12 +21,14 @@
 			},
 			"devDependencies": {
 				"@automattic/color-studio": "^2.5.0",
+				"@automattic/i18n-loader-webpack-plugin": "^2.0.51",
 				"@testing-library/jest-dom": "^5.16.5",
 				"@testing-library/react": "^12.1.5",
 				"@woocommerce/dependency-extraction-webpack-plugin": "^2.2.0",
 				"@woocommerce/eslint-plugin": "^2.2.0",
 				"@wordpress/prettier-config": "^2.14.0",
 				"@wordpress/scripts": "^24.6.0",
+				"crypto-js": "^4.2.0",
 				"husky": "^8.0.3",
 				"prettier": "npm:wp-prettier@^2.8.5",
 				"typescript": "^4.9.5"
@@ -205,6 +207,18 @@
 				"supports-color": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@automattic/i18n-loader-webpack-plugin": {
+			"version": "2.0.51",
+			"resolved": "https://registry.npmjs.org/@automattic/i18n-loader-webpack-plugin/-/i18n-loader-webpack-plugin-2.0.51.tgz",
+			"integrity": "sha512-xZqr3Q+hACPSr09pfLevvC9E4coBjDRS2jHF7R70+xgHHkvR1D+z4AtIHzjqXlNbF5+Ln3fsWiAV6mxSzhAVcw==",
+			"dev": true,
+			"dependencies": {
+				"debug": "^4.3.2"
+			},
+			"peerDependencies": {
+				"webpack": "^5.29.0"
 			}
 		},
 		"node_modules/@automattic/i18n-utils": {
@@ -11455,6 +11469,12 @@
 			"engines": {
 				"node": "*"
 			}
+		},
+		"node_modules/crypto-js": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+			"integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+			"dev": true
 		},
 		"node_modules/css-declaration-sorter": {
 			"version": "6.4.0",
@@ -25744,6 +25764,15 @@
 				}
 			}
 		},
+		"@automattic/i18n-loader-webpack-plugin": {
+			"version": "2.0.51",
+			"resolved": "https://registry.npmjs.org/@automattic/i18n-loader-webpack-plugin/-/i18n-loader-webpack-plugin-2.0.51.tgz",
+			"integrity": "sha512-xZqr3Q+hACPSr09pfLevvC9E4coBjDRS2jHF7R70+xgHHkvR1D+z4AtIHzjqXlNbF5+Ln3fsWiAV6mxSzhAVcw==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.3.2"
+			}
+		},
 		"@automattic/i18n-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@automattic/i18n-utils/-/i18n-utils-1.0.1.tgz",
@@ -34468,6 +34497,12 @@
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
 			"integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
+		},
+		"crypto-js": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+			"integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+			"dev": true
 		},
 		"css-declaration-sorter": {
 			"version": "6.4.0",

--- a/package.json
+++ b/package.json
@@ -29,12 +29,14 @@
 	],
 	"devDependencies": {
 		"@automattic/color-studio": "^2.5.0",
+		"@automattic/i18n-loader-webpack-plugin": "^2.0.51",
 		"@testing-library/jest-dom": "^5.16.5",
 		"@testing-library/react": "^12.1.5",
 		"@woocommerce/dependency-extraction-webpack-plugin": "^2.2.0",
 		"@woocommerce/eslint-plugin": "^2.2.0",
 		"@wordpress/prettier-config": "^2.14.0",
 		"@wordpress/scripts": "^24.6.0",
+		"crypto-js": "^4.2.0",
 		"husky": "^8.0.3",
 		"prettier": "npm:wp-prettier@^2.8.5",
 		"typescript": "^4.9.5"

--- a/scripts/commands/update-translations.js
+++ b/scripts/commands/update-translations.js
@@ -145,6 +145,11 @@ export default async function updateTranslations() {
 						'.mo'
 					) }`
 				);
+
+				await execPromise(
+					`${ wpPath } i18n make-json ${ LANG_FILENAME }`
+				);
+
 				success( `${ LANG_FILENAME } compiled successfully.` );
 			} catch ( err ) {
 				error(

--- a/scripts/commands/update-translations.js
+++ b/scripts/commands/update-translations.js
@@ -56,7 +56,7 @@ export default async function updateTranslations() {
 
 		// If the `wp i18n make-pot` command generates an error, an exception is thrown
 		await execPromise(
-			`${ wpPath } i18n make-pot . ${ POT_FILE_PATH } --ignore-domain`
+			`${ wpPath } i18n make-pot . ${ POT_FILE_PATH } --ignore-domain --exclude=src`
 		);
 		success( 'wp i18n make-pot command executed successfully.' );
 

--- a/src/i18n-loader.js
+++ b/src/i18n-loader.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import md5 from 'crypto-js/md5';
+import { setLocaleData } from '@wordpress/i18n';
+
+const defaultLocale = 'en_US';
+
+/**
+ * Load lazy loaded modules translation data.
+ *
+ * @param {string} path
+ * @param {string} domain
+ * @return {Promise}
+ */
+export async function loadTranslations( path, domain ) {
+	const locale = window?.wcCalypsoBridge?.i18n?.locale ?? defaultLocale;
+	const baseUrl = window?.wcCalypsoBridge?.i18n?.baseUrl;
+
+	if ( locale === defaultLocale || baseUrl === undefined ) {
+		return;
+	}
+
+	const [ relativePath, version ] = path.split( '?' );
+
+	const hash = md5( relativePath ).toString();
+	const filename =
+		`${ domain }-${ locale }-${ hash }.json` +
+		( version ? `?${ version }` : '' );
+
+	const response = await fetch( `${ baseUrl }/${ filename }` );
+
+	if ( ! response.ok ) {
+		throw new Error(
+			`HTTP request failed: ${ response.status } ${ response.statusText }`
+		);
+	}
+
+	const data = await response.json();
+	const localeData =
+		data?.locale_data?.[ domain ] || data?.locale_data?.messages;
+
+	setLocaleData( localeData, 'wc-calypso-bridge' );
+}

--- a/src/i18n-loader.js
+++ b/src/i18n-loader.js
@@ -10,7 +10,7 @@ import {
 	_nx,
 	_x,
 } from '@wordpress/i18n';
-import { addFilter, applyFilters } from '@wordpress/hooks';
+import { addFilter } from '@wordpress/hooks';
 
 const defaultLocale = 'en_US';
 

--- a/src/i18n-loader.js
+++ b/src/i18n-loader.js
@@ -17,7 +17,7 @@ const defaultLocale = 'en_US';
 /**
  * Some gettext calls in this package use the `woocommerce` text domain
  * and expect that the translation data is already loaded from WooCommerce.
- * If a translation is missing, these filters will attempt to transate the string
+ * If a translation is missing, these filters will attempt to translate the string
  * using the `wc-calypso-bridge` text domain as a fallback.
  */
 addFilter(

--- a/src/i18n-loader.js
+++ b/src/i18n-loader.js
@@ -2,9 +2,84 @@
  * External dependencies
  */
 import md5 from 'crypto-js/md5';
-import { setLocaleData } from '@wordpress/i18n';
+import {
+	setLocaleData,
+	hasTranslation,
+	__,
+	_n,
+	_nx,
+	_x,
+} from '@wordpress/i18n';
+import { addFilter, applyFilters } from '@wordpress/hooks';
 
 const defaultLocale = 'en_US';
+
+/**
+ * Some gettext calls in this package use the `woocommerce` text domain
+ * and expect that the translation data is already loaded from WooCommerce.
+ * If a translation is missing, these filters will attempt to transate the string
+ * using the `wc-calypso-bridge` text domain as a fallback.
+ */
+addFilter(
+	'i18n.gettext_woocommerce',
+	'wc-calypso-bridge',
+	( translation, text, domain ) => {
+		if (
+			text === translation &&
+			! hasTranslation( text, undefined, domain )
+		) {
+			// eslint-disable-next-line @wordpress/i18n-no-variables
+			return __( text, 'wc-calypso-bridge' );
+		}
+
+		return translation;
+	}
+);
+addFilter(
+	'i18n.ngettext_woocommerce',
+	'wc-calypso-bridge',
+	( translation, single, plural, number, domain ) => {
+		if (
+			( single === translation || plural === translation ) &&
+			! hasTranslation( single, undefined, domain )
+		) {
+			// eslint-disable-next-line @wordpress/i18n-no-variables
+			return _n( single, plural, number, 'wc-calypso-bridge' );
+		}
+
+		return translation;
+	}
+);
+addFilter(
+	'i18n.gettext_with_context_woocommerce',
+	'wc-calypso-bridge',
+	( translation, text, context, domain ) => {
+		if (
+			text === translation &&
+			! hasTranslation( text, context, domain )
+		) {
+			// eslint-disable-next-line @wordpress/i18n-no-variables
+			return _x( text, context, 'wc-calypso-bridge' );
+		}
+
+		return translation;
+	}
+);
+addFilter(
+	'i18n.ngettext_with_context_woocommerce',
+	'wc-calypso-bridge',
+	( translation, single, plural, number, context, domain ) => {
+		if (
+			( single === translation || plural === translation ) &&
+			! hasTranslation( single, context, domain )
+		) {
+			// eslint-disable-next-line @wordpress/i18n-no-variables
+			return _nx( single, plural, number, context, 'wc-calypso-bridge' );
+		}
+
+		return translation;
+	}
+);
 
 /**
  * Load lazy loaded modules translation data.

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ import { AppearanceFill, GetPaidWithSquareFill } from './task-fills';
 import './task-headers';
 import './track-menu-item';
 import { CalypsoBridgeIntroductoryOfferBanner } from './introductory-offer-banner';
+import './i18n-loader';
 
 // Modify webpack to append the ?ver parameter to JS chunk
 // https://webpack.js.org/api/module-variables/#__webpack_get_script_filename__-webpack-specific

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 const WooCommerceDependencyExtractionWebpackPlugin = require( '@woocommerce/dependency-extraction-webpack-plugin' );
+const I18nLoaderWebpackPlugin = require( '@automattic/i18n-loader-webpack-plugin' );
 const path = require( 'path' );
 
 // Import variables and mixins from the stylesheets directory so they can be used in all scss files.
@@ -35,5 +36,10 @@ module.exports = {
 				plugin.constructor.name !== 'DependencyExtractionWebpackPlugin'
 		),
 		new WooCommerceDependencyExtractionWebpackPlugin(),
+		new I18nLoaderWebpackPlugin( {
+			textdomain: 'wc-calypso-bridge',
+			loaderModule: './src/i18n-loader',
+			loaderMethod: 'loadTranslations',
+		} ),
 	],
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

* Load translations for `wc-calypso-bridge` script.
* Build JSON translations files with `wp i18n make-json [path-to-po-file]`.
* Exclude the `/src` path when generating the POT file to reduce the number of JSON translation files generated with `make-json`, as it uses the files paths references in the POT file to create the JSON files. A JSON translation files is loaded when its corresponding JS is enqueued in WordPress and given that the source modules never enqueued directly, generating translation files for those is unnecessary.
* Add filters for `gettext` calls with `woocommerce` to attempt to translate the same string using `wc-calypso-bridge` when there's no translation in the `woocommerce` domain. This change is targeted at gettext call used in this package with `woocommerce` text domain (such as [#1](https://github.com/Automattic/wc-calypso-bridge/blob/8e73dbad01396a364a3014a91ab25154a03793da/src/task-headers/products.js#L26), [#2](https://github.com/Automattic/wc-calypso-bridge/blob/8e73dbad01396a364a3014a91ab25154a03793da/src/free-trial/tax/avalara/card.tsx#L27), [#3](https://github.com/Automattic/wc-calypso-bridge/blob/8e73dbad01396a364a3014a91ab25154a03793da/src/payment-gateway-suggestions/index.js#L215), etc.).
* Load translation data for lazy loaded modules.

Related to 799-gh-Automattic/i18n-issues

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Checkout the branch locally.
2. Generate JSON translation files for one of the languages with `wp i18n make-json languages/[language].po`.
3. Sync the changes to your test site by following the instructions from pdDOJh-3ob-p2.
4. Open your test site and make sure set to the language you've generated the translation files for.
5. Navigate to `/wp-admin/admin.php?page=wc-admin` and confirm `wc-calypso-bridge-js-translations` translation data is loaded, i.e. the script `<script id="wc-calypso-bridge-js-translations">` that loads the data using `wp.i18n.setLocaleData()` is printed on the page.
6. Navigate to `/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing` and confirm translations for lazy loaded module `Marketing` are loaded as expected. The `isEcommercePlan`, `isEcommercePlanTrial`, `isWooNavigationEnabled` params on your test site must be `true` (can be overridden in [class-wc-calypso-bridge-shared.php](https://github.com/Automattic/wc-calypso-bridge/blob/45e22acc9033d37a9e95e30603e0a06cc6fdefab/class-wc-calypso-bridge-shared.php#L114-L117))

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
