### PR TITLE
Allow WooCommerce settings to fix guided setup being broken in WoW

### DIFF
--- a/includes/class-wc-calypso-bridge-tracks.php
+++ b/includes/class-wc-calypso-bridge-tracks.php
@@ -90,9 +90,6 @@ class WC_Calypso_Bridge_Tracks {
 		add_filter( 'jetpack_woocommerce_analytics_event_props', array( $this, 'filter_jetpack_woocommerce_analytics_event_props' ) );
 		add_filter( 'woocommerce_admin_survey_query', array( $this, 'set_survey_source' ) );
 
-		// Hide WooCommerce.com advanced settings page.
-		add_filter( 'woocommerce_get_sections_advanced', array( $this, 'hide_woocommerce_com_settings' ), 10, 1 );
-
 		// Always opt-in to Tracks, WPCOM user tracks preferences take priority.
 		add_filter( 'woocommerce_apply_tracking', '__return_true' );
 		add_filter( 'woocommerce_apply_user_tracking', '__return_true' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

See p1751462628090939-slack-dotcom-escalations

When the setting does not exist, guided setup is broken. Users cannot skip. 

### How to test the changes in this Pull Request:

Confirmed by:
- Adding define( 'WC_REMOVE_ALL_DATA', true ); to wp-config.php  and then deleting Woo to clear out all data, so that guided setup will fire when activating WooCommerce.
- Modifying `.../wpcomsh/vendor/automattic/wc-calypso-bridge/includes/class-wc-calypso-bridge-tracks.php to comment out `add_filter( 'woocommerce_get_sections_advanced', array( $this, 'hide_woocommerce_com_settings' ), 10, 1 );`
- Installing and activating WooCommerce to hit guided setup.
- Clicking "Skip guided setup".

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
