### PR TITLE
Hide WPCOM UI elements on LYS launch task preview

### DIFF
--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -6,7 +6,7 @@ defined( 'ABSPATH' ) || exit;
  * Class WC_Calypso_Bridge_Coming_Soon
  *
  * @since   2.6.0
- * @version 2.8.1
+ * @version x.x.x
  *
  * Handle Coming Soon mode.
  */
@@ -42,10 +42,22 @@ class WC_Calypso_Bridge_Coming_Soon {
 		// Admin bar menu is not only shown in the admin area but also in the front end when the admin user is logged in.
 		add_action( 'admin_bar_menu', array( $this, 'remove_site_visibility_badge' ), 32 );
 		add_filter( 'rest_pre_dispatch', array( $this, 'handle_initial_coming_soon_endpoint' ), 10, 3 );
+		add_action( 'wp_head', array( $this, 'possibly_remove_wpcom_ui_elements' ) );
 
 		if ( is_admin() ) {
 			add_filter( 'plugins_loaded', array( $this, 'maybe_add_admin_notice' ) );
 			add_filter( 'woocommerce_get_settings_site-visibility', array( $this, 'possibly_hide_site_visibility_form' ) );
+		}
+	}
+
+	/**
+	 * Remove WPCOM UI elements when the user is viewing the site with ?site-preview=true.
+	 *
+	 * @return void
+	 */
+	public function possibly_remove_wpcom_ui_elements() {
+		if ( isset( $_GET['site-preview'] ) && $_GET['site-preview'] === '1' ) {
+			WC_Calypso_Bridge_Helper_Functions::echo_admin_bar_hide();
 		}
 	}
 

--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -51,7 +51,7 @@ class WC_Calypso_Bridge_Coming_Soon {
 	}
 
 	/**
-	 * Remove WPCOM UI elements when the user is viewing the site with ?site-preview=true.
+	 * Remove WPCOM UI elements when the user is viewing the site with ?site-preview=1.
 	 *
 	 * @return void
 	 */

--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -56,7 +56,7 @@ class WC_Calypso_Bridge_Coming_Soon {
 	 * @return void
 	 */
 	public function possibly_remove_wpcom_ui_elements() {
-		if ( isset( $_GET['site-preview'] ) && $_GET['site-preview'] === '1' ) {
+		if ( isset( $_GET['site-preview'] ) && '1' === $_GET['site-preview'] ) {
 			WC_Calypso_Bridge_Helper_Functions::echo_admin_bar_hide();
 		}
 	}

--- a/includes/class-wc-calypso-bridge-customize-store.php
+++ b/includes/class-wc-calypso-bridge-customize-store.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since  1.0.0
- * @version 2.5.2
+ * @version x.x.x
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -79,25 +79,7 @@ class WC_Calypso_Bridge_Customize_Store {
 	 */
 	public function possibly_remove_wpcom_ui_elements() {
 		if ( isset( $_GET['cys-hide-admin-bar'] ) ) {
-			echo '
-			<style type="text/css">
-				#wpadminbar,
-				#wpcom-gifting-banner,
-				#wpcom-launch-banner-wrapper,
-				#atomic-proxy-bar,
-				#free-trial-plan-picker-banner { display: none !important; }
-				.woocommerce-store-notice { display: none !important; }
-				html { margin-top: 0 !important; }
-				body { overflow: hidden; }
-			</style>';
-			echo '
-			<script type="text/javascript">
-			( function() {
-				document.addEventListener( "DOMContentLoaded", function() {
-					document.documentElement.style.setProperty( "margin-top", "0px", "important" );
-				} );
-			} )();
-			</script>';
+			WC_Calypso_Bridge_Helper_Functions::echo_admin_bar_hide();
 		}
 	}
 

--- a/includes/class-wc-calypso-bridge-helper-functions.php
+++ b/includes/class-wc-calypso-bridge-helper-functions.php
@@ -4,7 +4,7 @@
  *
  * @package WC_Calypso_Bridge/Classes
  * @since   1.0.2
- * @version 1.9.8
+ * @version x.x.x
  */
 
 use Automattic\WooCommerce\Admin\WCAdminHelper;
@@ -227,6 +227,34 @@ class WC_Calypso_Bridge_Helper_Functions {
 		}
 
 		return $woocommerce_pages;
+	}
+
+	/**
+	 * Outputs CSS and JS to hide WPCOM UI elements.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return void
+	 */
+	public static function echo_admin_bar_hide() {
+		echo '
+			<style type="text/css">
+				#wpadminbar,
+				#wpcom-gifting-banner,
+				#wpcom-launch-banner-wrapper,
+				#atomic-proxy-bar,
+				#free-trial-plan-picker-banner { display: none !important; }
+				.woocommerce-store-notice { display: none !important; }
+				html { margin-top: 0 !important; }
+			</style>';
+			echo '
+			<script type="text/javascript">
+			( function() {
+				document.addEventListener( "DOMContentLoaded", function() {
+					document.documentElement.style.setProperty( "margin-top", "0px", "important" );
+				} );
+			} )();
+			</script>';
 	}
 
 }

--- a/readme.txt
+++ b/readme.txt
@@ -23,6 +23,7 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 = Unreleased =
+* Hide WPCOM UI elements on LYS launch task preview #1539
 
 = 2.8.3 =
 * Fix specific width to apply only on folded navigation bar #1535


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Addresses p6riRB-bFe-p2#comment-11892 where WordPress.com admin UI is shown in launch your store task site preview.

| Before | After |
|----|----|
| <img width="1181" alt="image" src="https://github.com/user-attachments/assets/bc5e0db8-6d72-49e8-988a-caf17aab7519" /> | <img width="1185" alt="image" src="https://github.com/user-attachments/assets/2af66f43-edb9-4ac6-969e-2cdc814606be" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### Testing launch your store task
1. In a business or ecommerce plan site, go to `Launch your store` task
2. Observe the site preview do not have WordPress.com UI elements such as the header

#### Testing regression
1. Go to `Customize your store` task
2. Go to `Use the store designer`
2. Observe the site preview do not have WordPress.com UI elements such as the header

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.