### PR TITLE
Refactor LYS to use unidirectional state flow

### DIFF
--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -37,34 +37,33 @@ class WC_Calypso_Bridge_Coming_Soon {
 	public function __construct() {
 		add_filter( 'a8c_show_coming_soon_page', array( $this, 'should_show_a8c_coming_soon_page' ), PHP_INT_MAX, 1 );
 		add_filter( 'woocommerce_coming_soon_exclude', array( $this, 'should_exclude_lys_coming_soon' ) );
-		add_action( 'update_option_wpcom_public_coming_soon', array( $this, 'sync_coming_soon_wpcom_to_lys' ), 10, 3 );
-		$this->hook_update_option_woocommerce_coming_soon();
+		add_filter( 'pre_option_woocommerce_coming_soon', array( $this, 'override_option_woocommerce_coming_soon' ) );
+		add_filter( 'pre_update_option_woocommerce_coming_soon', array( $this, 'override_update_woocommerce_coming_soon' ), 10, 2 );
+
+		if ( is_admin() ) {
+			add_filter( 'plugins_loaded', array( $this, 'maybe_add_admin_notice_pre_launch' ) );
+		}
 	}
 
 	/**
-	 * Hook on woocommerce_coming_soon option update for ease of use.
+	 * Check if Private_Site class and functions are available.
+	 *
+	 * @return bool
 	 */
-	public function hook_update_option_woocommerce_coming_soon() {
-		add_action( 'update_option_woocommerce_coming_soon' , array( $this, 'sync_coming_soon_lys_to_wpcom' ), 10, 3 );
-	}
-
-	/**
-	 * Unhook on woocommerce_coming_soon option update for ease of use.
-	 */
-	public function unhook_update_option_woocommerce_coming_soon() {
-		remove_action( 'update_option_woocommerce_coming_soon' , array( $this, 'sync_coming_soon_lys_to_wpcom' ), 10, 3 );
+	private function is_private_site_available() {
+		return function_exists( '\Private_Site\site_is_private' ) &&
+			function_exists( '\Private_Site\site_is_public_coming_soon' ) &&
+			function_exists( '\Private_Site\site_launch_status' );
 	}
 
 	/**
 	 * Hide the a8c coming soon page if the Launch Your Store feature is enabled.
 	 *
-	 * @param bool $should_show
+	 * @param bool $should_show Whether to show the coming soon page.
 	 * @return bool
 	 */
 	public function should_show_a8c_coming_soon_page( $should_show ) {
-		if (
-			class_exists( '\Automattic\WooCommerce\Admin\Features\Features' ) && \Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'launch-your-store' )
-		) {
+		if ( ! $this->is_feature_enabled() ) {
 			return false;
 		}
 
@@ -74,7 +73,7 @@ class WC_Calypso_Bridge_Coming_Soon {
 	/**
 	 * Exclude the coming soon page if the user is accessing the site via a valid share link.
 	 *
-	 * @param bool $exclude
+	 * @param bool $exclude Whether to exclude the coming soon page.
 	 * @return bool
 	 */
 	public function should_exclude_lys_coming_soon( $exclude ) {
@@ -91,50 +90,35 @@ class WC_Calypso_Bridge_Coming_Soon {
 	}
 
 	/**
-	 * Sync the coming soon option from wpcom_public_coming_soon to woocommerce_coming_soon.
+	 * Override the coming soon option value.
 	 *
-	 * @param int $old_value
-	 * @param int $new_value
-	 * @return void
+	 * @param string $current_value The current option value.
+	 * @return string
 	 */
-	public function sync_coming_soon_wpcom_to_lys( $old_value, $new_value ) {
-		if ( ! class_exists( '\Automattic\WooCommerce\Admin\Features\Features' ) || ! \Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'launch-your-store' ) ) {
-			return;
+	public function override_option_woocommerce_coming_soon( $current_value ) {
+		if ( ! $this->is_feature_enabled() || ! $this->is_private_site_available() ) {
+			return $current_value;
 		}
-
-		$woocommerce_coming_soon = get_option( 'woocommerce_coming_soon', false );
-		$is_coming_soon_wpcom = 1 === (int) $new_value;
-
-		// Value is already set, we don't need to update option.
-		if ( ( 'yes' ===  $woocommerce_coming_soon && $is_coming_soon_wpcom ) ||
-			( 'no' === $woocommerce_coming_soon && ! $is_coming_soon_wpcom ) ) {
-			return;
-		}
-
-		// Unhook listener to prevent a loop of updating option between WPCOM <-> LYS.
-		$this->unhook_update_option_woocommerce_coming_soon();
-
-		if ( $is_coming_soon_wpcom ) {
-			update_option( 'woocommerce_coming_soon', 'yes' );
-		} else {
-			update_option( 'woocommerce_coming_soon', 'no' );
-		}
-
-		$this->hook_update_option_woocommerce_coming_soon();
+		// Either private or coming soon is considered as coming soon.
+		return \Private_Site\site_is_private() || \Private_Site\site_is_public_coming_soon() ? 'yes' : 'no';
 	}
 
 	/**
-	 * Sync the coming soon option from to woocommerce_coming_soon wpcom.
-	 * Does not include a check of existing wpcom option values since
-	 * there could be multiple options that are affected.
+	 * Sends API request to WPCOM to update coming soon state or launch the site
+	 * when the option is updated. Still sets the underlying option value
+	 * to accommodate exporting sites via manual means.
 	 *
-	 * @param int $old_value
-	 * @param int $new_value
-	 * @return void
+	 * @param string $new_value The new option value.
+	 * @param string $old_value The old option value.
+	 * @return string
 	 */
-	public function sync_coming_soon_lys_to_wpcom( $old_value, $new_value ) {
-		$is_atomic_launched = 'launched' === get_option( 'launch-status' );
-		$response = false;
+	public function override_update_woocommerce_coming_soon( $new_value, $old_value ) {
+		if ( ! $this->is_feature_enabled() || ! $this->is_private_site_available() ) {
+			return $new_value;
+		}
+
+		$is_atomic_launched = 'unlaunched' !== \Private_Site\site_launch_status();
+		$response           = false;
 
 		if ( 'no' === $new_value ) {
 			if ( ! $is_atomic_launched ) {
@@ -151,32 +135,73 @@ class WC_Calypso_Bridge_Coming_Soon {
 			$error = json_decode( $body, true );
 
 			if ( isset( $error['message'] ) ) {
-				$this->add_admin_notice( $error[ 'message' ], 'error' );
+				$this->add_admin_notice( $error['message'], 'error' );
 			} else {
 				$this->add_admin_notice( __( 'There was a problem trying to update site visibility.', 'wc-calypso-bridge' ), 'error' );
 			}
+
+			// Don't update option value if there's an error.
+			return $old_value;
+		}
+
+		return $new_value;
+	}
+
+	/**
+	 * Conditionally add a notice when site is unlaunched.
+	 *
+	 * @return void
+	 */
+	public function maybe_add_admin_notice_pre_launch() {
+		if ( ! $this->is_feature_enabled() || ! $this->is_private_site_available() ) {
+			return;
+		}
+
+		$launch_status = \Private_Site\site_launch_status();
+		if ( 'unlaunched' === $launch_status ) {
+			$task_url = '/wp-admin/admin.php?page=wc-admin&path=%2Flaunch-your-store';
+			$this->add_admin_notice( sprintf( __( 'Looking to launch your site? Please visit <a href="%s">this link</a> to get started.', 'wc-calypso-bridge' ), esc_url( $task_url ) ), 'info' );
 		}
 	}
 
+	/**
+	 * Add admin notice to the Site Visibility settings page.
+	 *
+	 * @param string $message     The message to display.
+	 * @param string $notice_type The notice type.
+	 * @return void
+	 */
 	public function add_admin_notice( $message, $notice_type = 'info' ) {
-		add_action( 'admin_notices', function () use ( $message, $notice_type ) {
-			$screen    = get_current_screen();
-			$screen_id = $screen ? $screen->id : '';
+		add_action(
+			'admin_notices',
+			function () use ( $message, $notice_type ) {
+				$screen    = get_current_screen();
+				$screen_id = $screen ? $screen->id : '';
 
-			if ( 'woocommerce_page_wc-settings' !== $screen_id ) {
-				return;
+				if ( 'woocommerce_page_wc-settings' !== $screen_id ) {
+					return;
+				}
+
+				if ( ! isset( $_GET['tab'] ) || 'site-visibility' !== $_GET['tab'] ) {
+					return;
+				}
+
+				?>
+				<div class="notice notice-<?php echo esc_attr( $notice_type ); ?>">
+					<p><?php echo wp_kses_post( $message ); ?></p>
+				</div>
+				<?php
 			}
+		);
+	}
 
-			if ( ! isset( $_GET['tab'] ) || 'site-visibility' !== $_GET['tab'] ) {
-				return;
-			}
-
-			?>
-			<div class="notice notice-<?php echo $notice_type ?>">
-				<p><?php echo $message; ?></p>
-			</div>
-			<?php
-		} );
+	/**
+	 * Check if the Launch Your Store feature is enabled.
+	 *
+	 * @return bool
+	 */
+	private function is_feature_enabled() {
+		return class_exists( '\Automattic\WooCommerce\Admin\Features\Features' ) && \Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'launch-your-store' );
 	}
 }
 

--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -63,7 +63,7 @@ class WC_Calypso_Bridge_Coming_Soon {
 	 * @return bool
 	 */
 	public function should_show_a8c_coming_soon_page( $should_show ) {
-		if ( ! $this->is_feature_enabled() ) {
+		if ( $this->is_feature_enabled() ) {
 			return false;
 		}
 

--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -46,17 +46,6 @@ class WC_Calypso_Bridge_Coming_Soon {
 	}
 
 	/**
-	 * Check if Private_Site class and functions are available.
-	 *
-	 * @return bool
-	 */
-	private function is_private_site_available() {
-		return function_exists( '\Private_Site\site_is_private' ) &&
-			function_exists( '\Private_Site\site_is_public_coming_soon' ) &&
-			function_exists( '\Private_Site\site_launch_status' );
-	}
-
-	/**
 	 * Hide the a8c coming soon page if the Launch Your Store feature is enabled.
 	 *
 	 * @param bool $should_show Whether to show the coming soon page.
@@ -202,6 +191,17 @@ class WC_Calypso_Bridge_Coming_Soon {
 	 */
 	private function is_feature_enabled() {
 		return class_exists( '\Automattic\WooCommerce\Admin\Features\Features' ) && \Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'launch-your-store' );
+	}
+
+	/**
+	 * Check if Private_Site class and functions are available.
+	 *
+	 * @return bool
+	 */
+	private function is_private_site_available() {
+		return function_exists( '\Private_Site\site_is_private' ) &&
+			function_exists( '\Private_Site\site_is_public_coming_soon' ) &&
+			function_exists( '\Private_Site\site_launch_status' );
 	}
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -27,6 +27,7 @@ This section describes how to install the plugin and get it working.
 * Exclude LYS coming soon page for WPCOM share link #1501
 * Sync WPCOM coming soon status to LYS #1502
 * Add sync coming soon status from LYS to WPCOM #1503
+* Refactor LYS to use unidirectional data flow #1506
 
 = 2.5.5 =
 * Add a new class to customize for Stripe from Partner Aware Onboarding #1492


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR's main purpose is to override `woocommerce_coming_soon` option to use WPCOM's `Private_Site's` [`site_is_private` and `site_is_public_coming_soon`](https://github.com/Automattic/wpcomsh/blob/59eeb56ca1cef79e1ca1c5a1762f4b8109dcb87c/private-site/private-site.php#L97) using `pre_option_{}` and `pre_update_option_{}` to control coming soon status.

This refactor was created due to difficulty in guaranteeing data sync between LYS and WPCOM in various scenarios. Benefits of uni-directional state flow:

1. Eliminate out-of-sync issues for coming soon states
2. Simplifies state handling
3. Automatically inherit WPCOM's coming soon behaviours for migration and new sites
    - However, we'll still deal with migrations and new site logic in follow-ups

Also with this PR, I added admin notice when site is not launched to advocate users to launch using LYS task.

#### Known issues

- It seems updating from `Private` isn't possible via LYS. This may need a follow-up

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### Definition

1. "Site visibility page" is site's settings page at `Settings > WooCommerce > Site visibility`
2. "General settings page" is WPCOM's general settings page at `https://wordpress.com/settings/general/SITE_URL`
3. "LYS task" is Launch Your Store task at `Home > Launch Your Store`

#### How to un-launch your site

1. SSH into your sandbox
5. Run unlaunch script `php ~/public_html/bin/atomic/unlaunch-site.php SITE_URL` - Replace `SITE_URL` with your atomic site URL
6. If your site is still not "unlaunched", you can try ssh into your atomic site and run `wp option set launch-status launched` and run the unlaunch script again

#### Admin notice on site visibility page

1. Use a WPCOM atomic e-commerce site
1. Enable LYS feature flag (via beta tester or you can remove [these lines](https://github.com/Automattic/wc-calypso-bridge/blob/507bde7b933c60bb2cb7efdfad66b7bd8581b39b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php#L143-L147)).
1. Un-launch your site if it's launched
2. Go to site visibility page
3. Observe `Coming soon` is selected
4. Observe the admin notice `Looking to launch your site? Please visit this link to get started.`
5. Click on the admin notice link and observe you're navigated to LYS task

<img width="500" alt="image" src="https://github.com/user-attachments/assets/0d99c92e-aef3-44f7-98b9-1d9c4029d170">

#### Launch via LYS

1. In LYS task, click on `Launch your store`
1. Go to site visibility page and observe `Live` is selected
3. Go to general settings page and observe `Public` is selected

#### Launch via WPCOM

1. Un-launch your site if it's launched
1. Go to general settings page and click `Launch site`
1. Observe `Public` is selected after the request is completed
1. Go to site visibility page and observe `Live` is selected

#### Update settings via WPCOM

1. In general settings page, select `Private` and click `Save settings`
1. Go to site visibility page and observe `Coming soon` is selected
1. In general settings page, select `Public` and click `Save settings`
1. Go to site visibility page and observe `Live` is selected
1. In general settings page, select `Coming Soon` and click `Save settings`
1. Go to site visibility page and observe `Coming soon` is selected

#### Update settings via LYS

1. In site visibility page, select `Live` and click `Save changes`
1. Go to general settings page and observe `Public` is selected
1. In site visibility page, select `Coming soon` and click `Save changes`
1. Go to general settings page and observe `Coming Soon` is selected

#### LYS coming soon page applied

1. In an incognito window, open site's frontend
4. Observe LYS coming soon page is displayed


<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
