### PR TITLE
Plugins menu: Remove duplicate Plugins Marketplace menu

### DIFF
--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-plugins-screen.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-plugins-screen.php
@@ -77,6 +77,11 @@ class WC_Calypso_Bridge_Free_Trial_Plugins_Screen {
 	public function remove_marketplace_menu() {
 		$plugins_slug = 'https://wordpress.com/plugins/' . WC_Calypso_Bridge_Instance()->get_site_slug();
 		remove_menu_page( $plugins_slug );
+
+		/**
+		 * Remove the Marketplace submenu when the site is using the classic interface.
+		 */
+		remove_menu_page( 'plugins.php' );
 	}
 }
 

--- a/includes/free-trial/class-wc-calypso-bridge-free-trial-plugins-screen.php
+++ b/includes/free-trial/class-wc-calypso-bridge-free-trial-plugins-screen.php
@@ -46,7 +46,8 @@ class WC_Calypso_Bridge_Free_Trial_Plugins_Screen {
 	 * Initialize hooks.
 	 */
 	protected function init() {
-		add_action( 'admin_menu', array($this, 'add_menu_page'));
+		add_action( 'admin_menu', array( $this, 'add_menu_page' ) );
+		add_action( 'admin_menu', array( $this, 'remove_marketplace_menu' ), 100000 );
 	}
 
 	/**
@@ -66,6 +67,16 @@ class WC_Calypso_Bridge_Free_Trial_Plugins_Screen {
 				'capability' => 'manage_options',
 			)
 		);
+	}
+
+	/**
+	 * Remove the default Marketplace admin menu. Ecommerce trials have their own landing page for it.
+	 *
+	 * @return void
+	 */
+	public function remove_marketplace_menu() {
+		$plugins_slug = 'https://wordpress.com/plugins/' . WC_Calypso_Bridge_Instance()->get_site_slug();
+		remove_menu_page( $plugins_slug );
 	}
 }
 


### PR DESCRIPTION
eCommerce trials have their own dedicated Plugins page. This page is used as an upsell page that's specific to the eCommerce plan.

Since this one is more specific, we are now removing the generic Plugins admin menu since it's a duplicate.

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes DOTCOM-10702.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Get an Atomic Dev Site with the ecommerce plan
2. SSH into it
3. Replace the entire file from this PR into ~/htdocs/wp-content/mu-plugins/wpcomsh-dev/vendor/automattic/wc-calypso-bridge/includes/free-trial/class-wc-calypso-bridge-free-trial-plugins-screen.php
4. Go to SA and replace the eCommerce plan with the eCommerce Trial plan
5. Click sync purchases
6. Go to WP-Admin and notice that there's only one `Plugins` admin menu
7. Go to Settings > General and switch the dashboard to Classic
8. Notice that the Plugins menu is still not duplicated.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
