### PR TITLE
Exclude LYS coming soon page for WPCOM share link

### DIFF
--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -56,6 +56,12 @@ class WC_Calypso_Bridge_Coming_Soon {
 		return $should_show;
 	}
 
+	/**
+	 * Exclude the coming soon page if the user is accessing the site via a valid share link.
+	 *
+	 * @param bool $exclude
+	 * @return bool
+	 */
 	public function should_exclude_lys_coming_soon( $exclude ) {
 		if ( ! function_exists( '\A8C\FSE\Coming_soon\get_share_code' ) ) {
 			return $exclude;

--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -36,6 +36,8 @@ class WC_Calypso_Bridge_Coming_Soon {
 	 */
 	public function __construct() {
 		add_filter( 'a8c_show_coming_soon_page', array( $this, 'should_show_a8c_coming_soon_page' ), PHP_INT_MAX, 1 );
+		add_filter( 'woocommerce_coming_soon_exclude', array( $this, 'should_exclude_lys_coming_soon' ) );
+
 	}
 
 	/**
@@ -52,6 +54,19 @@ class WC_Calypso_Bridge_Coming_Soon {
 		}
 
 		return $should_show;
+	}
+
+	public function should_exclude_lys_coming_soon( $exclude ) {
+		if ( ! function_exists( '\A8C\FSE\Coming_soon\get_share_code' ) ) {
+			return $exclude;
+		}
+
+		$share_code = \A8C\FSE\Coming_soon\get_share_code();
+		if ( \A8C\FSE\Coming_soon\is_accessed_by_valid_share_link( $share_code ) ) {
+			return true;
+		}
+
+		return $exclude;
 	}
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,7 @@ This section describes how to install the plugin and get it working.
 
 = Unreleased =
 * Hide WPCOM's coming soon page when the launch-your-store feature flag is enabled #1500
+* Exclude LYS coming soon page for WPCOM share link #1501
 
 = 2.5.5 =
 * Add a new class to customize for Stripe from Partner Aware Onboarding #1492


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/Automattic/wc-calypso-bridge/issues/1499.

Add a filter to exclude LYS coming soon page for WPCOM share link


- When LYS private link is turned on, LYS private link should bypass coming soon mode.
- When WPCOM private link is turned on, WPCOM private link should bypass coming soon mode.


<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Use a WPCOM atomic e-commerce site
2. Enable LYS feature flag
3. Go to `https://wordpress.com/settings/general/SITE_URL` and enable WPCOM coming soon
4. Go to `/wp-admin/admin.php?page=wc-settings&tab=site-visibility` and enable LYS coming soon
5. Open the site frontend in an incognito window and confirm that the LYS coming soon page is shown
6. Enable WPCOM share link and use the share link to open the site in an incognito window
7. Confirm that the LYS coming soon page is not shown
8. Confirm that you can use LYS private link to bypass coming soon mode

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
