### PR TITLE
Remove `launch-your-store` feature flag override

### DIFF
--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -140,11 +140,6 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 	 * @return array
 	 */
 	public function filter_woocommerce_admin_features( $features ) {
-		// Disable launch-your-store to prevent clashes with similar functionality already provided.
-		if ( isset( $features['launch-your-store'] ) ) {
-			$features['launch-your-store'] = false;
-		}
-
 		// The rest applies only to Entrepreneur and Woo Express plans.
 		if ( ! wc_calypso_bridge_has_ecommerce_features() ) {
 			return $features;

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 2.5.2
+ * @version x.x.x
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,7 @@ This section describes how to install the plugin and get it working.
 
 = Unreleased =
 * Re-enable Site visibility settings tab for free trial plans #1512
+* Remove launch-your-store feature flag override #1521
 
 = 2.6.0 =
 * Hide WPCOM's coming soon page when the launch-your-store feature flag is enabled #1500


### PR DESCRIPTION
### Changes proposed in this Pull Request:

P2: pfwcF5-Cs-p2

In order to enable `launch-your-store` feature in WPCOM sites, we need to remove the feature flag override.

### How to test the changes in this Pull Request:

1. Use a WPCOM atomic e-commerce site
2. Go to `Settings > WooCommerce > Site visibility`
7. In an incognito window, open up site's frontend
8. Observe LYS branded coming soon page is displayed
3. Set to `Coming soon` and save
1. Open up `/_cli` in a new tab
4. Run `plugin install --activate https://github.com/woocommerce/woocommerce/releases/download/wc-beta-tester-2.4.0/woocommerce-beta-tester.zip` to install WCA Test Helper plugin
5. Go to `Tools > WCA Test Helper > Features`
6. Disable `Launch your store`
7. In an incognito window, open up site's frontend
3. Observe WPCOM branded coming soon page is displayed

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.