### PR TITLE
Disable coming soon on store pages only for new installs

### DIFF
--- a/includes/class-wc-calypso-bridge-coming-soon.php
+++ b/includes/class-wc-calypso-bridge-coming-soon.php
@@ -39,6 +39,7 @@ class WC_Calypso_Bridge_Coming_Soon {
 		add_filter( 'woocommerce_coming_soon_exclude', array( $this, 'should_exclude_lys_coming_soon' ) );
 		add_filter( 'pre_option_woocommerce_coming_soon', array( $this, 'override_option_woocommerce_coming_soon' ) );
 		add_filter( 'pre_update_option_woocommerce_coming_soon', array( $this, 'override_update_woocommerce_coming_soon' ), 10, 2 );
+		add_action( 'woocommerce_newly_installed', array( $this, 'disable_woocommerce_store_pages_only' ), 30 );
 		// Admin bar menu is not only shown in the admin area but also in the front end when the admin user is logged in.
 		add_action( 'admin_bar_menu', array( $this, 'remove_site_visibility_badge' ), 32 );
 		add_filter( 'rest_pre_dispatch', array( $this, 'handle_initial_coming_soon_endpoint' ), 10, 3 );
@@ -155,6 +156,19 @@ class WC_Calypso_Bridge_Coming_Soon {
 		}
 
 		return $new_value;
+	}
+
+	/**
+	 * Disable the store pages only option when WooCommerce is newly installed.
+	 *
+	 * This is to prevent the store pages only option from being enabled by default
+	 * when WooCommerce is newly installed on a WPCOM site. In most cases this is not
+	 * the desired behavior as the site is likely to be in coming soon mode.
+	 *
+	 * @return void
+	 */
+	public function disable_woocommerce_store_pages_only() {
+		delete_option( 'woocommerce_store_pages_only' );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

By default, when installing WooCommerce on new sites, the site visibility coming soon option is turned on and set to `Apply to store pages only`. This is causing a conflict with the WPCOM coming soon feature because it makes the non-woo pages public once WooCommerce is installed. This change aims to solve that by disabling the `store pages only` option when WooCommerce is installed.

Closes [DOTDEV-127](https://linear.app/a8c/issue/DOTDEV-127/dotcom-nmit-7-woocommerce-coming-soon-mode-overrides-wordpresscom-un)

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

1. Create a new WPCOM site with a business plan.
2. Make sure the site is not launched yet (coming soon).
3. Install the WooCommerce plugin.
4. Go to WooCommerce -> Settings -> Site visibility and make sure `Apply to store pages only` is off.
5. Log out and go to the homepage of the site.
6. You should see the global Woo coming soon page.

<img width="690" height="287" alt="image" src="https://github.com/user-attachments/assets/9337a81b-9ba6-44ce-b0b8-24140be43b89" />

<img width="1022" height="556" alt="image" src="https://github.com/user-attachments/assets/070e6201-6cdc-4e9d-985b-5fa7851d8fe8" />


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
