### PR TITLE
PTO: Allow to replace the onboarding payment task for partners

### DIFF
--- a/includes/class-wc-calypso-bridge-free-trial-payment-task.php
+++ b/includes/class-wc-calypso-bridge-free-trial-payment-task.php
@@ -18,6 +18,13 @@ class WC_Calypso_Bridge_Free_Trial_Payment_Task
 	protected static $instance = null;
 
 	/**
+	 * List of valid payment partners
+	 *
+	 * @var array
+	 */
+	const VALID_PARTNERS = ['square', 'paypal', 'stripe'];
+
+	/**
 	 * Get class instance.
 	 *
 	 * @return object Instance.
@@ -31,7 +38,12 @@ class WC_Calypso_Bridge_Free_Trial_Payment_Task
 	}
 
 	public function __construct() {
-		if ( ! wc_calypso_bridge_is_ecommerce_trial_plan() ) {
+		$onboarding_profile = get_option( 'woocommerce_onboarding_profile', array() );
+		if ( ! isset( $onboarding_profile['partner'] ) ) {
+			return;
+		}
+
+		if ( ! in_array( $onboarding_profile['partner'], self::VALID_PARTNERS ) ) {
 			return;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/Automattic/dotcom-forge/issues/10651

Update the condition to replace the payment task in the WooCommerce Launchpad to only depend on the `woocommerce_onboarding_profile` option. That means that it will not depend on the plan being installed.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. On a newly created or reset WoA developer site 
2. Install WooCommerce and WooCommerce Square plugins
3. Add the `woocommerce_onboarding_profile` option with the value `partner` => `square`. For that you can use `_cli` and use the following command:
```
wp option patch insert woocommerce_onboarding_profile partner square
```
5. Navigate to the WooCommerce Home page by clicking on WooCommerce > Home
6. Check you can see the following two tasks listed in Launchpad: `Get paid with Square` and `Get paid` 
![CleanShot 2025-03-19 at 19 03 12@2x](https://github.com/user-attachments/assets/b3bd0da5-029d-43f8-a8d1-6172c59b3f10)
7. Synchronize these changes to the Atomic site, you can use the following command:
```
rsync -avze ssh --delete  --relative includes/class-wc-calypso-bridge-free-trial-payment-task.php 
 USERNAME@sftp.wp.com:/htdocs/wp-content/mu-plugins/wpcomsh/vendor/automattic/wc-calypso-bridge/
```
8. Refresh the WooCommerce Homepage
9. Check the `Get paid` is not displayed anymore ant you can still see `Get paid with Square`

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
