### PR TITLE
Only disable add-ons menu for Commerce trials

### DIFF
--- a/includes/class-wc-calypso-bridge-addons.php
+++ b/includes/class-wc-calypso-bridge-addons.php
@@ -54,15 +54,14 @@ class WC_Calypso_Bridge_Addons {
 	 * Initialize.
 	 */
 	public function init() {
-
-		// Hide the default marketplace.
-		add_filter( 'woocommerce_show_addons_page', '__return_false' );
 		// Handle trial plan extensions menu.
 		add_action( 'admin_menu', array( $this, 'maybe_add_trial_extensions_submenu' ), PHP_INT_MAX );
 
-		// Add admin body class for the free trial landing page.
 		if ( wc_calypso_bridge_is_ecommerce_trial_plan() ) {
+			// Hide the default addons/marketplace for trial plans.
+        	add_filter( 'woocommerce_show_addons_page', '__return_false' );
 
+			// Add admin body class for the free trial landing page.
 			add_filter( 'admin_body_class', function( $classes ) {
 				$screen = get_current_screen();
 				if ( $screen && 'woocommerce_page_wc-addons' === $screen->id ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes DOTCOM-13568

This PR moves code that removes the legacy WooCommerce add-ons menu (which has been superseded by the Extensions menu) to run only when we have an Commerce trial plan, and not for all plans as was occurring. The main driver for this is that the admin path was being referenced by code used to disconnect from WooCommerce.com, which was making it impossible for users to disconnect from WooCommerce.com if they had their site on WordPress.com.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

#### Set up a dev blog

* Go to https://mc.a8c.com/atomic/wpcom-dev-blogs/ and designate a WordPress.com site that belongs to you as a dev blog. (Please do not pick any sites that are already Atomic.) You can leave `Transfers to Atomic dev server pool` unchecked. (This means you can modify `wpcomsh` on the site when it is Atomic.)
  - If you don't have any clean WordPress.com sites, feel free to create a free one via https://wordpress.com/start, and then use the tool to mark it as a dev blog
* Once the site has been designated as a dev blog, purchase a Commerce plan for the site -- monthly will be cheapest
  - You can assign yourself credits via https://mc.a8c.com/credits/
  - Feel free to ensure that any payment methods you have for WPCOM are _not_ linked to the subscription -- we don't need you to be charged for subscription renewals!
* Once the Commerce plan has been purchased, the site will automatically get WooCommerce installed and will be transferred to the Atomic platform with `wpcomsh` installed

##### Apply these changes manually

* From the https://mc.a8c.com/atomic/wpcom-dev-blogs/ page, click on the `Hosting config` link for your site
* Ensure that SFTP and SSH are enabled for the site
  - You shouldn't need to attach an SSH key to the site, as your A8c keys should work, but you may need to update your SSH config to ensure that your A8c key is used for connections to `ssh.wp.com` and `sftp.wp.com`.
* Connect to your site via SSH
* Apply the changes in this PR to the file in `~/htdocs/wp-content/mu-plugins/wpcomsh/vendor/automattic/wc-calypso-bridge/includes/class-wc-calypso-bridge-addons.php`

#### Actual testing

1. Navigate to `/wp-admin/admin.php?page=wc-admin&path=%2Fextensions` for your site
2. Click on the user icon in the top right corner
3. Choose to disconnect your account from WooCommerce.com
4. Verify that the operation completes successfully and the UI doesn't get stuck

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
