### PR TITLE
Fix coming soon unintentionally expose the rest of the site

### DIFF
--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -6,7 +6,7 @@ defined( 'ABSPATH' ) || exit;
  * Class WC_Calypso_Bridge_Coming_Soon
  *
  * @since   2.6.0
- * @version 2.7.1
+ * @version x.x.x
  *
  * Handle Coming Soon mode.
  */

--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -41,6 +41,7 @@ class WC_Calypso_Bridge_Coming_Soon {
 		add_filter( 'pre_update_option_woocommerce_coming_soon', array( $this, 'override_update_woocommerce_coming_soon' ), 10, 2 );
 		// Admin bar menu is not only shown in the admin area but also in the front end when the admin user is logged in.
 		add_action( 'admin_bar_menu', array( $this, 'remove_site_visibility_badge' ), 32 );
+		add_filter( 'rest_pre_dispatch', array( $this, 'handle_initial_coming_soon_endpoint' ), 10, 3 );
 
 		if ( is_admin() ) {
 			add_filter( 'plugins_loaded', array( $this, 'maybe_add_admin_notice' ) );
@@ -225,6 +226,37 @@ class WC_Calypso_Bridge_Coming_Soon {
 			return array();
 		}
 		return $settings;
+	}
+
+
+	/**
+	 * Handle the initial coming soon endpoint when coming soon mode is already enabled.
+	 *
+	 * This is to prevent the API request from being made when coming soon mode is already enabled
+	 * so that store pages only option won't be enabled when WPCOM site is in coming soon mode.
+	 *
+	 * @param mixed $result The dispatch result.
+	 * @param WP_REST_Server $server The REST server instance.
+	 * @param WP_REST_Request $request The request object.
+	 * @return mixed
+	 */
+	public function handle_initial_coming_soon_endpoint( $result, $server, $request ) {
+		if ( '/wc-admin/launch-your-store/initialize-coming-soon' !== $request->get_route() ) {
+			// Abort if the request is not for the coming soon endpoint. This should be faster than checking if the feature is enabled.
+			return $result;
+		}
+
+		if ( ! $this->is_feature_enabled() ) {
+			return $result;
+		}
+
+		if ( 'yes' === get_option( 'woocommerce_coming_soon' ) ) {
+			return new WP_REST_Response( true, 200 );
+		}
+
+		// Site is live, set default option for store pages only to true and proceed with the request.
+		add_option( 'woocommerce_store_pages_only', 'yes' );
+		return $result;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,7 @@ This section describes how to install the plugin and get it working.
 
 = Unreleased =
 * Add optional check and fix button deprecated parameters #1527
+* Fix coming soon unintentionally expose the rest of the site #1529
 
 = 2.8.0 =
 * Move "composer/installers" package to require-dev. #1513


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/Automattic/wc-calypso-bridge/issues/1528.

This PR modifies the handling of WooCommerce's coming soon initialization endpoint to respect WordPress.com's site-wide Coming Soon status. Key changes:

- Added a check to detect if WordPress.com Coming Soon mode is active
- If active, we return `true` immediately to prevent WooCommerce from modifying the site's visibility
- Only set the `woocommerce_store_pages_only` option when the site is already live

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

#### Test with Coming Soon mode enabled

1. Set up a WordPress.com business site with Coming Soon mode enabled
2. Install WooCommerce through the plugins menu
3. Go through the core profiler (either skip or complete)
4. Verify that the site remains in Coming Soon mode after the process

#### Test with Coming Soon mode disabled

1. Set up a WordPress.com business site with Coming Soon mode disabled
2. Install WooCommerce through the plugins menu
3. Go through the core profiler (either skip or complete)
4. Verify that site is in Coming Soon mode with Store Pages only


<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
