### PR TITLE
Fix WC_Tracks called too early crashing frontpage

### DIFF
--- a/includes/class-wc-calypso-bridge-customize-store.php
+++ b/includes/class-wc-calypso-bridge-customize-store.php
@@ -103,7 +103,7 @@ class WC_Calypso_Bridge_Customize_Store {
 
 	public function possibly_add_track_homepage_view() {
 		if ( self::is_admin() ) {
-			if ( is_front_page() || is_home() ) {
+			if ( class_exists( 'WC_Tracks' ) && ( is_front_page() || is_home() ) ) {
 				// This is tracked via backend.
 				WC_Tracks::record_event( 'store_homepage_view' );
 			}

--- a/includes/class-wc-calypso-bridge-customize-store.php
+++ b/includes/class-wc-calypso-bridge-customize-store.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since  1.0.0
- * @version 2.3.0
+ * @version x.x.x
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleased =
+* Fix homepage crashing with WooCommerce 9.0.0
+
 = 2.5.1 =
 * Fix broken image on Woo launchpad header #1481
 * Ensure i18n loader is preserved in the production build #1480


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When using WooCommerce 9.0.0 and viewing homepage as an admin, PHP crashes.

p1717075183129709/1717053288.243629-slack-C011ENB20Q1

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Set up with Entrepreneuer plan (by following this guide pdDOJh-3ob-p2, or the old free trial guide and upgrade it to Entrepreneur plan peapX7-1D4-p2)
1. Go to cli
4. Run `wp wpcomsh plugin use-unmanaged woocommerce`
5. Download and install [WooCommerce 9.0.0 beta 2](https://github.com/woocommerce/woocommerce/releases/tag/9.0.0-beta.2)
6. In your logged in browser, go to homepage in the frontend (not wp-admin)
7. Observe the homepage is loaded correctly (no white screen)

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.