### PR TITLE
Disable launch your store on trial sites

### DIFF
--- a/class-wc-calypso-bridge-dotcom-features.php
+++ b/class-wc-calypso-bridge-dotcom-features.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   2.0.0
- * @version 2.2.22
+ * @version x.x.x
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/class-wc-calypso-bridge-dotcom-features.php
+++ b/class-wc-calypso-bridge-dotcom-features.php
@@ -370,7 +370,7 @@ class WC_Calypso_Bridge_DotCom_Features {
 		if ( is_null( self::$is_trial_plan ) ) {
 			self::$is_trial_plan = self::is_ecommerce_trial_plan()
 				// Business trial plans
-				|| self::has_any_of_plans( array('wp-bundle-hosting-trial',  'wp-bundle-migration-trial'), true );
+				|| self::has_any_of_plans( array( 'wp-bundle-hosting-trial',  'wp-bundle-migration-trial' ), true );
 
 		}
 

--- a/class-wc-calypso-bridge-dotcom-features.php
+++ b/class-wc-calypso-bridge-dotcom-features.php
@@ -361,37 +361,32 @@ class WC_Calypso_Bridge_DotCom_Features {
 		return self::$is_business_plan;
 	}
 
+	/**
+	 * Determine if the site is on a trial plan.
+	 *
+	 * @return bool True if the site is on a trial plan, false otherwise.
+	 */
 	public static function is_trial_plan() {
 		if ( is_null( self::$is_trial_plan ) ) {
 			self::$is_trial_plan = self::is_ecommerce_trial_plan()
 				// Business trial plans
-				|| self::has_plan( 'wp-bundle-hosting-trial', true )
-				|| self::has_plan( 'wp-bundle-migration-trial', true );
+				|| self::has_any_of_plans( array('wp-bundle-hosting-trial',  'wp-bundle-migration-trial'), true );
+
 		}
 
 		return self::$is_trial_plan;
 	}
 
+
 	/**
-	 * Check if the site has a specific plan.
+	 * Check if the site has any of the specified plans.
 	 *
-	 * @param string $plan The plan to check for.
-	 * @param bool $exact_one_plan If true, the site must have exactly one plan.
+	 * @param array $plans           The plans to check for. An array of plan slugs.
+	 * @param bool  $exact_one_plan If true, the site must have exactly one plan purchase.
 	 *
-	 * @return bool True if the site has the plan, false otherwise.
+	 * @return bool True if the site has any of the specified plans (or exactly one plan if $exact_one_plan is true). False otherwise.
 	 */
-	/**
-	 * Check if the site has a specific plan.
-	 *
-	 * This method checks if the current site has a particular plan based on its purchases.
-	 * It can optionally check if the site has exactly one plan.
-	 *
-	 * @param string $plan           The plan slug to check for.
-	 * @param bool   $exact_one_plan If true, the site must have exactly one plan.
-	 *
-	 * @return bool True if the site has the specified plan, false otherwise.
-	 */
-	private static function has_plan( $plan, $exact_one_plan = false ) {
+	private static function has_any_of_plans( $plans, $exact_one_plan = true ) {
 		if ( ! function_exists( 'wpcom_get_site_purchases' ) ) {
 			return false;
 		}
@@ -410,7 +405,7 @@ class WC_Calypso_Bridge_DotCom_Features {
 		}
 
 		foreach ( $bundles as $bundle ) {
-			if ( isset( $bundle->billing_product_slug ) && $bundle->billing_product_slug === $plan ) {
+			if ( isset( $bundle->billing_product_slug ) && in_array(  $bundle->billing_product_slug, $plans, true ) ) {
 				return true;
 			}
 		}

--- a/class-wc-calypso-bridge-dotcom-features.php
+++ b/class-wc-calypso-bridge-dotcom-features.php
@@ -380,6 +380,17 @@ class WC_Calypso_Bridge_DotCom_Features {
 	 *
 	 * @return bool True if the site has the plan, false otherwise.
 	 */
+	/**
+	 * Check if the site has a specific plan.
+	 *
+	 * This method checks if the current site has a particular plan based on its purchases.
+	 * It can optionally check if the site has exactly one plan.
+	 *
+	 * @param string $plan           The plan slug to check for.
+	 * @param bool   $exact_one_plan If true, the site must have exactly one plan.
+	 *
+	 * @return bool True if the site has the specified plan, false otherwise.
+	 */
 	private static function has_plan( $plan, $exact_one_plan = false ) {
 		if ( ! function_exists( 'wpcom_get_site_purchases' ) ) {
 			return false;
@@ -390,8 +401,10 @@ class WC_Calypso_Bridge_DotCom_Features {
 			return false;
 		}
 
+		// Filter purchases to get only bundles.
 		$bundles = wp_list_filter( $all_site_purchases, array( 'product_type' => 'bundle' ) );
 
+		// If exact_one_plan is true, ensure there's exactly one bundle
 		if ( $exact_one_plan && count( $bundles ) !== 1 ) {
 			return false;
 		}

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -187,6 +187,7 @@ class WC_Calypso_Bridge {
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/free-trial/partners/class-wc-calypso-bridge-partner-stripe.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/free-trial/partners/class-wc-calypso-bridge-partner-paypal.php';
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-coming-soon.php';
+		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/class-wc-calypso-bridge-admin-settings.php';
 
 		// Experiments.
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/experiments/class-wc-calypso-bridge-task-list-reminderbar-experiment.php';

--- a/includes/class-wc-calypso-bridge-admin-settings.php
+++ b/includes/class-wc-calypso-bridge-admin-settings.php
@@ -8,7 +8,7 @@ defined( 'ABSPATH' ) || exit;
  * @since   x.x.x
  * @version x.x.x
  *
- * Handle Coming Soon mode.
+ * Handle Admin Settings.
  */
 class WC_Calypso_Bridge_Admin_Settings {
 	/**

--- a/includes/class-wc-calypso-bridge-admin-settings.php
+++ b/includes/class-wc-calypso-bridge-admin-settings.php
@@ -35,6 +35,10 @@ class WC_Calypso_Bridge_Admin_Settings {
 	 * Constructor.
 	 */
 	public function __construct() {
+		if ( ! is_admin() ) {
+			return;
+		}
+
 		add_filter( 'woocommerce_settings_tabs_array', array( $this, 'replace_settings_tab' ), PHP_INT_MAX );
 	}
 
@@ -47,7 +51,7 @@ class WC_Calypso_Bridge_Admin_Settings {
 	public function replace_settings_tab( $tabs ) {
 		global $current_tab;
 
-		if ( wc_calypso_bridge_is_ecommerce_trial_plan() ) {
+		if ( wc_calypso_bridge_is_trial_plan() ) {
 			// Remove Site Visibility setting for the free trial plan.
 			unset( $tabs['site-visibility'] );
 

--- a/includes/class-wc-calypso-bridge-admin-settings.php
+++ b/includes/class-wc-calypso-bridge-admin-settings.php
@@ -1,0 +1,64 @@
+<?php
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class WC_Calypso_Bridge_Admin_Settings
+ *
+ * @since   x.x.x
+ * @version x.x.x
+ *
+ * Handle Coming Soon mode.
+ */
+class WC_Calypso_Bridge_Admin_Settings {
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var WC_Calypso_Bridge_Admin_Settings
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return object Instance.
+	 */
+	final public static function get_instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_filter( 'woocommerce_settings_tabs_array', array( $this, 'replace_settings_tab' ), PHP_INT_MAX );
+	}
+
+	/**
+	 * Replace the settings tab.
+	 *
+	 * @param array $tabs The tabs.
+	 * @return array The tabs.
+	 */
+	public function replace_settings_tab( $tabs ) {
+		global $current_tab;
+
+		if ( wc_calypso_bridge_is_ecommerce_trial_plan() ) {
+			// Remove Site Visibility setting for the free trial plan.
+			unset( $tabs['site-visibility'] );
+
+			if ( isset( $current_tab ) && $current_tab === 'site-visibility' ) {
+				wp_safe_redirect( admin_url( 'admin.php?page=wc-settings' ) );
+				exit;
+			}
+		}
+
+		return $tabs;
+	}
+}
+
+WC_Calypso_Bridge_Admin_Settings::get_instance();

--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -86,7 +86,7 @@ class WC_Calypso_Bridge_Coming_Soon {
 	 */
 	public function override_option_woocommerce_coming_soon( $current_value ) {
 		// Turn off coming soon mode for trial plan.
-		if ( wc_calypso_bridge_is_ecommerce_trial_plan() ) {
+		if ( wc_calypso_bridge_is_trial_plan() ) {
 			return 'no';
 		}
 

--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -198,8 +198,8 @@ class WC_Calypso_Bridge_Coming_Soon {
 	 * @return void
 	 */
 	public function possibly_remove_site_visibility_badge( $wp_admin_bar  ) {
-		// TODO: Check if feature is enabled when the site visibility badge is behind the feature flag.
-		if ( wc_calypso_bridge_is_trial_plan() ) {
+		// TODO: Remove feature check once the site visibility badge is behind feature flag in core.
+		if ( wc_calypso_bridge_is_trial_plan() || ! $this->is_feature_enabled() ) {
 			$wp_admin_bar->remove_node( 'woocommerce-site-visibility-badge' );
 		}
 	}

--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -85,6 +85,11 @@ class WC_Calypso_Bridge_Coming_Soon {
 	 * @return string
 	 */
 	public function override_option_woocommerce_coming_soon( $current_value ) {
+		// Turn off coming soon mode for trial plan.
+		if ( wc_calypso_bridge_is_ecommerce_trial_plan() ) {
+			return 'no';
+		}
+
 		if ( ! $this->is_feature_enabled() || ! $this->is_private_site_available() ) {
 			return $current_value;
 		}
@@ -202,20 +207,6 @@ class WC_Calypso_Bridge_Coming_Soon {
 		return function_exists( '\Private_Site\site_is_private' ) &&
 			function_exists( '\Private_Site\site_is_public_coming_soon' ) &&
 			function_exists( '\Private_Site\site_launch_status' );
-	}
-
-	/**
-	 * Disable the coming soon page if the user is on the free trial plan.
-	 *
-	 * @param string $value
-	 * @return string
-	 */
-	public function possibly_disable_lys_coming_soon( $value ) {
-		if ( wc_calypso_bridge_is_ecommerce_trial_plan() ) {
-			return 'no';
-		}
-
-		return $value;
 	}
 }
 

--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -39,6 +39,8 @@ class WC_Calypso_Bridge_Coming_Soon {
 		add_filter( 'woocommerce_coming_soon_exclude', array( $this, 'should_exclude_lys_coming_soon' ) );
 		add_filter( 'pre_option_woocommerce_coming_soon', array( $this, 'override_option_woocommerce_coming_soon' ) );
 		add_filter( 'pre_update_option_woocommerce_coming_soon', array( $this, 'override_update_woocommerce_coming_soon' ), 10, 2 );
+		// Admin bar menu is not only shown in the admin area but also in the front end when the admin user is logged in.
+		add_action( 'admin_bar_menu', array( $this, 'possibly_remove_site_visibility_badge' ), 32 );
 
 		if ( is_admin() ) {
 			add_filter( 'plugins_loaded', array( $this, 'maybe_add_admin_notice_pre_launch' ) );
@@ -52,7 +54,7 @@ class WC_Calypso_Bridge_Coming_Soon {
 	 * @return bool
 	 */
 	public function should_show_a8c_coming_soon_page( $should_show ) {
-		if ( $this->is_feature_enabled() ) {
+		if ( $this->is_feature_enabled() && ! wc_calypso_bridge_is_trial_plan() ) {
 			return false;
 		}
 
@@ -187,6 +189,19 @@ class WC_Calypso_Bridge_Coming_Soon {
 				<?php
 			}
 		);
+	}
+
+	/**
+	 * Possibly remove the site visibility badge from the admin bar.
+	 *
+	 * @param WP_Admin_Bar $wp_admin_bar The admin bar instance.
+	 * @return void
+	 */
+	public function possibly_remove_site_visibility_badge( $wp_admin_bar  ) {
+		// TODO: Check if feature is enabled when the site visibility badge is behind the feature flag.
+		if ( wc_calypso_bridge_is_trial_plan() ) {
+			$wp_admin_bar->remove_node( 'woocommerce-site-visibility-badge' );
+		}
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -203,6 +203,20 @@ class WC_Calypso_Bridge_Coming_Soon {
 			function_exists( '\Private_Site\site_is_public_coming_soon' ) &&
 			function_exists( '\Private_Site\site_launch_status' );
 	}
+
+	/**
+	 * Disable the coming soon page if the user is on the free trial plan.
+	 *
+	 * @param string $value
+	 * @return string
+	 */
+	public function possibly_disable_lys_coming_soon( $value ) {
+		if ( wc_calypso_bridge_is_ecommerce_trial_plan() ) {
+			return 'no';
+		}
+
+		return $value;
+	}
 }
 
 WC_Calypso_Bridge_Coming_Soon::get_instance();

--- a/includes/class-wc-calypso-bridge-setup-tasks.php
+++ b/includes/class-wc-calypso-bridge-setup-tasks.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   2.0.0
- * @version 2.3.3
+ * @version x.x.x
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -140,6 +140,12 @@ class WC_Calypso_Bridge_Setup_Tasks {
 					case 'purchase':
 						// Remove appearance and purchase task.
 						unset( $lists['setup']->tasks[$index] );
+						break;
+					case 'launch-your-store':
+						if ( wc_calypso_bridge_is_ecommerce_trial_plan() ){
+							// Remove launch your store task.
+							unset( $lists['setup']->tasks[$index] );
+						}
 						break;
 				}
 			}

--- a/includes/class-wc-calypso-bridge-setup-tasks.php
+++ b/includes/class-wc-calypso-bridge-setup-tasks.php
@@ -142,8 +142,8 @@ class WC_Calypso_Bridge_Setup_Tasks {
 						unset( $lists['setup']->tasks[$index] );
 						break;
 					case 'launch-your-store':
-						if ( wc_calypso_bridge_is_ecommerce_trial_plan() ){
-							// Remove launch your store task.
+						if ( wc_calypso_bridge_is_trial_plan() ) {
+							// Don't show launch your store task for trial sites.
 							unset( $lists['setup']->tasks[$index] );
 						}
 						break;

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -140,10 +140,7 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 	 * @return array
 	 */
 	public function filter_woocommerce_admin_features( $features ) {
-		// Disable launch-your-store to prevent clashes with similar functionality already provided.
-		if ( isset( $features['launch-your-store'] ) ) {
-			$features['launch-your-store'] = false;
-		}
+
 
 		// The rest applies only to Entrepreneur and Woo Express plans.
 		if ( ! wc_calypso_bridge_has_ecommerce_features() ) {

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -140,7 +140,10 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 	 * @return array
 	 */
 	public function filter_woocommerce_admin_features( $features ) {
-
+		// Disable launch-your-store to prevent clashes with similar functionality already provided.
+		if ( isset( $features['launch-your-store'] ) ) {
+			$features['launch-your-store'] = false;
+		}
 
 		// The rest applies only to Entrepreneur and Woo Express plans.
 		if ( ! wc_calypso_bridge_has_ecommerce_features() ) {

--- a/readme.txt
+++ b/readme.txt
@@ -28,6 +28,7 @@ This section describes how to install the plugin and get it working.
 * Sync WPCOM coming soon status to LYS #1502
 * Add sync coming soon status from LYS to WPCOM #1503
 * Refactor LYS to use unidirectional data flow #1506
+* Disable launch your store on trial sites #1507
 
 = 2.5.5 =
 * Add a new class to customize for Stripe from Partner Aware Onboarding #1492


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/Automattic/wc-calypso-bridge/issues/1504.

 Apply all of the below for trial plans (both ecommerce and business trial plans) 

@ilyasfoo I'm using `wc_calypso_bridge_is_ecommerce_trial_plan()` to check if the store is on a trial plan. I'm not sure if this is sufficient. Please let me know if there is a better way to check if the store is on any trial plan. 🙏 

- Hide `Site visibility` settings tabs
- Hide `Launch your store` task
- Disable WPCOM coming soon page override implemented in [this PR](https://github.com/Automattic/wc-calypso-bridge/pull/1500)
- Disable the coming soon banner [shown in frontend](https://github.com/user-attachments/assets/02fc7a23-e4b6-406d-835b-0fb454cf4bb2) 
- Hide site visibility badge


<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Setting up a free eCommerce trial site for development peapX7-1D4-p2
2. Use master branch
3. Enable LYS feature flag (via beta tester or you can remove [these lines](https://github.com/Automattic/wc-calypso-bridge/blob/507bde7b933c60bb2cb7efdfad66b7bd8581b39b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php#L143-L147)).
4. Go to /wp-admin/admin.php?page=wc-settings&tab=site-visibility
5. Enable `Coming Soon` mode
6. Checkout this branch
7. Go to /wp-admin/admin.php?page=wc-settings&tab=site-visibility and confirm you're redirected to /wp-admin/admin.php?page=wc-settings
8. Confirm `Site visibility` settings tabs are hidden
9. Go to WooCommerce > Home and confirm `Launch your store` task is hidden
10. Go to the frontend and confirm the coming soon banner is not shown
11. Go to the frontend in incognito mode and confirm the LYS coming soon page is not shown
12. Confirm site visibility badge is not shown

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.