### PR TITLE
WooCommerce Bridge: Hide legacy extensions sub-menu

### DIFF
--- a/.github/workflows/check-bundle-size.yml
+++ b/.github/workflows/check-bundle-size.yml
@@ -6,7 +6,7 @@ on:
 jobs:
     build-and-size:
         name: Bundle Size
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
 
         steps:
             - uses: actions/checkout@v3

--- a/.github/workflows/check-coding-standards.yml
+++ b/.github/workflows/check-coding-standards.yml
@@ -7,7 +7,7 @@ jobs:
 
     php-coding-standards:
         name: Coding standards
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
 
         steps:
 

--- a/.github/workflows/ci-release-smoke-test.yml
+++ b/.github/workflows/ci-release-smoke-test.yml
@@ -10,7 +10,7 @@ jobs:
     check-versions:
         if: startsWith(github.head_ref, 'release/')
         name: Check versions
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
 
         steps:
 

--- a/.github/workflows/setup-node.yml
+++ b/.github/workflows/setup-node.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   setup:
     name: Setup
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
         - uses: actions/checkout@v3
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dd2b89cb44ce0c72a3cb64151c57e943",
+    "content-hash": "96afab2415fe11afab61e3568cb3a7df",
     "packages": [],
     "packages-dev": [
         {
@@ -3006,23 +3006,23 @@
         },
         {
             "name": "sirbrillig/phpcs-changed",
-            "version": "v2.11.4",
+            "version": "v2.11.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-changed.git",
-                "reference": "acc946731ec65053e49cb0d3185c8ffe74895f93"
+                "reference": "1c6deb684d648b4d75c577bead4c6d43dc46e4ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-changed/zipball/acc946731ec65053e49cb0d3185c8ffe74895f93",
-                "reference": "acc946731ec65053e49cb0d3185c8ffe74895f93",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-changed/zipball/1c6deb684d648b4d75c577bead4c6d43dc46e4ab",
+                "reference": "1c6deb684d648b4d75c577bead4c6d43dc46e4ab",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1 || ^1.0.0",
                 "phpunit/phpunit": "^6.4 || ^9.5",
                 "sirbrillig/phpcs-variable-analysis": "^2.1.3",
                 "squizlabs/php_codesniffer": "^3.2.1",
@@ -3054,9 +3054,9 @@
             "description": "Run phpcs on files, but only report warnings/errors from lines which were changed.",
             "support": {
                 "issues": "https://github.com/sirbrillig/phpcs-changed/issues",
-                "source": "https://github.com/sirbrillig/phpcs-changed/tree/v2.11.4"
+                "source": "https://github.com/sirbrillig/phpcs-changed/tree/v2.11.8"
             },
-            "time": "2023-09-29T21:27:51+00:00"
+            "time": "2025-03-11T15:23:48+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -6596,10 +6596,10 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/includes/class-wc-calypso-bridge-addons.php
+++ b/includes/class-wc-calypso-bridge-addons.php
@@ -58,7 +58,7 @@ class WC_Calypso_Bridge_Addons {
 		// Hide the default marketplace.
 		add_filter( 'woocommerce_show_addons_page', '__return_false' );
 		// Handle the addons legacy page.
-		add_action( 'admin_menu', array( $this, 'addons_menu' ), 70 );
+		add_action( 'admin_menu', array( $this, 'addons_menu' ), PHP_INT_MAX );
 
 		// Add admin body class for the free trial landing page.
 		if ( wc_calypso_bridge_is_ecommerce_trial_plan() ) {
@@ -85,7 +85,24 @@ class WC_Calypso_Bridge_Addons {
 		$count_html = WC_Helper_Updater::get_updates_count_html();
 		/* translators: %s: extensions count */
 		$menu_title = sprintf( __( 'Extensions %s', 'wc-calypso-bridge' ), $count_html );
-		add_submenu_page( 'woocommerce', __( 'WooCommerce extensions', 'wc-calypso-bridge' ), $menu_title, 'manage_woocommerce', 'wc-addons', array( $this, 'addons_page' ) );
+
+		// Check if we already have a non legacy extensions submenu added.
+		global $submenu;
+		foreach ( $submenu['woocommerce'] ?? [] as $submenu_item ) {
+			if ( 'wc-admin' === $submenu_item[2] ?? '' ) {
+				// Submenu already added, exit early
+				return;
+			}
+		}
+
+		add_submenu_page(
+			'woocommerce',
+			__( 'WooCommerce extensions', 'wc-calypso-bridge' ),
+			$menu_title,
+			'manage_woocommerce',
+			'wc-addons',
+			array( $this, 'addons_page' )
+		);
 	}
 
 	/**

--- a/includes/class-wc-calypso-bridge-addons.php
+++ b/includes/class-wc-calypso-bridge-addons.php
@@ -57,8 +57,8 @@ class WC_Calypso_Bridge_Addons {
 
 		// Hide the default marketplace.
 		add_filter( 'woocommerce_show_addons_page', '__return_false' );
-		// Handle the addons legacy page.
-		add_action( 'admin_menu', array( $this, 'addons_menu' ), PHP_INT_MAX );
+		// Handle trial plan extensions menu.
+		add_action( 'admin_menu', array( $this, 'maybe_add_trial_extensions_submenu' ), PHP_INT_MAX );
 
 		// Add admin body class for the free trial landing page.
 		if ( wc_calypso_bridge_is_ecommerce_trial_plan() ) {
@@ -79,22 +79,21 @@ class WC_Calypso_Bridge_Addons {
 	}
 
 	/**
-	 * Addons menu item.
+	 * Adds the trial extensions submenu when needed.
 	 */
-	public function addons_menu() {
+	public function maybe_add_trial_extensions_submenu() {
+		if ( ! wc_calypso_bridge_is_ecommerce_trial_plan() ) {
+			return;
+		}
+
 		$count_html = WC_Helper_Updater::get_updates_count_html();
 		/* translators: %s: extensions count */
 		$menu_title = sprintf( __( 'Extensions %s', 'wc-calypso-bridge' ), $count_html );
 
-		// Check if we already have a non legacy extensions submenu added.
-		global $submenu;
-		foreach ( $submenu['woocommerce'] ?? [] as $submenu_item ) {
-			if ( 'wc-admin' === $submenu_item[2] ?? '' ) {
-				// Submenu already added, exit early
-				return;
-			}
-		}
+		// We need to remove the default extensions menu since it isn't available on the trial plan.
+		remove_submenu_page( 'woocommerce', 'wc-admin&path=/extensions' );
 
+		// Add the trial extension sub menu.
 		add_submenu_page(
 			'woocommerce',
 			__( 'WooCommerce extensions', 'wc-calypso-bridge' ),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
There was a problem reported about the extensions sub-menu being shown twice under the WooCommerce menu. We now check if the non-legacy extensions sub-menu has been registered before adding the legacy one to avoid displaying 2 at the same time.

| Before | After |
|--------|--------|
|![Screenshot 2025-04-30 at 11 21 21](https://github.com/user-attachments/assets/04f814c0-994d-4c03-87b5-59d4ed2e6758)|![Screenshot 2025-04-30 at 11 20 48](https://github.com/user-attachments/assets/6f15a509-acc8-406c-86c5-18068cfc89b8)|

Closes: 
- https://github.com/Automattic/wp-calypso/issues/102713
- [DOTCOM-10914](https://linear.app/a8c/issue/DOTCOM-10914/ecommerce-sites-have-2-extensions-sub-menus-in-the-woocommerce-menu)

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Apply these changes to an eCommerce site.
2. You should see that under the WooCommerce menu, the `Extensions` sub-menu is no longer duplicated.
3. The extensions menu should work as expected
4. Use SA and add a commerce trial plan and remove the commerce plan
5. You should see just 1 extensions menu and should work as expected.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
