### PR TITLE
Harden release CI against head_ref shell injection

### DIFF
--- a/.github/workflows/ci-release-smoke-test.yml
+++ b/.github/workflows/ci-release-smoke-test.yml
@@ -19,7 +19,7 @@ jobs:
 
             - name: Extract Version Number
               run: |
-                if [[ "${{ github.head_ref }}" =~ ^release\/([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+                if [[ "$HEAD_REF" =~ ^release\/([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
                   version="${BASH_REMATCH[1]}"
                   echo "Extracted version number: ${version}"
                   if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -29,11 +29,12 @@ jobs:
                   echo "Valid version number format"
                   echo "VERSION=${version}" >> $GITHUB_ENV
                 else
-                  echo "Branch name does not match the release/X.X.X format: ${{ github.head_ref }}"
+                  echo "Branch name does not match the release/X.X.X format: $HEAD_REF"
                   exit 1
                 fi
               env:
                 GITHUB_REF: ${{ github.ref }}
+                HEAD_REF: ${{ github.head_ref }}
 
             - name: Check Versions
               run: |

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -22,7 +22,7 @@ jobs:
 
           - name: Extract Version Number
             run: |
-              if [[ "${{ github.head_ref }}" =~ ^release\/([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+              if [[ "$HEAD_REF" =~ ^release\/([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
                 version="${BASH_REMATCH[1]}"
                 echo "Extracted version number: ${version}"
                 if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -32,11 +32,12 @@ jobs:
                 echo "Valid version number format"
                 echo "VERSION=${version}" >> $GITHUB_ENV
               else
-                echo "Branch name does not match the release/X.X.X format: ${{ github.head_ref }}"
+                echo "Branch name does not match the release/X.X.X format: $HEAD_REF"
                 exit 1
               fi
             env:
               GITHUB_REF: ${{ github.ref }}
+              HEAD_REF: ${{ github.head_ref }}
 
           - name: Check Versions
             run: |
@@ -64,7 +65,7 @@ jobs:
 
         - name: Extract Version Number
           run: |
-            if [[ "${{ github.head_ref }}" =~ ^release\/([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            if [[ "$HEAD_REF" =~ ^release\/([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
               version="${BASH_REMATCH[1]}"
               echo "Extracted version number: ${version}"
               if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -74,11 +75,12 @@ jobs:
               echo "Valid version number format"
               echo "VERSION=${version}" >> $GITHUB_ENV
             else
-              echo "Branch name does not match the release/X.X.X format: ${{ github.head_ref }}"
+              echo "Branch name does not match the release/X.X.X format: $HEAD_REF"
               exit 1
             fi
           env:
             GITHUB_REF: ${{ github.ref }}
+            HEAD_REF: ${{ github.head_ref }}
 
         - name: Validate version number
           run: |


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Hardens the two release CI workflows (`ci-release.yml`, `ci-release-smoke-test.yml`) against shell injection via the PR head branch name.

Both workflows interpolate `${{ github.head_ref }}` directly into a `run:` script. Because the branch name is attacker-controllable on a fork PR, this is a script-injection sink that can lead to command execution on the runner. This PR passes the value through an `env:` variable and references it as a quoted shell variable (`"$HEAD_REF"`) — the GitHub-recommended pattern — which is behaviour-preserving for legitimate `release/x.y.z` branches.

Both workflows run on `pull_request` (read-only token, no secrets), so the impact is limited to the runner.

Closes # .

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Push a `release/9.9.9` branch and open a PR against `master`; confirm the **Release Smoke Test CI → Check versions** job still extracts the version and passes (behaviour unchanged).
2. Confirm a non-`release/` branch is still rejected exactly as before.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
