### PR TITLE
Fix PHP warnings: use current() after array_filter, guard foreach against null

### DIFF
--- a/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
+++ b/includes/class-wc-calypso-bridge-woocommerce-admin-features.php
@@ -241,6 +241,10 @@ class WC_Calypso_Bridge_WooCommerce_Admin_Features {
 	 * @return array
 	 */
 	public function filter_woocommerce_settings_pages_order( $pages ) {
+		if ( ! is_array( $pages ) ) {
+			return $pages;
+		}
+
 		foreach ( $pages as $page_id => $page ) {
 			if ( 'advanced' === $page_id ) {
 				unset( $pages[ $page_id ] );

--- a/includes/notes/class-wc-calypso-bridge-choose-domain.php
+++ b/includes/notes/class-wc-calypso-bridge-choose-domain.php
@@ -111,7 +111,7 @@ class WC_Calypso_Bridge_Choose_Domain_Note {
 		}
 
 		// Calculate how many hours have passed since the paid plan purchase.
-		$subscribed_date = strtotime( get_date_from_gmt( $plan_purchases[0]->subscribed_date ) );
+		$subscribed_date = strtotime( get_date_from_gmt( current( $plan_purchases )->subscribed_date ) );
 		$current_date    = current_time( 'timestamp', true );
 		$hours_passed    = ( $current_date - $subscribed_date ) / HOUR_IN_SECONDS;
 

--- a/includes/notes/class-wc-calypso-bridge-choose-domain.php
+++ b/includes/notes/class-wc-calypso-bridge-choose-domain.php
@@ -111,7 +111,7 @@ class WC_Calypso_Bridge_Choose_Domain_Note {
 		}
 
 		// Calculate how many hours have passed since the paid plan purchase.
-		$subscribed_date = strtotime( get_date_from_gmt( current( $plan_purchases )->subscribed_date ) );
+		$subscribed_date = strtotime( get_date_from_gmt( reset( $plan_purchases )->subscribed_date ) );
 		$current_date    = current_time( 'timestamp', true );
 		$hours_passed    = ( $current_date - $subscribed_date ) / HOUR_IN_SECONDS;
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fix two PHP warnings fired ~4000 times/day on WP Cloud sites from the `automattic/wc-calypso-bridge` package.

- **`choose-domain.php`**: `array_filter()` preserves original array keys, so `$plan_purchases[0]` returns `null` when the bundle purchase is not at index 0. Replaced with `current( $plan_purchases )` which always returns the first element regardless of key.
- **`class-wc-calypso-bridge-woocommerce-admin-features.php`**: `filter_woocommerce_settings_pages_order()` can receive a non-array value from upstream. Added an `is_array()` guard before the `foreach` to prevent the warning.

Fixes WCCOM-2455.

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### How to test the changes in this Pull Request:

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

**On trunk (before) — reproduce the warnings:**

1. On a WP Cloud site with the `wc-calypso-bridge` package vendored via `wpcomsh`, open the PHP error log.
2. Confirm you see recurring warnings:
   - `PHP Warning: Attempt to read property "subscribed_date" on null in .../class-wc-calypso-bridge-choose-domain.php on line 114`
   - `PHP Warning: Undefined array key 0 in .../class-wc-calypso-bridge-choose-domain.php on line 114`
   - `PHP Warning: foreach() argument must be of type array|object, null given in .../class-wc-calypso-bridge-woocommerce-admin-features.php on line 244`

**On this branch (after):**

1. With this version deployed, navigate to **WP Admin → WooCommerce → Settings** on a site that has a paid bundle plan purchase where the plan is not the first entry in the purchases array (e.g., a site with multiple purchases where the bundle is at a non-zero index).
2. Confirm the WooCommerce Settings page loads without PHP warnings.
3. Check the PHP error log — no new warnings should appear from either `class-wc-calypso-bridge-choose-domain.php` or `class-wc-calypso-bridge-woocommerce-admin-features.php`.
4. Navigate to **WP Admin → WooCommerce → Notes** (Inbox) and confirm the Choose Domain note still renders correctly and the `subscribed_date` logic works (note marked as unread if plan was purchased within the last 2 hours).

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.