### PR TITLE
Implement is_complete for the square task

### DIFF
--- a/includes/tasks/class-wc-calypso-task-get-paid-with-square.php
+++ b/includes/tasks/class-wc-calypso-task-get-paid-with-square.php
@@ -42,6 +42,18 @@ class WCBridgeGetPaidWithSquare extends Task {
 	}
 
 	/**
+	 * Check if the task is complete.
+	 * 
+	 * When Square is connected, it sets an access token in the options table.
+	 * Count the access token and consider the task complete if it is not empty.
+	 * 
+	 */
+	public function is_complete() {
+		$access_token = get_option( 'wc_square_access_tokens', array() );
+		return ! empty( $access_token );
+	}
+
+	/**
 	 * Time.
 	 *
 	 * @return string


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR implements `is_complete` function for the Square task.

The logic is copied from Square plugin's [is_connected](https://github.com/woocommerce/woocommerce-square/blob/trunk/includes/Settings.php#L765) function.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Create a new Square PAO site.
2. SSH into the site and replace `includes/tasks/class-wc-calypso-task-get-paid-with-square.php` with the one included in this PR. 
3. Go to `WooCommerce -> Home` and click on `Get paid with Square` task.
4. You can either sign up for Square or manually set `wc_square_access_tokens` option. I would recommend signing up a square account. 
5. Once you're redirected back to the site from Square, the task should be marked as completed.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
