### PR TITLE
Add `siteIsAtomic` property to remote logging error data

### DIFF
--- a/class-wc-calypso-bridge-shared.php
+++ b/class-wc-calypso-bridge-shared.php
@@ -138,6 +138,7 @@ class WC_Calypso_Bridge_Shared {
 				'baseUrl' => plugins_url( '/languages', __FILE__ ),
 				'locale' => get_user_locale(),
 			),
+			'isAtomic'                     => defined( 'IS_ATOMIC' ) && IS_ATOMIC,
 		);
 
 		/**

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -332,7 +332,7 @@ class WC_Calypso_Bridge {
 	 * @return array Modified log data with Atomic site information.
 	 */
 	public function add_site_atomic_property_to_logs( $log_data ) {
-		if ( ! isset( $log_data['properties'] ) ) {
+		if ( ! is_array( $log_data ) || ! isset( $log_data['properties'] ) ) {
 			$log_data['properties'] = array();
 		}
 		$log_data['properties']['siteIsAtomic'] = true;

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.0
- * @version 2.8.1
+ * @version x.x.x
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -77,6 +77,10 @@ class WC_Calypso_Bridge {
 		add_action( 'muplugins_loaded', array( $this, 'deactivate_duplicate_tiktok' ), PHP_INT_MAX );
 		add_action( 'plugins_loaded', array( $this, 'initialize' ), 0 );
 		add_action( 'plugins_loaded', array( $this, 'load_translation' ) );
+
+		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+			add_filter( 'woocommerce_remote_logger_formatted_log_data', array( $this, 'add_site_atomic_property_to_logs' ) );
+		}
 	}
 
 	/**
@@ -317,6 +321,23 @@ class WC_Calypso_Bridge {
 
 		$logger = wc_get_logger();
 		$logger->log( $level, $message, array( 'source' => $context ) );
+	}
+
+	/**
+	 * Add siteIsAtomic property to remote logging data.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array $log_data The log data being sent to the remote logging service.
+	 * @return array Modified log data with Atomic site information.
+	 */
+	public function add_site_atomic_property_to_logs( $log_data ) {
+		if ( ! isset( $log_data['properties'] ) ) {
+			$log_data['properties'] = array();
+		}
+		$log_data['properties']['siteIsAtomic'] = true;
+
+		return $log_data;
 	}
 }
 

--- a/class-wc-calypso-bridge.php
+++ b/class-wc-calypso-bridge.php
@@ -332,9 +332,14 @@ class WC_Calypso_Bridge {
 	 * @return array Modified log data with Atomic site information.
 	 */
 	public function add_site_atomic_property_to_logs( $log_data ) {
-		if ( ! is_array( $log_data ) || ! isset( $log_data['properties'] ) ) {
+		if ( ! is_array( $log_data ) ) {
+			$log_data = array();
+		}
+
+		if ( ! isset( $log_data['properties'] ) ) {
 			$log_data['properties'] = array();
 		}
+
 		$log_data['properties']['siteIsAtomic'] = true;
 
 		return $log_data;

--- a/readme.txt
+++ b/readme.txt
@@ -23,6 +23,7 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 = Unreleased =
+* Add siteIsAtomic property to remote logging error data #1538
 
 = 2.8.3 =
 * Fix specific width to apply only on folded navigation bar #1535

--- a/src/index.js
+++ b/src/index.js
@@ -26,11 +26,32 @@ import {
 	ProgressTitleFill,
 } from './homescreen-progress-header';
 import { CalypsoBridgeHomescreenBanner } from './homescreen-banner';
-import { AppearanceFill, GetPaidWithSquareFill, GetPaidWithStripeFill, GetPaidWithPayPalFill } from './task-fills';
+import {
+	AppearanceFill,
+	GetPaidWithSquareFill,
+	GetPaidWithStripeFill,
+	GetPaidWithPayPalFill,
+} from './task-fills';
 import './task-headers';
 import './track-menu-item';
 import { CalypsoBridgeIntroductoryOfferBanner } from './introductory-offer-banner';
 import { loadTranslations } from './i18n-loader';
+
+// Register the remote logging filter early to ensure it's applied before any logging occurs.
+if ( !! window.wcCalypsoBridge?.isAtomic ) {
+	// Add `siteIsAtomic` property to remote logging error data so we can filter logs for Atomic sites.
+	addFilter(
+		'woocommerce_remote_logging_error_data',
+		'wc-calypso-bridge',
+		( errorData ) => ( {
+			...errorData,
+			properties: {
+				...errorData.properties,
+				siteIsAtomic: true,
+			},
+		} )
+	);
+}
 
 // A workaround for Webpack's tree-shaking to ensure `loadTranslations` is included in the production bundle.
 ( function () {} )( loadTranslations );
@@ -182,7 +203,7 @@ if ( !! window.wcCalypsoBridge.isEcommercePlanTrial ) {
 			scope: 'woocommerce-tasks',
 			render: GetPaidWithStripeFill,
 		} );
-  }
+	}
 
 	if ( window?.wcCalypsoBridge?.paypal_connect_url ) {
 		// Setup PayPal task fill (Partner Aware Onboarding).


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/Automattic/wc-calypso-bridge/issues/1537

This PR introduces a `siteIsAtomic` property to the remote logging data in both PHP and JavaScript, indicating whether the site is Atomic. This addition will help in effectively monitoring and analyzing errors during release "bakes" on Atomic sites.

**Why using `siteIsAtomic` as a property name?**

I checked the logstash and found that existing logs have `isAtomic` and `siteIsAtomic` properties fields. However, only `siteIsAtomic` has relevant logs, so I decided to use the same field name here.

**Do we need to check if the site is Atomic?**

If I understand correctly, the `wc-calypso-bridge` plugin is loaded in wpcomsh so it should only be loaded on Atomic sites. But to make sure, I still add the `IS_ATOMIC` constant check.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Create an E-commerce site on WordPress.com
2. Upload and activate the **local** `wc-calypso-bridge` plugin
3. Upload and activate the beta tester plugin https://github.com/woocommerce/woocommerce/releases/download/wc-beta-tester-3.0.0/woocommerce-beta-tester.zip
4. Go to `/wp-admin/tools.php?page=woocommerce-admin-test-helper&tab=remote-logging`
5. Enable remote logging
6. Click on `Simulate Core Exception` to simulate a PHP error and fresh the page to trigger the error
7. Check the logs in logstash PCYsg-11XN-p2
8. Confirm that the logs have `siteIsAtomic = true`.
9. Enable debug logging `window.localStorage.setItem( 'debug', 'wc:remote-logging');`
10. Click on `Simulate Core Exception` to simulate a JavaScript error
11. Go to any WC Admin page
12. Check the logs in console/network tab first to see if the error is sent. When I tested, the API returned an error because I reached the API limit.
13. If it's sent, check the logs in logstash to confirm that the logs have `siteIsAtomic = true`. If it's not sent due to the API limit, simply check the debug logs in the console to verify the error data contains `siteIsAtomic = true`.


<img width="924" alt="Screenshot 2025-03-04 at 16 37 14" src="https://github.com/user-attachments/assets/c4bb7503-ac2b-4ac4-98a7-6cffc7d80aa8" />

![Screenshot 2025-03-04 at 17 27 45](https://github.com/user-attachments/assets/47987125-3c91-439c-b8f2-c5e570b7e5d1)


<img width="946" alt="Screenshot 2025-03-04 at 16 23 35" src="https://github.com/user-attachments/assets/6e8303ae-b6d3-4ccd-b026-78a4428f99f1" />



<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.