### PR TITLE
Add conditional check to replace launch-site task with LYS task

### DIFF
--- a/includes/class-wc-calypso-bridge-setup-tasks.php
+++ b/includes/class-wc-calypso-bridge-setup-tasks.php
@@ -110,15 +110,18 @@ class WC_Calypso_Bridge_Setup_Tasks {
 
 		$tl = \Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists::instance();
 		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/tasks/class-wc-calypso-task-add-domain.php';
-		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/tasks/class-wc-calypso-task-launch-site.php';
 
 		$list = $tl::get_lists_by_ids( array( 'setup' ) );
 		$list = array_pop( $list );
 
 		$add_domain_task  = new \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\AddDomain( $list );
-		$launch_site_task = new \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\LaunchSite( $list );
 		$tl::add_task( 'setup', $add_domain_task );
-		$tl::add_task( 'setup', $launch_site_task );
+
+		if ( ! class_exists( '\Automattic\WooCommerce\Admin\Features\Features' ) || ! \Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'launch-your-store' ) ) {
+			require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/tasks/class-wc-calypso-task-launch-site.php';
+			$launch_site_task = new \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\LaunchSite( $list );
+			$tl::add_task( 'setup', $launch_site_task );
+		}
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-setup-tasks.php
+++ b/includes/class-wc-calypso-bridge-setup-tasks.php
@@ -42,7 +42,6 @@ class WC_Calypso_Bridge_Setup_Tasks {
 		// All plans.
 		add_action( 'load-woocommerce_page_wc-settings', array( $this, 'redirect_store_details_onboarding' ) );
 		add_action( 'wp_ajax_launch_store', array( $this, 'handle_ajax_launch_endpoint' ) );
-		add_action( 'init', array( $this, 'add_tasks' ) );
 		add_filter( 'woocommerce_admin_experimental_onboarding_tasklists', [ $this, 'replace_tasks' ] );
 		add_filter( 'get_user_metadata', array( $this, 'override_user_meta_field' ), 10, 4 );
 	}
@@ -86,14 +85,9 @@ class WC_Calypso_Bridge_Setup_Tasks {
 	}
 
 	/**
-	 * Add Setup Tasks.
+	 * Add and replace setup tasks.
 	 */
-	public function add_tasks() {
-
-		if ( ! class_exists( '\Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists' ) ) {
-			return;
-		}
-
+	public function replace_tasks( $lists ) {
 		/**
 		 * `ecommerce_custom_setup_tasks_enabled` filter.
 		 *
@@ -104,30 +98,7 @@ class WC_Calypso_Bridge_Setup_Tasks {
 		 * @param  bool $status_enabled
 		 * @return bool
 		 */
-		if ( ! (bool) apply_filters( 'ecommerce_custom_setup_tasks_enabled', true ) ) {
-			return;
-		}
-
-		$tl = \Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists::instance();
-		require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/tasks/class-wc-calypso-task-add-domain.php';
-
-		$list = $tl::get_lists_by_ids( array( 'setup' ) );
-		$list = array_pop( $list );
-
-		$add_domain_task  = new \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\AddDomain( $list );
-		$tl::add_task( 'setup', $add_domain_task );
-
-		if ( ! class_exists( '\Automattic\WooCommerce\Admin\Features\Features' ) || ! \Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'launch-your-store' ) ) {
-			require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/tasks/class-wc-calypso-task-launch-site.php';
-			$launch_site_task = new \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\LaunchSite( $list );
-			$tl::add_task( 'setup', $launch_site_task );
-		}
-	}
-
-	/**
-	 * Replace setup tasks.
-	 */
-	public function replace_tasks( $lists ) {
+		$ecommerce_custom_setup_tasks_enabled = (bool) apply_filters( 'ecommerce_custom_setup_tasks_enabled', true );
 		if ( isset( $lists['setup'] ) ) {
 			// Default product task index.
 			$product_task_index = 2;
@@ -144,6 +115,15 @@ class WC_Calypso_Bridge_Setup_Tasks {
 						// Remove appearance and purchase task.
 						unset( $lists['setup']->tasks[$index] );
 						break;
+					case 'launch-your-store':
+					case 'launch_site':
+						if ( $ecommerce_custom_setup_tasks_enabled ) {
+							// Append add domain task after launch your store task.
+							require_once __DIR__ . '/tasks/class-wc-calypso-task-add-domain.php';
+							$add_domain_task = array( new \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\AddDomain( $lists['setup'] ) );
+							array_splice( $lists['setup']->tasks, $index, 0, $add_domain_task );
+						}
+						break;
 				}
 			}
 
@@ -152,6 +132,12 @@ class WC_Calypso_Bridge_Setup_Tasks {
 				require_once __DIR__ . '/tasks/class-wc-calypso-task-appearance.php';
 				$appearance_task = array( new \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\WCBridgeAppearance( $lists['setup'] ) );
 				array_splice( $lists['setup']->tasks, $product_task_index, 0, $appearance_task );
+			}
+
+			if ( ! Features::is_enabled( 'launch-your-store' ) && $ecommerce_custom_setup_tasks_enabled ) {
+				require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/tasks/class-wc-calypso-task-launch-site.php';
+				$launch_site_task = new \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\LaunchSite( $lists['setup'] );
+				$lists['setup']->tasks[] = $launch_site_task;
 			}
 		}
 		return $lists;

--- a/includes/class-wc-calypso-bridge-setup-tasks.php
+++ b/includes/class-wc-calypso-bridge-setup-tasks.php
@@ -116,12 +116,18 @@ class WC_Calypso_Bridge_Setup_Tasks {
 						unset( $lists['setup']->tasks[$index] );
 						break;
 					case 'launch-your-store':
-					case 'launch_site':
 						if ( $ecommerce_custom_setup_tasks_enabled ) {
-							// Append add domain task after launch your store task.
+							// Append add domain task before launch your store task.
 							require_once __DIR__ . '/tasks/class-wc-calypso-task-add-domain.php';
 							$add_domain_task = array( new \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\AddDomain( $lists['setup'] ) );
 							array_splice( $lists['setup']->tasks, $index, 0, $add_domain_task );
+
+							// Replace launch your store task with launch site task.
+							if ( ! Features::is_enabled( 'launch-your-store' ) ) {
+								require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/tasks/class-wc-calypso-task-launch-site.php';
+								$launch_site_task = new \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\LaunchSite( $lists['setup'] );
+								$lists['setup']->tasks[$index + 1] = $launch_site_task;
+							}
 						}
 						break;
 				}
@@ -132,12 +138,6 @@ class WC_Calypso_Bridge_Setup_Tasks {
 				require_once __DIR__ . '/tasks/class-wc-calypso-task-appearance.php';
 				$appearance_task = array( new \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\WCBridgeAppearance( $lists['setup'] ) );
 				array_splice( $lists['setup']->tasks, $product_task_index, 0, $appearance_task );
-			}
-
-			if ( ! Features::is_enabled( 'launch-your-store' ) && $ecommerce_custom_setup_tasks_enabled ) {
-				require_once WC_CALYPSO_BRIDGE_PLUGIN_PATH . '/includes/tasks/class-wc-calypso-task-launch-site.php';
-				$launch_site_task = new \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\LaunchSite( $lists['setup'] );
-				$lists['setup']->tasks[] = $launch_site_task;
 			}
 		}
 		return $lists;

--- a/readme.txt
+++ b/readme.txt
@@ -28,6 +28,7 @@ This section describes how to install the plugin and get it working.
 * Sync WPCOM coming soon status to LYS #1502
 * Add sync coming soon status from LYS to WPCOM #1503
 * Refactor LYS to use unidirectional data flow #1506
+* Add conditional check to replace launch-site task with LYS task #1509
 
 = 2.5.5 =
 * Add a new class to customize for Stripe from Partner Aware Onboarding #1492


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1497

- Replace `launch-site` task with LYS task when LYS feature is enabled. 
- Refactor and merge `add_tasks` function to `replace_tasks` to consolidate logic and enable easier tasks sorting

I decided to skip adding a redirect from `/wp-admin/admin.php?page=wc-admin&task=launch_site` because it doesn't seem to be a simple endeavour and it only serves a tiny edge case like users having the link opened. 

This PR does not handle free trial detection yet.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### Test LYS feature enabled
1. Use a WPCOM atomic e-commerce site
1. Enable LYS feature flag (via beta tester or you can set [these lines](https://github.com/Automattic/wc-calypso-bridge/blob/507bde7b933c60bb2cb7efdfad66b7bd8581b39b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php#L143-L147) to `true`).
1. Go to Homescreen
2. Observe LYS task is displayed and `launch-site` task is hidden
3. Observe LYS task is displayed after `Add a domain` task

#### Test LYS feature disabled

1. Disable LYS feature flag (via beta tester or you can set [these lines](https://github.com/Automattic/wc-calypso-bridge/blob/507bde7b933c60bb2cb7efdfad66b7bd8581b39b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php#L143-L147) to `false`).
1. Go to Homescreen
2. Observe `launch-site` task is displayed and LYS task is hidden
3. Observe `launch-site` task is displayed after `Add a domain` task


<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
