### PR TITLE
i18n: Change the textdomain for strings which only exist in wc-calypso-bridge

### DIFF
--- a/includes/class-wc-calypso-bridge-free-trial-payment-restrictions.php
+++ b/includes/class-wc-calypso-bridge-free-trial-payment-restrictions.php
@@ -294,7 +294,7 @@ class WC_Calypso_Bridge_Free_Trial_Payment_Restrictions {
 			?>
 			<script type="text/javascript">
 				function overrideNoPaymentMethodsMessage( translation, text, domain ) {
-					if ( text === '<?php /* phpcs:ignore WordPress.WP.I18n.TextDomainMismatch */ esc_html_e( 'There are no payment methods available. This may be an error on our side. Please contact us if you need any help placing your order.', 'woocommerce' ); ?>' ) {
+					if ( text === '<?php /* phpcs:ignore WordPress.WP.I18n.TextDomainMismatch */ esc_html_e( 'There are no payment methods available. This may be an error on our side. Please contact us if you need any help placing your order.', 'wc-calypso-bridge' ); ?>' ) {
 						return '<?php esc_html_e( 'This store is not ready to accept orders. Checkout functionality is currently enabled for preview purposes only.', 'wc-calypso-bridge' ); ?>';
 					}
 

--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -317,7 +317,7 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 				array(
 					'title' => __( 'Onboarding', 'wc-calypso-bridge' ),
 					'type'  => 'title',
-					'desc'  => __( 'Use these options to restore the visibility of the onboarding Task Lists in the WooCommerce Home.', 'woocommerce' ),
+					'desc'  => __( 'Use these options to restore the visibility of the onboarding Task Lists in the WooCommerce Home.', 'wc-calypso-bridge' ),
 					'id'    => 'onboarding_options',
 				)
 			)

--- a/includes/tasks/class-wc-calypso-task-headstart-products.php
+++ b/includes/tasks/class-wc-calypso-task-headstart-products.php
@@ -88,13 +88,13 @@ class HeadstartProducts extends Products {
 		if ( self::is_already_selling() ) {
 			return __(
 				'Import your products. Show off your products or services and get ready to start selling – import your existing product info, images, and descriptions.',
-				'woocommerce'
+				'wc-calypso-bridge'
 			);
 		}
 
 		return __(
 			'Add your products. Show off your products or services and get ready to start selling – add your product info, images, and descriptions.',
-			'woocommerce'
+			'wc-calypso-bridge'
 		);
 	}
 

--- a/includes/tasks/class-wc-calypso-task-launch-site.php
+++ b/includes/tasks/class-wc-calypso-task-launch-site.php
@@ -29,7 +29,7 @@ class LaunchSite extends Task {
 	public function get_title() {
 		if ( true === $this->get_parent_option( 'use_completed_title' ) ) {
 			if ( $this->is_complete() ) {
-				return __( 'You\'ve already launched your store', 'woocommerce' );
+				return __( 'You\'ve already launched your store', 'wc-calypso-bridge' );
 			}
 
 			return __( 'Launch your store', 'woocommerce' );
@@ -46,7 +46,7 @@ class LaunchSite extends Task {
 	public function get_content() {
 		return __(
 			'It\'s time to celebrate! Ready to launch your store?',
-			'woocommerce'
+			'wc-calypso-bridge'
 		);
 	}
 

--- a/store-on-wpcom/api/class-wc-calypso-bridge-data-counts-controller.php
+++ b/store-on-wpcom/api/class-wc-calypso-bridge-data-counts-controller.php
@@ -263,19 +263,19 @@ class WC_Calypso_Bridge_Data_Counts_Controller extends WC_REST_Controller {
 			'properties' => array(
 				'orders' => array(
 					'type'        => 'object',
-					'description' => __( 'Collection of order totals by order status.', 'woocommerce' ),
+					'description' => __( 'Collection of order totals by order status.', 'wc-calypso-bridge' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
 				'products' => array(
 					'type'        => 'object',
-					'description' => __( 'Collection of product totals by stock status.', 'woocommerce' ),
+					'description' => __( 'Collection of product totals by stock status.', 'wc-calypso-bridge' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
 				'reviews' => array(
 					'type'        => 'object',
-					'description' => __( 'Collection of review totals by comment status.', 'woocommerce' ),
+					'description' => __( 'Collection of review totals by comment status.', 'wc-calypso-bridge' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),

--- a/store-on-wpcom/api/class-wc-calypso-bridge-product-reviews-controller.php
+++ b/store-on-wpcom/api/class-wc-calypso-bridge-product-reviews-controller.php
@@ -237,7 +237,7 @@ class WC_Calypso_Bridge_Product_Reviews_Controller extends WC_REST_Controller {
 
 		$params['status'] = array(
 			'default'           => 'any',
-			'description'       => __( 'Limit result set to reviews with a specific status.', 'woocommerce' ),
+			'description'       => __( 'Limit result set to reviews with a specific status.', 'wc-calypso-bridge' ),
 			'type'              => 'stringy',
 			'enum'              => array( 'any', 'pending', 'approved', 'trash', 'spam' ),
 			'validate_callback' => 'rest_validate_request_arg',
@@ -271,7 +271,7 @@ class WC_Calypso_Bridge_Product_Reviews_Controller extends WC_REST_Controller {
 		);
 
 		$params['product'] = array(
-			'description'       => __( 'Limit result set to reviews assigned a specific product.', 'woocommerce' ),
+			'description'       => __( 'Limit result set to reviews assigned a specific product.', 'wc-calypso-bridge' ),
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -335,7 +335,7 @@ class WC_Calypso_Bridge_Product_Reviews_Controller extends WC_REST_Controller {
 					'context'     => array( 'view', 'edit' ),
 				),
 				'avatar_urls' => array(
-					'description' => __( "URLs for the reviewer's avatar.", 'woocommerce' ),
+					'description' => __( "URLs for the reviewer's avatar.", 'wc-calypso-bridge' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 				),
@@ -346,32 +346,32 @@ class WC_Calypso_Bridge_Product_Reviews_Controller extends WC_REST_Controller {
 					'readonly'    => true,
 				),
 				'status' => array(
-					'description' => __( 'Status of the review', 'woocommerce' ),
+					'description' => __( 'Status of the review', 'wc-calypso-bridge' ),
 					'type'        => 'string',
 					'enum'        => array( 'pending', 'approved', 'trash', 'spam' ),
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'product' => array(
-					'description' => __( 'Basic information on the product that the review is for.', 'woocommerce' ),
+					'description' => __( 'Basic information on the product that the review is for.', 'wc-calypso-bridge' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 					'properties' => array(
 						'id' => array(
-							'description' => __( 'ID of the product.', 'woocommerce' ),
+							'description' => __( 'ID of the product.', 'wc-calypso-bridge' ),
 							'type'        => 'integer',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 						),
 						'name' => array(
-							'description' => __( 'Name of the product.', 'woocommerce' ),
+							'description' => __( 'Name of the product.', 'wc-calypso-bridge' ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 						),
 						'image' => array(
-							'description' => __( 'Featured image for the product.', 'woocommerce' ),
+							'description' => __( 'Featured image for the product.', 'wc-calypso-bridge' ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Related to TRA-33.
There are several translatable strings in wc-calypso-bridge which have translations, but they're not being used because the wrong textdomain is used when displaying them. This PR fixes all the instances where `woocommerce` textdomain was used instead of `wc-calypso-bridge`, when the string only exists in wc-calypso-bridge.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. One option would be to go to /wp-admin/admin.php?page=wc-admin on a new site with WooCommerce installed and confirm that `Add your products. Show off your products...` appears translated.
2. Another option is to review the changes and do some spot checks to confirm that the strings only appear in https://translate.wordpress.com/projects/woocommerce/wc-calypso-bridge/de/default/, but not in https://translate.wordpress.org/projects/wp-plugins/woocommerce/stable/fr/default/.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
