### PR TITLE
Updated the default WooCommerce jetpack module list

### DIFF
--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -541,6 +541,9 @@ class WC_Calypso_Bridge_Setup {
 				'publicize',
 				'verification-tools',
 				'sitemaps',
+				'blocks',
+				'blaze',
+				'account-protection',
 			);
 
 			$sharing_options = array(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Original Slack Thread: p1744052983694779-slack-CDLH4C1UZ
[Linear task](https://linear.app/a8c/issue/DOTCOM-13242/jetpack-block-module-deactivates-after-commerce-migration)

**TLDR**: Some Jetpack modules (like blocks) are disabled after a `Business` > `Commerce` upgrade. Because of that, those sites won't have the Jetpack blocks activated:

![image](https://github.com/user-attachments/assets/7dccb16b-295e-4d8d-bb39-421a18a169eb)

**Solution**: Here, we're updating the list of active modules we expect to have enabled after that migration. This was originally implemented [on this PR](https://github.com/Automattic/wc-calypso-bridge/pull/844), and here's more on why: peapX7-yd-p2

**Why this happens?**
It's related to the WooCommerce plugin initialization. Turns out [we have a list of Jetpack modules](https://github.com/Automattic/wc-calypso-bridge/blob/master/includes/class-wc-calypso-bridge-setup.php#L514-L544) we override when starting a WooCommerce store.

**More context**
I first tried to solve this problem with these two approaches, which partially fixed it, but fortunately, this new PR is the correct approach as we're fixing the root cause of the issue. The following PRs will be overridden after merging the current PR:

- https://github.com/Automattic/jetpack/pull/42971
- 181039-ghe-Automattic/wpcom



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

I'm unsure how to test the changes using this repository. But I'll describe how to test them on an Atomic site:

1. Create a new site using the Business plan
2. Add it as a dev site on [wpcom dev blogs](https://mc.a8c.com/atomic/wpcom-dev-blogs/)
3. Convert it to Atomic by enabling the Hosting features
4. SSH into it the new server
5. Edit the source file, at line 543, with `vim /htdocs/wp-content/mu-plugins/wpcomsh/vendor/automattic/wc-calypso-bridge/includes/class-wc-calypso-bridge-setup.php`
6. Add the three extra modules to the `$active_modules` array: `'blocks', 'blaze', 'account-protection'`
	![image](https://github.com/user-attachments/assets/0145cd60-8cab-49f7-b27a-382283c207e3)
8. Open that site's plans page: https://wordpress.com/plans/{blogId}
9. Buy the Commerce plan
10. Wait for the migration to complete (ensure you see WooCommerce at the /wp-admin):
	![image](https://github.com/user-attachments/assets/f05702fa-5946-4d6a-a761-e8f72cdfa278)
12. Create a new post
13. Ensure you still see Jetpack blocks:
 	![image](https://github.com/user-attachments/assets/c3d542e4-8ed0-4ab6-97eb-9f0571716519)


<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.