### PR TITLE
Fix logic for disabling lys task on trial sites

### DIFF
--- a/includes/class-wc-calypso-bridge-setup-tasks.php
+++ b/includes/class-wc-calypso-bridge-setup-tasks.php
@@ -116,6 +116,10 @@ class WC_Calypso_Bridge_Setup_Tasks {
 						unset( $lists['setup']->tasks[$index] );
 						break;
 					case 'launch-your-store':
+						if ( wc_calypso_bridge_is_trial_plan() ) {
+							// Don't show launch your store task for trial sites.
+							unset( $lists['setup']->tasks[$index] );
+						}
 						if ( $ecommerce_custom_setup_tasks_enabled ) {
 							// Append add domain task before launch your store task.
 							require_once __DIR__ . '/tasks/class-wc-calypso-task-add-domain.php';
@@ -128,9 +132,6 @@ class WC_Calypso_Bridge_Setup_Tasks {
 								$launch_site_task = new \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\LaunchSite( $lists['setup'] );
 								$lists['setup']->tasks[$index + 1] = $launch_site_task;
 							}
-						} else if ( wc_calypso_bridge_is_trial_plan() ) {
-							// Don't show launch your store task for trial sites.
-							unset( $lists['setup']->tasks[$index] );
 						}
 						break;
 				}

--- a/readme.txt
+++ b/readme.txt
@@ -30,6 +30,7 @@ This section describes how to install the plugin and get it working.
 * Refactor LYS to use unidirectional data flow #1506
 * Disable launch your store on trial sites #1507
 * Add conditional check to replace launch-site task with LYS task #1509
+* Fix logic for disabling lys task on trial sites #1511
 
 = 2.5.5 =
 * Add a new class to customize for Stripe from Partner Aware Onboarding #1492


### PR DESCRIPTION
Quick fix on displaying LYS task. Currently, it seems LYS task is shown in ecommerce trial plan sites.

### After fix

#### Business trial plan:
<img width="793" alt="image" src="https://github.com/user-attachments/assets/39c4c365-47cd-4e91-a1f1-6de9f4b74ede">

#### Ecommerce trial plan:
<img width="786" alt="image" src="https://github.com/user-attachments/assets/1455ba9f-2c9d-4d2a-85e9-80b9f6287572">


#### Ecommerce plan:
<img width="779" alt="image" src="https://github.com/user-attachments/assets/839e9bb1-9430-4c51-948f-fe68dffdcc85">
