### PR TITLE
[Square PTO] Silence WooPayments Action incentive and NOX main providers suggestions

### DIFF
--- a/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
+++ b/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
@@ -210,8 +210,8 @@ class WC_Calypso_Bridge_Partner_Square {
 	}
 
 	/**
-	 * Force square_cash_app_pay and square_credit_card order
-	 * IF user hans't customized the payment methods order yet.
+	 * Force square_cash_app_pay, square_credit_card, and gift_cards_pay order
+	 * IF user hasn't customized the payment methods order yet.
 	 *
 	 * @return void
 	 */
@@ -219,8 +219,9 @@ class WC_Calypso_Bridge_Partner_Square {
 		$order_option = get_option( 'woocommerce_gateway_order', false );
 		if ( ! $order_option ) {
 			update_option( 'woocommerce_gateway_order', array(
-				'square_credit_card' => 0,
+				'square_credit_card'  => 0,
 				'square_cash_app_pay' => 1,
+				'gift_cards_pay'      => 2,
 			) );
 		}
 	}

--- a/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
+++ b/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
@@ -47,6 +47,8 @@ class WC_Calypso_Bridge_Partner_Square {
 		$this->add_square_connect_url_to_js();
 		$this->remove_woo_payments_from_payments_suggestions_feed();
 		$this->remove_payments_note();
+		$this->remove_woopayments_action_incentives();
+		$this->nox_hide_suggestions_from_providers_list();
 	}
 
 	/**
@@ -221,6 +223,76 @@ class WC_Calypso_Bridge_Partner_Square {
 				'square_cash_app_pay' => 1,
 			) );
 		}
+	}
+
+	/**
+	 * Hooks into the WooPayments incentives API HTTP response to remove the WooPayments action incentives.
+	 *
+	 * @return void
+	 */
+	private function remove_woopayments_action_incentives() {
+		// Filter the Transact incentives response to remove the WooPayments action incentives, if any.
+		add_filter( 'http_response', function( $response, $args, $url ) {
+			if ( is_wp_error( $response ) || false === strpos( $url, 'wpcom/v2/wcpay/incentives' ) ) {
+				return $response;
+			}
+
+			$data = json_decode( wp_remote_retrieve_body( $response ), true ) ?? array();
+			if ( empty( $data ) || ! is_array( $data ) || ! array_is_list( $data ) ) {
+				return $response;
+			}
+
+			// Remove any incentives that are action incentives.
+			$data = array_filter( $data, function( $incentive ) {
+				return empty( $incentive['id'] ) || false === strpos( $incentive['id'], '-action-' );
+			} );
+
+			$response['body'] = wp_json_encode( array_values( $data ) );
+
+			return $response;
+		}, 10, 3 );
+	}
+
+	/**
+	 * Auto-hides the main payment provider suggestions for the current user.
+	 *
+	 * This only happens if the user didn't interact with the NOX suggestions and hid them.
+	 *
+	 * @return void
+	 */
+	private function nox_hide_suggestions_from_providers_list() {
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		$user_nox_profile = get_user_meta( get_current_user_id(), 'woocommerce_payments_nox_profile', true );
+		// If the user has already hidden the suggestions, we don't need to do anything.
+		if ( ! empty( $user_nox_profile['hidden_suggestions'] ) ) {
+			return;
+		}
+
+		// Auto-hide the main providers list suggestions.
+		// For now, we will hide the suggestions for WooPayments, PayPal Full Stack, and Stripe.
+		// These are the only PSPs that will appear in the main providers list in countries where Square is available.
+		if ( ! is_array( $user_nox_profile ) ) {
+			$user_nox_profile = array();
+		}
+		$user_nox_profile['hidden_suggestions'] = array(
+			array(
+				'id'        => 'woopayments',
+				'timestamp' => time(),
+			),
+			array(
+				'id'        => 'paypal_full_stack',
+				'timestamp' => time(),
+			),
+			array(
+				'id'        => 'stripe',
+				'timestamp' => time(),
+			),
+		);
+
+		update_user_meta( get_current_user_id(), 'woocommerce_payments_nox_profile', $user_nox_profile );
 	}
 }
 WC_Calypso_Bridge_Partner_Square::get_instance();

--- a/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
+++ b/includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php
@@ -226,28 +226,19 @@ class WC_Calypso_Bridge_Partner_Square {
 	}
 
 	/**
-	 * Hooks into the WooPayments incentives API HTTP response to remove the WooPayments action incentives.
+	 * Hooks into the WooPayments incentives API HTTP response to remove all the WooPayments incentives.
 	 *
 	 * @return void
 	 */
 	private function remove_woopayments_action_incentives() {
-		// Filter the Transact incentives response to remove the WooPayments action incentives, if any.
+		// Filter the Transact Platform incentives response to remove all the WooPayments incentives.
 		add_filter( 'http_response', function( $response, $args, $url ) {
 			if ( is_wp_error( $response ) || false === strpos( $url, 'wpcom/v2/wcpay/incentives' ) ) {
 				return $response;
 			}
 
-			$data = json_decode( wp_remote_retrieve_body( $response ), true ) ?? array();
-			if ( empty( $data ) || ! is_array( $data ) || ! array_is_list( $data ) ) {
-				return $response;
-			}
-
-			// Remove any incentives that are action incentives.
-			$data = array_filter( $data, function( $incentive ) {
-				return empty( $incentive['id'] ) || false === strpos( $incentive['id'], '-action-' );
-			} );
-
-			$response['body'] = wp_json_encode( array_values( $data ) );
+			// Just return an empty array.
+			$response['body'] = wp_json_encode( array() );
 
 			return $response;
 		}, 10, 3 );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When we are in the context of Square PTO, we want to not have any WooPayments incentives active and in the new WooCommerce Payments Settings page (NOX), we don't want any PSP suggestions in the main providers list.

This PR provides both these changes.

NOX default state (for US, with the Square extension installed and activated):
![Screenshot 2025-03-25 at 18 39 18](https://github.com/user-attachments/assets/00a1c284-e2fd-4778-9701-e022a3688d90)

NOX state with the Other Payment Options section expanded (for US, , with the Square extension installed and activated):
![Screenshot 2025-03-25 at 18 39 31](https://github.com/user-attachments/assets/b3c30b8c-8752-470d-b689-51ffc66a5418)

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. On a newly created or reset WoA developer site 
2. Install and activate WooCommerce and WooCommerce Square plugins.
3. Add the `woocommerce_onboarding_profile` option with the value `partner` => `square`. For that you can use `_cli` and use the following command:
```
wp option patch insert woocommerce_onboarding_profile partner square
```
4. Use `_cli` to install the WC Beta Tester plugin:
```
wp plugin install --activate https://github.com/woocommerce/woocommerce/releases/download/wc-beta-tester-3.0.0/woocommerce-beta-tester.zip
```
5. Go to Tools > WCA Test Helper > Features and enable the `reactify-classic-payments-settings` feature (if not already enabled).
4. Go to `WooCommerce -> Settings -> Payments`
6. You should see WooPayments and PayPal in the "Payment Providers" main list with a WooPayments discount banner at the top.
7. Synchronize this PR's changes to the Atomic site - you can use the following command:
```
rsync -avze ssh --delete  --relative includes/free-trial/partners/class-wc-calypso-bridge-partner-square.php 
 USERNAME@sftp.wp.com:/htdocs/wp-content/mu-plugins/wpcomsh/vendor/automattic/wc-calypso-bridge/
```
8. Refresh the WooCommerce Payments settings page.
9. WooPayments and PayPal should no longer be visible in the main list but be present in the Other Payment Options section.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
