### PR TITLE
Hide WPCOM coming soon page when lys feature flag is enabled

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -184,6 +184,7 @@ class WC_Calypso_Bridge {
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/free-trial/partners/class-wc-calypso-bridge-partner-stripe.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/free-trial/partners/class-wc-calypso-bridge-partner-paypal.php';
+		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-coming-soon.php';
 
 		// Experiments.
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/experiments/class-wc-calypso-bridge-task-list-reminderbar-experiment.php';

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 2.3.4
+ * @version x.x.x
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -37,7 +37,7 @@ class WC_Calypso_Bridge_Coming_Soon {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_filter( 'a8c_show_coming_soon_page', array( $this, 'should_show_a8c_coming_soon_page' ), 99999, 1 );
+		add_filter( 'a8c_show_coming_soon_page', array( $this, 'should_show_a8c_coming_soon_page' ), PHP_INT_MAX, 1 );
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -41,18 +41,19 @@ class WC_Calypso_Bridge_Coming_Soon {
 	}
 
 	/**
-	 * Show the coming soon page if the Launch Your Store feature is enabled.
+	 * Hide the a8c coming soon page if the Launch Your Store feature is enabled.
 	 *
 	 * @param bool $should_show
 	 * @return bool
 	 */
 	public function should_show_a8c_coming_soon_page( $should_show ) {
-		if ( ! Features::is_enabled( 'launch-your-store' ) ) {
-			// Bail out early if the Launch Your Store feature is not enabled.
-			return $should_show;
+		if (
+			class_exists( '\Automattic\WooCommerce\Admin\Features\Features' ) && \Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'launch-your-store' )
+		) {
+			return false;
 		}
 
-		return false;
+		return $should_show;
 	}
 }
 

--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -1,7 +1,5 @@
 <?php
 
-use Automattic\WooCommerce\Admin\Features\Features;
-
 defined( 'ABSPATH' ) || exit;
 
 /**

--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * Handle Coming Soon mode.
  */
-class  WC_Calypso_Bridge_Coming_Soon {
+class WC_Calypso_Bridge_Coming_Soon {
 	/**
 	 * The single instance of the class.
 	 *
@@ -33,10 +33,19 @@ class  WC_Calypso_Bridge_Coming_Soon {
 		return self::$instance;
 	}
 
+	/**
+	 * Constructor.
+	 */
 	public function __construct() {
 		add_filter( 'a8c_show_coming_soon_page', array( $this, 'should_show_a8c_coming_soon_page' ), 99999, 1 );
 	}
 
+	/**
+	 * Show the coming soon page if the Launch Your Store feature is enabled.
+	 *
+	 * @param bool $should_show
+	 * @return bool
+	 */
 	public function should_show_a8c_coming_soon_page( $should_show ) {
 		if ( ! Features::is_enabled( 'launch-your-store' ) ) {
 			// Bail out early if the Launch Your Store feature is not enabled.
@@ -45,8 +54,6 @@ class  WC_Calypso_Bridge_Coming_Soon {
 
 		return false;
 	}
-
-
 }
 
 WC_Calypso_Bridge_Coming_Soon::get_instance();

--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -1,0 +1,52 @@
+<?php
+
+use Automattic\WooCommerce\Admin\Features\Features;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class WC_Calypso_Bridge_Coming_Soon
+ *
+ * @since   x.x.x
+ * @version x.x.x
+ *
+ * Handle Coming Soon mode.
+ */
+class  WC_Calypso_Bridge_Coming_Soon {
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var object
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return object Instance.
+	 */
+	final public static function get_instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	public function __construct() {
+		add_filter( 'a8c_show_coming_soon_page', array( $this, 'should_show_a8c_coming_soon_page' ), 99999, 1 );
+	}
+
+	public function should_show_a8c_coming_soon_page( $should_show ) {
+		if ( ! Features::is_enabled( 'launch-your-store' ) ) {
+			// Bail out early if the Launch Your Store feature is not enabled.
+			return $should_show;
+		}
+
+		return false;
+	}
+
+
+}
+
+WC_Calypso_Bridge_Coming_Soon::get_instance();

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,7 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 = Unreleased =
-* Hide WPCOM's coming soon page when the launch-your-store feature flag is enabled
+* Hide WPCOM's coming soon page when the launch-your-store feature flag is enabled #1500
 
 = 2.5.5 =
 * Add a new class to customize for Stripe from Partner Aware Onboarding #1492

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleased =
+* Hide WPCOM's coming soon page when the launch-your-store feature flag is enabled
+
 = 2.5.5 =
 * Add a new class to customize for Stripe from Partner Aware Onboarding #1492
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/Automattic/wc-calypso-bridge/issues/1498.

Use the filter [a8c_show_coming_soon_page](https://github.com/Automattic/jetpack/blob/065c5cbec110192aeef1bfb37124a2351251a00e/projects/packages/jetpack-mu-wpcom/src/features/coming-soon/coming-soon.php#L40C25-L40C50) to override WPCOM's coming soon status so that we can show LYS coming soon page instead.

There a another task to [sync WPCOM coming soon status to LYS](https://github.com/woocommerce/team-ghidorah/issues/344). When that is done, we should see WooCommerce's coming soon template shown, when in coming soon mode either on LYS or WPCOM.


<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Use a WPCOM atomic e-commerce site and local wc-calypso-bridge
2. Enable LYS feature flag (via beta tester or you can remove [these lines](https://github.com/Automattic/wc-calypso-bridge/blob/507bde7b933c60bb2cb7efdfad66b7bd8581b39b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php#L143-L147).
3. Go to `https://wordpress.com/settings/general/SITE_URL` and enable WPCOM coming soon
4. Go to `/wp-admin/admin.php?page=wc-settings&tab=site-visibility` and enable LYS coming soon
5. Open the site frontend in an incognito window and confirm that the LYS coming soon page is shown

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
