### PR TITLE
i18n: Ensure i18n loader is included in the production build

### DIFF
--- a/src/i18n-loader.js
+++ b/src/i18n-loader.js
@@ -117,3 +117,5 @@ export async function loadTranslations( path, domain ) {
 
 	setLocaleData( localeData, 'wc-calypso-bridge' );
 }
+
+export default { loadTranslations };

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,10 @@ import { AppearanceFill, GetPaidWithSquareFill } from './task-fills';
 import './task-headers';
 import './track-menu-item';
 import { CalypsoBridgeIntroductoryOfferBanner } from './introductory-offer-banner';
-import './i18n-loader';
+import { loadTranslations } from './i18n-loader';
+
+// A workaround for Webpack's tree-shaking to ensure `loadTranslations` is included in the production bundle.
+( function () {} )( loadTranslations );
 
 // Modify webpack to append the ?ver parameter to JS chunk
 // https://webpack.js.org/api/module-variables/#__webpack_get_script_filename__-webpack-specific

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,9 @@ defaultConfig.module.rules.push( {
 	],
 } );
 
+// Disable exports mangling to ensure the exported loader method name `loadTranslations` is preserved.
+defaultConfig.optimization.mangleExports = false;
+
 module.exports = {
 	...defaultConfig,
 	plugins: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,8 @@ defaultConfig.module.rules.push( {
 	],
 } );
 
-// Disable exports mangling to ensure the exported loader method name `loadTranslations` is preserved.
+// Disable exports mangling to ensure the exported i18n loader method name `loadTranslations` is preserved,
+// as it's being referred by name in the I18nLoaderWebpackPlugin's runtime template.
 defaultConfig.optimization.mangleExports = false;
 
 module.exports = {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

https://github.com/Automattic/wc-calypso-bridge/pull/1472 introduced loading translations for lazy loaded JS modules using `@automattic/i18n-loader-webpack-plugin` and [a custom i18n loader module](https://github.com/Automattic/wc-calypso-bridge/blob/master/src/i18n-loader.js).

However, due to `loadTranslations` function from the i18n loader being used only in the runtime template, it got removed from the production build by Webpack's tree-shaking, which resulted in errors in the console when trying to fetch the translations.

This PR introduces some changes to ensure that the function is preserved in the production build and can be used in the runtime template.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Checkout the branch locally.
2. Build the app locally with `npm run build`.
3. Sync the changes to your test site by following the instructions from pdDOJh-3ob-p2.
4. Change the language of your test site to any Mag-16 language.
5. If your test site is not on Ecommerce Trial plan, override the isEcommercePlan` and `isEcommercePlanTrial` params to `true` in [class-wc-calypso-bridge-shared.php](https://github.com/Automattic/wc-calypso-bridge/blob/45e22acc9033d37a9e95e30603e0a06cc6fdefab/class-wc-calypso-bridge-shared.php#L114-L117).
7. Navigate to `/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing` and confirm strings are rendered translated.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
