### PR TITLE
Moved logic to ensure launch-your-store feature is disabled in all plans

### DIFF
--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 2.3.12
+ * @version x.x.x
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -40,12 +40,6 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 	 * Constructor.
 	 */
 	public function __construct() {
-
-		// Only in Ecommerce and Woo Express plans.
-		if ( ! wc_calypso_bridge_has_ecommerce_features() ) {
-			return;
-		}
-
 		add_action( 'plugins_loaded', array( $this, 'initialize' ), 2 );
 	}
 
@@ -53,10 +47,15 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 	 * Initialize.
 	 */
 	public function initialize() {
+		add_filter( 'woocommerce_admin_get_feature_config', array( $this, 'filter_woocommerce_admin_features' ), PHP_INT_MAX );
+
+		// The rest applies only to Entrepreneur and Woo Express plans.
+		if ( ! wc_calypso_bridge_has_ecommerce_features() ) {
+			return;
+		}
 
 		add_filter( 'wc_admin_get_feature_config', array( $this, 'maybe_remove_devdocs_menu_item' ) );
 		add_filter( 'woocommerce_admin_features', array( $this, 'filter_wc_admin_enabled_features' ) );
-		add_filter( 'woocommerce_admin_get_feature_config', array( $this, 'filter_woocommerce_admin_features' ), PHP_INT_MAX );
 
 		/*
 		 * Hide the features under 'Advanced > Features' but let users disable our commerce-optimized menu.
@@ -141,15 +140,19 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 	 * @return array
 	 */
 	public function filter_woocommerce_admin_features( $features ) {
+		// Disable launch-your-store to prevent clashes with similar functionality already provided.
+		if ( isset( $features['launch-your-store'] ) ) {
+			$features['launch-your-store'] = false;
+		}
+
+		// The rest applies only to Entrepreneur and Woo Express plans.
+		if ( ! wc_calypso_bridge_has_ecommerce_features() ) {
+			return $features;
+		}
 
 		// Disable and revert the navigation experiment.
 		if ( isset( $features['navigation'] ) ) {
 			$features['navigation'] = false;
-		}
-
-		// Disable launch-your-store to prevent clashes with similar functionality already provided.
-		if ( isset( $features['launch-your-store'] ) ) {
-			$features['launch-your-store'] = false;
 		}
 
 		// Keep Woo Analytics enabled.

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,7 @@ This section describes how to install the plugin and get it working.
 
 = Unreleased =
 * Fix homepage crashing with WooCommerce 9.0.0 #1483
+* Moved logic to ensure launch-your-store feature is disabled in all plans #1485
 
 = 2.5.1 =
 * Fix broken image on Woo launchpad header #1481


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Disables `launch-your-store` feature in all plans.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

#### If you don't have Creator plan on WoA
1. Create a free site in wordpress.com.
2. Add the site to WoA dev blog (link in peapX7-1D4-p2).
3. Upgrade the site with Creator plan.

#### Testing instructions
1. Open up `/_cli`.
1. Run `wpcomsh plugin use-unmanaged woocommerce`
3. Run `plugin delete woocommerce`
3. Run `plugin install --activate https://github.com/woocommerce/woocommerce/releases/download/9.0.0-rc.1/woocommerce.zip`
3. Run `plugin install --activate https://github.com/woocommerce/woocommerce/releases/download/wc-beta-tester-2.3.1/woocommerce-beta-tester.zip`
4. Go to WooCommerce > Home
5. Observe there's only one `Launch your store` task and no badge at top bar
6. Go to `Tools > WCA Test Helper > Features`
7. Try enabling `launch-you-store` but observe that you can't



<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.