### PR TITLE
Revert "Deactivate WooCommerce Services if either Woo Shipping or Woo Tax is active (#1458)"

### DIFF
--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -75,7 +75,6 @@ class WC_Calypso_Bridge {
 	 */
 	public function __construct() {
 		add_action( 'muplugins_loaded', array( $this, 'deactivate_duplicate_tiktok' ), PHP_INT_MAX );
-		add_action( 'muplugins_loaded', array( $this, 'deactivate_wc_services_if_woo_shipping_or_woo_tax_is_active_on_ecomm_plans'), PHP_INT_MAX );
 		add_action( 'plugins_loaded', array( $this, 'initialize' ), 0 );
 		add_action( 'plugins_loaded', array( $this, 'load_translation' ) );
 	}
@@ -93,32 +92,6 @@ class WC_Calypso_Bridge {
 
 		if ( ! empty( $business_key ) && ! empty( $woocommerce_key ) ) {
 			unset( $active_plugins[ $woocommerce_key[0] ] );
-			update_option( 'active_plugins', $active_plugins );
-		}
-	}
-
-	/**
-	 * Deactivate WooCommerce Services if either Woo Shipping or Woo Tax is active on an ecommerce-related plan.
-	 *
-	 * This applies to WPCOM and Woo Express, including trial plans.
-	 *
-	 * @since 2.3.14
-	 * @link https://github.com/Automattic/wc-calypso-bridge/pull/1458
-	 *
-	 * @return void
-	 */
-	public function deactivate_wc_services_if_woo_shipping_or_woo_tax_is_active_on_ecomm_plans() {
-		if ( ! wc_calypso_bridge_has_ecommerce_features() ) {
-			return;
-		}
-
-		$active_plugins = (array) get_option( 'active_plugins', array() );
-		$shipping_key   = array_keys( $active_plugins, 'woocommerce-shipping/woocommerce-shipping.php' );
-		$tax_key        = array_keys( $active_plugins, 'woocommerce-tax/woocommerce-tax.php' );
-		$services_key   = array_keys( $active_plugins, 'woocommerce-services/woocommerce-services.php' );
-
-		if ( ( ! empty( $shipping_key ) || ! empty( $tax_key ) ) && ! empty( $services_key ) ) {
-			unset( $active_plugins[ $services_key[0] ] );
 			update_option( 'active_plugins', $active_plugins );
 		}
 	}

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 2.7.0
+ * @version x.x.x
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,7 @@ This section describes how to install the plugin and get it working.
 
 = Unreleased =
 * Add optional check and fix button deprecated parameters #1527
+* Allow WooCommerce Services to co-exist with WooCommerce Shipping to provide tax functionality only
 
 = 2.8.0 =
 * Move "composer/installers" package to require-dev. #1513


### PR DESCRIPTION
WooCommerce Shipping & Tax was supposed to be replaced by WooCommerce Shipping and WooCommerce Tax. But we end up needing to reuse the tax functionality in WooCommerce Shipping & Tax, so it now needs to be active even if WooCommerce Shipping is active. 

This [PR](https://github.com/Automattic/wc-calypso-bridge/pull/1458) we're reverting now, was added to disable WooCommerce Shipping & Tax when either WooCommerce Shipping or WooCommerce Tax were active. It needs to be reverted because, otherwise, WooCommerce Shipping & Tax will be disabled when WooCommerce Shipping is active, and the tax functionality will not work.

### Testing instructions:

1. Check out this branch.
2. Install WooCommerce Shipping & Tax in the store, and activate it.
3. Install WooCommerce Shipping in the store, and activate it.
4. WooCommerce Shipping & Tax should be still active.

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.