### PR TITLE
PTO - Square: Remove is trial condition so it only depends on the option

### DIFF
--- a/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
+++ b/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
@@ -33,10 +33,6 @@ class WC_Calypso_Bridge_Partner_Square {
 	 * Constructor.
 	 */
 	public function __construct() {
-		// Only for free trials.
-		if ( ! wc_calypso_bridge_is_ecommerce_trial_plan() ) {
-			return;
-		}
 		$onboarding_profile = get_option( 'woocommerce_onboarding_profile', array() );
 		if ( ! isset( $onboarding_profile['partner'] ) ) {
 			return;
@@ -227,5 +223,4 @@ class WC_Calypso_Bridge_Partner_Square {
 		}
 	}
 }
-
 WC_Calypso_Bridge_Partner_Square::get_instance();

--- a/src/index.js
+++ b/src/index.js
@@ -189,14 +189,6 @@ if ( !! window.wcCalypsoBridge.isEcommercePlanTrial ) {
 		} );
 	}
 
-	if ( window?.wcCalypsoBridge?.square_connect_url ) {
-		// Setup Square task fill (Partner Aware Onboarding).
-		registerPlugin( 'wc-calypso-bridge-task-setup-woocommerce-square', {
-			scope: 'woocommerce-tasks',
-			render: GetPaidWithSquareFill,
-		} );
-	}
-
 	if ( window?.wcCalypsoBridge?.stripe_connect_url ) {
 		// Setup Stripe task fill (Partner Aware Onboarding).
 		registerPlugin( 'wc-calypso-bridge-task-setup-woocommerce-stripe', {
@@ -212,6 +204,14 @@ if ( !! window.wcCalypsoBridge.isEcommercePlanTrial ) {
 			render: GetPaidWithPayPalFill,
 		} );
 	}
+}
+
+if ( window?.wcCalypsoBridge?.square_connect_url ) {
+	// Setup Square task fill (Partner Aware Onboarding).
+	registerPlugin( 'wc-calypso-bridge-task-setup-woocommerce-square', {
+		scope: 'woocommerce-tasks',
+		render: GetPaidWithSquareFill,
+	} );
 }
 
 if ( !! window.wcCalypsoBridge.isEcommercePlan ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/Automattic/dotcom-forge/issues/10594

This PR implements a new updated PTO flow for Square that does not require a trial site. Further context in this PT: pdt2If-222-p2. With this new flow, the Launchpad Tasks for `Get paid with Square` will be displayed as long as the corresponding option has the expected value (i.e. `square`) so no other conditions are required.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. In an Atomic site with `WooCommerce` installed (either Business or Commerce), create an option with the name `woocommerce_onboarding_profile` and the value `array("partner" => "square")` or you can use the following `wp` command
```
wp option add woocommerce_onboarding_profile --format=json '{"partner": "square"}'
```
If the option already exists with another key, use this command to insert the new key:
```
wp option patch insert woocommerce_onboarding_profile partner square
```
(You can check the option value with `wp option get woocommerce_onboarding_profile`)
3. Apply the `wc-calypso-bridge` to that atomic site, you can use this `rsync` command pdt2If-23m-p2
4. Navigate to the WooCommerce launchpad and make sure you can see `Get paid with Square`

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.