### PR TITLE
Admin Menu: Fix order of Jetpack submenu pages.

### DIFF
--- a/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
+++ b/includes/class-wc-calypso-bridge-ecommerce-admin-menu.php
@@ -642,6 +642,9 @@ class WC_Calypso_Bridge_Ecommerce_Admin_Menu extends WC_Calypso_Bridge_Base_Admi
 
 				return ( $A < $B ) ? -1 : 1;
 			} );
+
+			// After sorting, reindex the array to ensure keys are sequential.
+			$submenu['jetpack'] = array_values( $submenu['jetpack'] );
 		}
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Jetpack menu ordering changes were introduced in the commit: https://github.com/Automattic/wc-calypso-bridge/commit/ffd4b88f3aaf09844b40501f372975380233f25a

Closes https://github.com/Automattic/dotcom-forge/issues/7358

#### Before the fix:
![Screenshot 2024-05-21 at 10 02 29](https://github.com/Automattic/wc-calypso-bridge/assets/2019970/937eec92-a6d2-407a-989d-c8b476b0519b)

#### After the fix:
- **Stats** submenu item is right below **Dashboard** submenu item
 

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

Please follow these test instructions: PdDOJh-3tE-p2.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.