### PR TITLE
Entrepreneur trial: Fix incorrectly used plan name in the trial "Welcome" note

### DIFF
--- a/includes/notes/class-wc-calypso-bridge-free-trial-welcome.php
+++ b/includes/notes/class-wc-calypso-bridge-free-trial-welcome.php
@@ -33,17 +33,15 @@ class WC_Calypso_Bridge_Free_Trial_Welcome_Note {
 	 * @return void|Note
 	 */
 	public static function get_note() {
-
-		$current_plan       = get_option( 'jetpack_active_plan',  array() );
-		$product_name_short = $current_plan[ 'product_name_short' ];
+		$plan_name = 'Entrepreneur';
 
 		/* translators: %s: trial plan name, e.g. Entrepreneur */
-		$note_title = sprintf( __( 'Your %s free trial has just started', 'wc-calypso-bridge' ), $product_name_short );
+		$note_title = sprintf( __( 'Your %s free trial has just started', 'wc-calypso-bridge' ), $plan_name );
 
 		/* translators: %s: trial plan name, e.g. Entrepreneur */
 		$note_content = sprintf(
 			__( 'Welcome to your 14-day free trial of the %s plan – everything you need to start and grow a successful online business, all in one place. The journey toward your first sale has just begun! Ready to explore?', 'wc-calypso-bridge' ),
-			$product_name_short
+			$plan_name
 		);
 
 		$note = new Note();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The proposed change addresses issue discovered in https://github.com/Automattic/dotcom-forge/issues/7220#issuecomment-2186585648 where incorrectly used plan name is causing confusing "Welcome" note message.

| Before | After |
|--------|--------|
| ![342354629-7e4dafae-0a28-4f25-be6d-bb08ee43ae4b](https://github.com/Automattic/wc-calypso-bridge/assets/25105483/57225bf2-648c-4a41-8dd2-06dd92ec6771) | ![Markup on 2024-07-11 at 15:18:17](https://github.com/Automattic/wc-calypso-bridge/assets/25105483/e873d4f9-afa2-4c60-b8df-0b99cd36c3ee) | 

Originally, I aimed to avoid hardcoding the plan/product name, but it is not easily accessible in `wc-calypso-bridge`, plus we would need to load the plan/product name based on its slug - as the trial site won't have the full "Entrepreneur" plan/product name assigned to it anyways.

The proposed solution has advantage compared to the old Woo Express plan code (https://github.com/Automattic/wc-calypso-bridge/pull/1471/files#diff-26640952f8341c7dd518fee8f2bccdc3bcefefe943c53b992ff0bb4cf1da0876L38) where the plan name was hardcoded as well, but also was a part of the translated string. With the currently proposed PR, if the plan ever changes in the future, there won't be any need for new translations.

Related discussion: p1720687546715789-slack-C02TCEHP3HA

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

The changes proposed in this PR are targeting Entrepreneur Trial plan, however, due to technical limitations, we will only perform a partial test on a "full" Entrepreneur plan site.

If you don't have your WoA test site yet, please follow the steps outlined in pdDOJh-3ob-p2 and create a test site with Entrepreneur plan (the plan can be added through the SA).

1. Check out the PR and sync it with your WoA test site on an Entrepreneur plan.
2. Make the following temporary change:

```diff
diff --git a/includes/class-wc-calypso-bridge-setup.php b/includes/class-wc-calypso-bridge-setup.php
index 5429c57..16d1866 100644
--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -127,6 +127,11 @@ class WC_Calypso_Bridge_Setup {
 
 				$wp_admin_bar->remove_menu( 'ab-new-post' );
 			}, PHP_INT_MAX );
+
+			add_action( 'wp_before_admin_bar_render', function () {
+				include_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/notes/class-wc-calypso-bridge-free-trial-welcome.php';
+				WC_Calypso_Bridge_Free_Trial_Welcome_Note::possibly_add_note();
+			}, PHP_INT_MAX );
 		}
 	}
 
diff --git a/includes/notes/class-wc-calypso-bridge-free-trial-welcome.php b/includes/notes/class-wc-calypso-bridge-free-trial-welcome.php
index 826c430..ff49fb5 100644
--- a/includes/notes/class-wc-calypso-bridge-free-trial-welcome.php
+++ b/includes/notes/class-wc-calypso-bridge-free-trial-welcome.php
@@ -67,6 +67,7 @@ class WC_Calypso_Bridge_Free_Trial_Welcome_Note {
 	 * @return bool
 	 */
 	public static function can_be_added() {
+		return true;
 		$note = self::get_note();
 
 		if ( ! $note instanceof Note && ! $note instanceof WC_Admin_Note ) {

```

3. Navigate to `/wp-admin/admin.php?page=wc-admin` and review the Welcome note. It should include correct copy - as can be seen in the _After_ screenshot above.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.