### PR TITLE
Revert "Fix LYS badge override (#1517)"

### DIFF
--- a/assets/css/nav-unification.css
+++ b/assets/css/nav-unification.css
@@ -40,13 +40,3 @@
 		width: calc( 100% - 36px );
 	}
 }
-
-/* Monkey patch for fresh theme color overriding LYS badge on admin bar. */
-.admin-color-fresh #wpadminbar:not(.mobile) .ab-top-menu>li#wp-admin-bar-woocommerce-site-visibility-badge:hover>.ab-item {
-	background-color: #DCDCDE !important;
-}
-
-.admin-color-fresh #wpadminbar:not(.mobile) .ab-top-menu>li#wp-admin-bar-woocommerce-site-visibility-badge.woocommerce-site-status-badge-live:hover>.ab-item {
-	background-color: #B8E6BF !important;
-}
-/* End monkey patch */

--- a/readme.txt
+++ b/readme.txt
@@ -24,7 +24,6 @@ This section describes how to install the plugin and get it working.
 
 = Unreleased =
 * Re-enable Site visibility settings tab for free trial plans #1512
-* Fix LYS badge override #1517
 
 = 2.6.0 =
 * Hide WPCOM's coming soon page when the launch-your-store feature flag is enabled #1500


### PR DESCRIPTION
This reverts commit ec38584f030bfe33150aab245f769214ddbf2845.

### Changes proposed in this Pull Request:

Since badge is going to be removed in https://github.com/Automattic/wc-calypso-bridge/pull/1519, the recent change is made irrelevant

### How to test the changes in this Pull Request:

1. Reviewing the code change should be sufficient
