### PR TITLE
chore: pin third-party GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14

--- a/.github/workflows/check-bundle-size.yml
+++ b/.github/workflows/check-bundle-size.yml
@@ -15,7 +15,7 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version-file: '.nvmrc'
-            - uses: preactjs/compressed-size-action@v2
+            - uses: preactjs/compressed-size-action@66325aad6443cb7cf89c4bfcd414aea2367cda94 # 2.9.1
               with:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
                   pattern: "./build/*.{js,css}"

--- a/.github/workflows/check-coding-standards.yml
+++ b/.github/workflows/check-coding-standards.yml
@@ -15,7 +15,7 @@ jobs:
               uses: actions/checkout@v3
 
             - name: Set up PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
               with:
                   php-version: '8.0'
                   coverage: none


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wc-calypso-bridge/pull/1601.

During DEVPROD-1072 follow-up review, this repository still had two third-party GitHub Actions on floating version refs. This PR pins those actions to commit SHAs and adds GitHub Actions Dependabot coverage.

DEVPROD-1072
