### PR TITLE
Remove LYS badge even when feature flag is disabled

### DIFF
--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -209,7 +209,7 @@ class WC_Calypso_Bridge_Coming_Soon {
 	 * @return void
 	 */
 	public function remove_site_visibility_badge( $wp_admin_bar ) {
-		if ( $wp_admin_bar && $this->is_feature_enabled() ) {
+		if ( $wp_admin_bar ) {
 			$wp_admin_bar->remove_node( 'woocommerce-site-visibility-badge' );
 		}
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In WooCommerce 9.3, coming soon badge is shown despite the feature flag being disabled. It was fixed in [9.4](https://github.com/woocommerce/woocommerce/pull/51159), but at the time of writing this bug will affect WPCOM.

This PR forces removal of the badge regardless of WC version.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Disable LYS feature flag
2. In Homescreen, observe coming soon badge does not show in admin bar

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
