### PR TITLE
Add sync coming soon status from LYS to WPCOM

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -143,6 +143,8 @@ class WC_Calypso_Bridge {
 	 * Include files and controllers.
 	 */
 	public function includes() {
+		// Helpers.
+		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/atomic-api/class-wc-calypso-bridge-atomic-launch-api.php';
 
 		/**
 		 * Hint:

--- a/includes/atomic-api/class-wc-calypso-bridge-atomic-launch-api.php
+++ b/includes/atomic-api/class-wc-calypso-bridge-atomic-launch-api.php
@@ -1,0 +1,57 @@
+<?php
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * Class WC_Calypso_Bridge_Atomic_Launch_API.
+ *
+ * @since   x.x.x
+ * @version x.x.x
+ *
+ * API for launch on Atomic.
+ */
+class WC_Calypso_Bridge_Atomic_Launch_API {
+	/**
+	 * Launch Atomic.
+	 */
+	public static function launch_site() {
+		if ( ! class_exists( '\Jetpack_Options' ) ) {
+			return;
+		}
+
+		$blog_id = \Jetpack_Options::get_option( 'id' );
+		return Client::wpcom_json_api_request_as_user(
+			sprintf( '/sites/%d/launch', $blog_id ),
+			'2',
+			array(
+				'method' => 'POST',
+			),
+			json_encode( array(
+				'site' => $blog_id
+			 ) ),
+			'wpcom'
+		);
+	}
+
+	/**
+	 * Update coming soon.
+	 */
+	public static function update_coming_soon( $is_coming_soon ) {
+		if ( ! class_exists( '\Jetpack_Options' ) ) {
+			return;
+		}
+
+		$blog_id = \Jetpack_Options::get_option( 'id' );
+		return Client::wpcom_json_api_request_as_user(
+			sprintf( '/sites/%d/coming-soon', $blog_id ),
+			'2',
+			array(
+				'method' => 'POST',
+			),
+			array(
+				'is_coming_soon' => $is_coming_soon ? 1 : 0
+			),
+			'wpcom'
+		);
+	}
+}

--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -37,7 +37,22 @@ class WC_Calypso_Bridge_Coming_Soon {
 	public function __construct() {
 		add_filter( 'a8c_show_coming_soon_page', array( $this, 'should_show_a8c_coming_soon_page' ), PHP_INT_MAX, 1 );
 		add_filter( 'woocommerce_coming_soon_exclude', array( $this, 'should_exclude_lys_coming_soon' ) );
-		add_action( 'update_option_wpcom_public_coming_soon', array( $this, 'sync_coming_soon_option' ), 10, 3 );
+		add_action( 'update_option_wpcom_public_coming_soon', array( $this, 'sync_coming_soon_wpcom_to_lys' ), 10, 3 );
+		$this->hook_update_option_woocommerce_coming_soon();
+	}
+
+	/**
+	 * Hook on woocommerce_coming_soon option update for ease of use.
+	 */
+	public function hook_update_option_woocommerce_coming_soon() {
+		add_action( 'update_option_woocommerce_coming_soon' , array( $this, 'sync_coming_soon_lys_to_wpcom' ), 10, 3 );
+	}
+
+	/**
+	 * Unhook on woocommerce_coming_soon option update for ease of use.
+	 */
+	public function unhook_update_option_woocommerce_coming_soon() {
+		remove_action( 'update_option_woocommerce_coming_soon' , array( $this, 'sync_coming_soon_lys_to_wpcom' ), 10, 3 );
 	}
 
 	/**
@@ -80,19 +95,88 @@ class WC_Calypso_Bridge_Coming_Soon {
 	 *
 	 * @param int $old_value
 	 * @param int $new_value
-	 * @param string $option
 	 * @return void
 	 */
-	public function sync_coming_soon_option( $old_value, $new_value, $option ) {
+	public function sync_coming_soon_wpcom_to_lys( $old_value, $new_value ) {
 		if ( ! class_exists( '\Automattic\WooCommerce\Admin\Features\Features' ) || ! \Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'launch-your-store' ) ) {
 			return;
 		}
+
+		$woocommerce_coming_soon = get_option( 'woocommerce_coming_soon', false );
+		$is_coming_soon_wpcom = 1 === (int) $new_value;
+
+		// Value is already set, we don't need to update option.
+		if ( ( 'yes' ===  $woocommerce_coming_soon && $is_coming_soon_wpcom ) ||
+			( 'no' === $woocommerce_coming_soon && ! $is_coming_soon_wpcom ) ) {
+			return;
+		}
+
+		// Unhook listener to prevent a loop of updating option between WPCOM <-> LYS.
+		$this->unhook_update_option_woocommerce_coming_soon();
 
 		if ( 1 ===  (int) $new_value ) {
 			update_option( 'woocommerce_coming_soon', 'yes' );
 		} else {
 			update_option( 'woocommerce_coming_soon', 'no' );
 		}
+
+		$this->hook_update_option_woocommerce_coming_soon();
+	}
+
+	/**
+	 * Sync the coming soon option from to woocommerce_coming_soon wpcom.
+	 * Does not include a check of existing wpcom option values since
+	 * there could be multiple options that are affected.
+	 *
+	 * @param int $old_value
+	 * @param int $new_value
+	 * @return void
+	 */
+	public function sync_coming_soon_lys_to_wpcom( $old_value, $new_value ) {
+		$is_atomic_launched = 'launched' === get_option( 'launch-status' );
+		$response = false;
+
+		if ( 'no' === $new_value ) {
+			if ( ! $is_atomic_launched ) {
+				$response = WC_Calypso_Bridge_Atomic_Launch_API::launch_site();
+			} else {
+				$response = WC_Calypso_Bridge_Atomic_Launch_API::update_coming_soon( false );
+			}
+		} elseif ( $is_atomic_launched && 'yes' === $new_value ) {
+			$response = WC_Calypso_Bridge_Atomic_Launch_API::update_coming_soon( true );
+		}
+
+		if ( $response && 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			$body  = wp_remote_retrieve_body( $response );
+			$error = json_decode( $body, true );
+
+			if ( isset( $error['message'] ) ) {
+				$this->add_admin_notice( $error[ 'message' ], 'error' );
+			} else {
+				$this->add_admin_notice( __( 'There was a problem trying to update site visibility.', 'wc-calypso-bridge' ), 'error' );
+			}
+		}
+	}
+
+	public function add_admin_notice( $message, $notice_type = 'info' ) {
+		add_action( 'admin_notices', function () use ( $message, $notice_type ) {
+			$screen    = get_current_screen();
+			$screen_id = $screen ? $screen->id : '';
+
+			if ( 'woocommerce_page_wc-settings' !== $screen_id ) {
+				return;
+			}
+
+			if ( ! isset( $_GET['tab'] ) || 'site-visibility' !== $_GET['tab'] ) {
+				return;
+			}
+
+			?>
+			<div class="notice notice-<?php echo $notice_type ?>">
+				<p><?php echo $message; ?></p>
+			</div>
+			<?php
+		} );
 	}
 }
 

--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -114,7 +114,7 @@ class WC_Calypso_Bridge_Coming_Soon {
 		// Unhook listener to prevent a loop of updating option between WPCOM <-> LYS.
 		$this->unhook_update_option_woocommerce_coming_soon();
 
-		if ( 1 ===  (int) $new_value ) {
+		if ( $is_coming_soon_wpcom ) {
 			update_option( 'woocommerce_coming_soon', 'yes' );
 		} else {
 			update_option( 'woocommerce_coming_soon', 'no' );

--- a/readme.txt
+++ b/readme.txt
@@ -26,6 +26,7 @@ This section describes how to install the plugin and get it working.
 * Hide WPCOM's coming soon page when the launch-your-store feature flag is enabled #1500
 * Exclude LYS coming soon page for WPCOM share link #1501
 * Sync WPCOM coming soon status to LYS #1502
+* Add sync coming soon status from LYS to WPCOM #1503
 
 = 2.5.5 =
 * Add a new class to customize for Stripe from Partner Aware Onboarding #1492


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1496

Sync coming soon status from LYS to WPCOM.

- When updating to either `Live` or `Coming soon` in `Settings > WooCommerce > Site visibility` 
- When clicking on `Launch` in `Launch your store` task

Note: This PR requires D159271-code

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### If D159271-code isn't merged

1. Patch your wpcom sandbox with D159271-code
2. SSH to your atomic site
3. Run `vim ~/htdocs/wp-config.php`
4. Add the line near the top of the config `define( 'JETPACK__SANDBOX_DOMAIN', 'SANDBOX_URL' );` - Replace `SANDBOX_URL` with your sandbox URL and save
5. Refresh `wp-admin` page and observe `Jetpack API Sandboxed` on admin bar

#### If your site has already launched

1. SSH into your sandbox
2. Run `php ./public_html/bin/atomic/unlaunch-site.php SITE_URL` - Replace `SITE_URL` with your atomic site URL

#### Test launch your store task

1. Use a WPCOM atomic e-commerce site
1. Enable LYS feature flag (via beta tester or you can remove [these lines](https://github.com/Automattic/wc-calypso-bridge/blob/507bde7b933c60bb2cb7efdfad66b7bd8581b39b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php#L143-L147)).
4. Go to `Settings > WooCommerce > Site visibility`
6. Ensure `Coming soon` is selected
7. Go to `https://wordpress.com/settings/general/SITE_URL`
8. Ensure your site is not launched yet. If not, do the steps in instructions above this one
1. Go to `My Home` 
9. Click on `Launch your store` task
10. Click on `Launch your store` button
7. Go to `https://wordpress.com/settings/general/SITE_URL`
8. Observe your site is live

#### Test site visibility coming soon

1. Go to `Settings > WooCommerce > Site visibility`
1. Select `Coming soon` and click `Save changes`
7. Go to `https://wordpress.com/settings/general/SITE_URL`
8. Wait for latest settings to fetch in around 5 seconds
9. Observe `Coming soon` is selected

#### Test site visibility live

1. Go to `Settings > WooCommerce > Site visibility`
1. Select `Live` and click `Save changes`
7. Go to `https://wordpress.com/settings/general/SITE_URL`
8. Wait for latest settings to fetch in around 5 seconds
9. Observe `Public` is selected

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.