### PR TITLE
Sync WPCOM coming soon status to LYS

### DIFF
--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -37,7 +37,7 @@ class WC_Calypso_Bridge_Coming_Soon {
 	public function __construct() {
 		add_filter( 'a8c_show_coming_soon_page', array( $this, 'should_show_a8c_coming_soon_page' ), PHP_INT_MAX, 1 );
 		add_filter( 'woocommerce_coming_soon_exclude', array( $this, 'should_exclude_lys_coming_soon' ) );
-
+		add_action( 'update_option_wpcom_public_coming_soon', array( $this, 'sync_coming_soon_option' ), 10, 3 );
 	}
 
 	/**
@@ -73,6 +73,22 @@ class WC_Calypso_Bridge_Coming_Soon {
 		}
 
 		return $exclude;
+	}
+
+	/**
+	 * Sync the coming soon option from wpcom_public_coming_soon to woocommerce_coming_soon.
+	 *
+	 * @param int $old_value
+	 * @param int $new_value
+	 * @param string $option
+	 * @return void
+	 */
+	public function sync_coming_soon_option( $old_value, $new_value, $option ) {
+		if ( 1 ===  (int) $new_value ) {
+			update_option( 'woocommerce_coming_soon', 'yes' );
+		} else {
+			update_option( 'woocommerce_coming_soon', 'no' );
+		}
 	}
 }
 

--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -84,7 +84,7 @@ class WC_Calypso_Bridge_Coming_Soon {
 	 * @return void
 	 */
 	public function sync_coming_soon_option( $old_value, $new_value, $option ) {
-		if ( ! Features::is_enabled( 'launch-your-store' ) ) {
+		if ( ! class_exists( '\Automattic\WooCommerce\Admin\Features\Features' ) || ! \Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'launch-your-store' ) ) {
 			return;
 		}
 

--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -84,6 +84,10 @@ class WC_Calypso_Bridge_Coming_Soon {
 	 * @return void
 	 */
 	public function sync_coming_soon_option( $old_value, $new_value, $option ) {
+		if ( ! Features::is_enabled( 'launch-your-store' ) ) {
+			return;
+		}
+
 		if ( 1 ===  (int) $new_value ) {
 			update_option( 'woocommerce_coming_soon', 'yes' );
 		} else {

--- a/readme.txt
+++ b/readme.txt
@@ -25,6 +25,7 @@ This section describes how to install the plugin and get it working.
 = Unreleased =
 * Hide WPCOM's coming soon page when the launch-your-store feature flag is enabled #1500
 * Exclude LYS coming soon page for WPCOM share link #1501
+* Sync WPCOM coming soon status to LYS #1502
 
 = 2.5.5 =
 * Add a new class to customize for Stripe from Partner Aware Onboarding #1492


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Partially closes https://github.com/woocommerce/team-ghidorah/issues/344

Sync coming soon status from WPCOM to LYS.

When clicking on Launch site button in https://wordpress.com/settings/general/SITE_URL
When changing the following states in https://wordpress.com/settings/general/SITE_URL:
- Live - LYS should be set to live
- Coming soon - LYS should be set to coming soon
- Private - No change to LYS state, but frontend page should prompt wp-admin login

This PR doesn't sync the initial coming soon state from WPCOM. I think we need to see when WPCOM set the initial coming soon state to decide how to handle it.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Use a WPCOM atomic e-commerce site
2. Enable LYS feature flag
3. Run `wp option set launch-status unlaunched` if the site is launched before
4. Enable LYS coming soon mode
5. Open site in the incognito window and confirm that the site is in coming soon mode
6. Go to `https://wordpress.com/settings/general/SITE_URL` and click on Launch site button
7. Confirm that the site is in live mode
8. Change the WPCOM site status to coming soon
9. Confirm that the site is in coming soon mode
10. Change the WPCOM site status to Live mode
11. Confirm that the site is in live mode
12. Change the WPCOM site status to private
13. Confirm that the site is in private mode


<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
