### PR TITLE
Fix specific width to apply only on folded navigation bar

### DIFF
--- a/assets/css/nav-unification.css
+++ b/assets/css/nav-unification.css
@@ -28,7 +28,7 @@
 
 /* Fix header overflow https://github.com/woocommerce/woocommerce-admin/issues/7035 */
 @media ( min-width: 961px ) {
-	.jetpack-connected.is-nav-unification:not(.rtl) .woocommerce-layout__header {
+	.jetpack-connected.is-nav-unification:not(.rtl):not(.folded) .woocommerce-layout__header {
 		width: calc( 100% - 272px );
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -22,10 +22,11 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= Unreleased =
+* Fix specific width to apply only on folded navigation bar #1535
+
 = 2.8.2 =
 * Fix header width bug with RTL languages #1533
-
-= Unreleased =
 
 = 2.8.1 =
 * Add optional check and fix button deprecated parameters #1527


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Reported in p1738577288149249-slack-C03TY6J1A

Follow-up to https://github.com/Automattic/wc-calypso-bridge/pull/1533

When navigation menu is folded, the header width is not applied for non-RTL sites.

#### Previously:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/3ec5b726-9edc-4160-8e3e-9c2a809cbdca" />

#### After:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/3637867f-2256-48e1-8411-c9f439ac9af2" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

1. Set up a fresh business plan site on WoA, which should have jetpack connected & nav unification class applied
1. Ensure you're using non-RTL language
2. Ensure your window width is more than 961px
3. Sync bridge (alternatively, override the CSS on browser)
4. Go to Homescreen
5. Observe the width does not overflow screen ([example](https://github.com/user-attachments/assets/515dbd73-f13f-484e-944a-328bcb9b84c2) from past issue)
6. Collapse the navigation bar on the left
7. Observe the no grey column appearing on the right side

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.