### PR TITLE
Revert "Entrepreneur my home goes to Calypso instead"

### DIFF
--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -262,18 +262,6 @@ class WC_Calypso_Bridge_Ecommerce_Admin_Menu extends WC_Calypso_Bridge_Base_Admi
 			'wpcom-hosting-menu',
 			esc_url( "https://wordpress.com/home/{$this->domain}" )
 		);
-
-		// If we have entrepreneur plan, we change the url of home
-		if ( $this->has_entrepreneur_plan() ) {
-			$this->update_menu(
-				'index.php',
-				'https://wordpress.com/home/' . $this->domain . '?flags=entrepreneur-my-home',
-				$label,
-				'edit_posts',
-				'dashicons-admin-home'
-			);
-			remove_submenu_page( 'index.php', 'admin.php?page=wc-admin' );
-		}
 	}
 
 	/**
@@ -655,27 +643,5 @@ class WC_Calypso_Bridge_Ecommerce_Admin_Menu extends WC_Calypso_Bridge_Base_Admi
 				return ( $A < $B ) ? -1 : 1;
 			} );
 		}
-	}
-
-	/**
-	 * Check if the site has Entrepreneur plan
-	 *
-	 * @return bool
-	 */
-	protected function has_entrepreneur_plan() {
-		$current_plan = get_option( 'jetpack_active_plan',  array() );
-		if ( empty( $current_plan ) ) {
-			return false;
-		}
-
-		$entrepreneur_plans = [
-			'ecommerce-bundle-monthly',
-			'ecommerce-bundle',
-			'ecommerce-bundle-2y',
-			'ecommerce-bundle-3y',
-			'ecommerce-trial-bundle-monthly',
-		];
-
-		return in_array( $current_plan['product_slug'], $entrepreneur_plans, true );
 	}
 }


### PR DESCRIPTION
Reverts Automattic/wc-calypso-bridge#1467

After a thoughtful conversation (here: pdDOJh-3t6-p2 ), we decided to revert the My Home link to take the user back to WooComerce My Home instead of Calypso My Home.