### PR TITLE
Fix LYS badge override

### DIFF
--- a/assets/css/nav-unification.css
+++ b/assets/css/nav-unification.css
@@ -40,3 +40,13 @@
 		width: calc( 100% - 36px );
 	}
 }
+
+/* Monkey patch for fresh theme color overriding LYS badge on admin bar. */
+.admin-color-fresh #wpadminbar:not(.mobile) .ab-top-menu>li#wp-admin-bar-woocommerce-site-visibility-badge:hover>.ab-item {
+	background-color: #DCDCDE !important;
+}
+
+.admin-color-fresh #wpadminbar:not(.mobile) .ab-top-menu>li#wp-admin-bar-woocommerce-site-visibility-badge.woocommerce-site-status-badge-live:hover>.ab-item {
+	background-color: #B8E6BF !important;
+}
+/* End monkey patch */

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,7 @@ This section describes how to install the plugin and get it working.
 
 = Unreleased =
 * Re-enable Site visibility settings tab for free trial plans #1512
+* Fix LYS badge override #1517
 
 = 2.6.0 =
 * Hide WPCOM's coming soon page when the launch-your-store feature flag is enabled #1500


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/Automattic/wc-calypso-bridge/issues/1516

This PR fixes LYS badge style overridden by default admin color scheme.

I used `nav-unification.css` because I didn't want to add a new globally-loaded CSS for a mere couple lines fix.

#### Before

<img width="317" alt="image" src="https://github.com/user-attachments/assets/5c905ef1-1c9e-4ad0-af66-2f34986733e4">
<img width="227" alt="image" src="https://github.com/user-attachments/assets/0909b087-904f-401d-89e3-00b8fac553e3">

#### After

<img width="301" alt="image" src="https://github.com/user-attachments/assets/365f789d-170f-41f6-8c26-a65aa074a3ff">
<img width="242" alt="image" src="https://github.com/user-attachments/assets/63c79015-7cbd-4365-b1c7-1767dfe9bb0c">


### How to test the changes in this Pull Request:

1. Use a WPCOM atomic e-commerce site
1. Enable LYS feature flag (you can set [these lines](https://github.com/Automattic/wc-calypso-bridge/blob/507bde7b933c60bb2cb7efdfad66b7bd8581b39b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php#L143-L147) to `true`).
2. Go to `/wp-admin/profile.php`
3. Select `Default` admin color scheme and click `Update Profile`
4. Hover the LYS badge
5. Observe that it does not have a black background color
6. Go to `Settings > WooCommerce > Site visibility`
7. If it was `Live`, set to `Coming soon`, and vice versa. Click `Save changes`
4. Hover the LYS badge
5. Observe that it does not have a dark background color

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
