### PR TITLE
Update critical npm dependency paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1534,11 +1534,13 @@
 			"integrity": "sha512-aZhGcaXVeT0rxZdsPq+xbQyIpT+GoS5gYiXAVrTrImOgWUEhP0LU9guil8Wy9/2FJrxfD3IkvNnzC1aWviXw1w=="
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.21.4",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.21.4.tgz",
-			"integrity": "sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
 			"dependencies": {
-				"@babel/highlight": "^7.18.6"
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1611,15 +1613,16 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.21.4",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.4.tgz",
-			"integrity": "sha512-NieM3pVIYW2SwGzKoqfPrQsf4xGs9M9AIG3ThppsSRmO+m7eQhmI6amajKMUeIO37wFfsvnvcxQFx6x6iqxDnA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+			"integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.21.4",
-				"@jridgewell/gen-mapping": "^0.3.2",
-				"@jridgewell/trace-mapping": "^0.3.17",
-				"jsesc": "^2.5.1"
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
+				"jsesc": "^3.0.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1725,10 +1728,13 @@
 			}
 		},
 		"node_modules/@babel/helper-environment-visitor": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-			"integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
+			"integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
 			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.24.7"
+			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -1746,25 +1752,25 @@
 			}
 		},
 		"node_modules/@babel/helper-function-name": {
-			"version": "7.21.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz",
-			"integrity": "sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
+			"integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/template": "^7.20.7",
-				"@babel/types": "^7.21.0"
+				"@babel/template": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-hoist-variables": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
-			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
+			"integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.18.6"
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1893,29 +1899,29 @@
 			}
 		},
 		"node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
-			"integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+			"integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.18.6"
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.19.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
-			"integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+			"integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.19.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -1958,24 +1964,14 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/highlight": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.18.6",
-				"chalk": "^2.0.0",
-				"js-tokens": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/parser": {
-			"version": "7.21.4",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.4.tgz",
-			"integrity": "sha512-alVJj7k7zIxqBZ7BTRhz0IqJFxW1VJbm6N8JbcYhQ186df9ZBPbZBmWSqAMXwHGsCJdYks7z/voa3ibiS5bCIw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+			"integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
 			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.29.7"
+			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -3297,33 +3293,33 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
-			"integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+			"integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.18.6",
-				"@babel/parser": "^7.20.7",
-				"@babel/types": "^7.20.7"
+				"@babel/code-frame": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.21.4",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.4.tgz",
-			"integrity": "sha512-eyKrRHKdyZxqDm+fV1iqL9UAHMoIg0nDaGqfIOd8rKH17m5snv7Gn4qgjBoFfLz9APvjFU/ICT00NVCv1Epp8Q==",
+			"version": "7.23.2",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+			"integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.21.4",
-				"@babel/generator": "^7.21.4",
-				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.21.0",
-				"@babel/helper-hoist-variables": "^7.18.6",
-				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/parser": "^7.21.4",
-				"@babel/types": "^7.21.4",
+				"@babel/code-frame": "^7.22.13",
+				"@babel/generator": "^7.23.0",
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-function-name": "^7.23.0",
+				"@babel/helper-hoist-variables": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/parser": "^7.23.0",
+				"@babel/types": "^7.23.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -3332,13 +3328,12 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.21.4",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.4.tgz",
-			"integrity": "sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+			"integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.19.4",
-				"@babel/helper-validator-identifier": "^7.19.1",
-				"to-fast-properties": "^2.0.0"
+				"@babel/helper-string-parser": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -4503,32 +4498,19 @@
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/set-array": "^1.0.1",
-				"@jridgewell/sourcemap-codec": "^1.4.10",
-				"@jridgewell/trace-mapping": "^0.3.9"
-			},
-			"engines": {
-				"node": ">=6.0.0"
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
 			}
 		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
 			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@jridgewell/set-array": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
@@ -4545,26 +4527,20 @@
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.4.15",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
 			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.18",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
-			"integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/resolve-uri": "3.1.0",
-				"@jridgewell/sourcemap-codec": "1.4.14"
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
-		},
-		"node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.4.14",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-			"dev": true
 		},
 		"node_modules/@kwsites/file-exists": {
 			"version": "1.1.1",
@@ -4855,6 +4831,19 @@
 			"resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
 			"integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
 			"dev": true
+		},
+		"node_modules/@simple-git/args-pathspec": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+			"integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA=="
+		},
+		"node_modules/@simple-git/argv-parser": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+			"integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
+			"dependencies": {
+				"@simple-git/args-pathspec": "^1.0.3"
+			}
 		},
 		"node_modules/@sinclair/typebox": {
 			"version": "0.25.24",
@@ -11327,27 +11316,6 @@
 				"upper-case-first": "^2.0.2"
 			}
 		},
-		"node_modules/chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/chalk/node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
 		"node_modules/change-case": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
@@ -15035,14 +15003,16 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-			"integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
+			"integrity": "sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==",
 			"dev": true,
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
+				"mime-types": "^2.1.35"
 			},
 			"engines": {
 				"node": ">= 6"
@@ -15551,14 +15521,6 @@
 			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/has-property-descriptors": {
@@ -18791,15 +18753,15 @@
 			}
 		},
 		"node_modules/jsesc": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
 			"dev": true,
 			"bin": {
 				"jsesc": "bin/jsesc"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=6"
 			}
 		},
 		"node_modules/json-parse-even-better-errors": {
@@ -19021,11 +18983,11 @@
 			}
 		},
 		"node_modules/locutus": {
-			"version": "2.0.39",
-			"resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.39.tgz",
-			"integrity": "sha512-v2iub44UtGpbIv+pFkkYhZ+JsbIM0bJsQcQ1+VayUNGVA/YhM8+CkBiRACcpuuE9Q0xI1pgNzGNwzZDCp1MCww==",
+			"version": "3.0.36",
+			"resolved": "https://registry.npmjs.org/locutus/-/locutus-3.0.36.tgz",
+			"integrity": "sha512-ilsz33lqEd+KerV9JnSHM9EApVYOZ86/JTGKyafmWvhTFtjYauzT1WmZgdJ4JBGR3dY0N0PTfIq2uLvazw5QsQ==",
 			"engines": {
-				"node": ">= 10",
+				"node": ">= 22",
 				"yarn": ">= 1"
 			}
 		},
@@ -20837,8 +20799,7 @@
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-			"dev": true
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
@@ -23708,20 +23669,6 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
 		},
-		"node_modules/simple-git": {
-			"version": "3.18.0",
-			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.18.0.tgz",
-			"integrity": "sha512-Yt0GJ5aYrpPci3JyrYcsPz8Xc05Hi4JPSOb+Sgn/BmPX35fn/6Fp9Mef8eMBCrL2siY5w4j49TA5Q+bxPpri1Q==",
-			"dependencies": {
-				"@kwsites/file-exists": "^1.1.1",
-				"@kwsites/promise-deferred": "^1.1.1",
-				"debug": "^4.3.4"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/steveukx/git-js?sponsor=1"
-			}
-		},
 		"node_modules/simple-html-tokenizer": {
 			"version": "0.5.11",
 			"resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz",
@@ -24556,17 +24503,6 @@
 			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
 			"integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
 		},
-		"node_modules/supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dependencies": {
-				"has-flag": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/supports-hyperlinks": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
@@ -24887,14 +24823,6 @@
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
 			"integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
 			"dev": true
-		},
-		"node_modules/to-fast-properties": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-			"engines": {
-				"node": ">=4"
-			}
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -26620,7 +26548,7 @@
 				"chalk": "^5.2.0",
 				"inquirer": "^8.0.0",
 				"semver": "^7.3.5",
-				"simple-git": "^3.18.0"
+				"simple-git": "^3.36.0"
 			}
 		},
 		"scripts/node_modules/chalk": {
@@ -26634,6 +26562,22 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
+		"scripts/node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
 		"scripts/node_modules/lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -26644,6 +26588,11 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"scripts/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
 		},
 		"scripts/node_modules/semver": {
 			"version": "7.5.0",
@@ -26657,6 +26606,22 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"scripts/node_modules/simple-git": {
+			"version": "3.36.0",
+			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+			"integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
+			"dependencies": {
+				"@kwsites/file-exists": "^1.1.1",
+				"@kwsites/promise-deferred": "^1.1.1",
+				"@simple-git/args-pathspec": "^1.0.3",
+				"@simple-git/argv-parser": "^1.1.0",
+				"debug": "^4.4.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/steveukx/git-js?sponsor=1"
 			}
 		},
 		"scripts/node_modules/yallist": {
@@ -27827,11 +27792,13 @@
 			"integrity": "sha512-aZhGcaXVeT0rxZdsPq+xbQyIpT+GoS5gYiXAVrTrImOgWUEhP0LU9guil8Wy9/2FJrxfD3IkvNnzC1aWviXw1w=="
 		},
 		"@babel/code-frame": {
-			"version": "7.21.4",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.21.4.tgz",
-			"integrity": "sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
 			"requires": {
-				"@babel/highlight": "^7.18.6"
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
 			}
 		},
 		"@babel/compat-data": {
@@ -27854,7 +27821,7 @@
 				"@babel/helpers": "^7.21.0",
 				"@babel/parser": "^7.21.4",
 				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.21.4",
+				"@babel/traverse": "7.23.2",
 				"@babel/types": "^7.21.4",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
@@ -27883,15 +27850,16 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.21.4",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.4.tgz",
-			"integrity": "sha512-NieM3pVIYW2SwGzKoqfPrQsf4xGs9M9AIG3ThppsSRmO+m7eQhmI6amajKMUeIO37wFfsvnvcxQFx6x6iqxDnA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+			"integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.21.4",
-				"@jridgewell/gen-mapping": "^0.3.2",
-				"@jridgewell/trace-mapping": "^0.3.17",
-				"jsesc": "^2.5.1"
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
+				"jsesc": "^3.0.2"
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
@@ -27967,10 +27935,13 @@
 			}
 		},
 		"@babel/helper-environment-visitor": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-			"integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
-			"dev": true
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
+			"integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.24.7"
+			}
 		},
 		"@babel/helper-explode-assignable-expression": {
 			"version": "7.18.6",
@@ -27982,22 +27953,22 @@
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.21.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz",
-			"integrity": "sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
+			"integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.20.7",
-				"@babel/types": "^7.21.0"
+				"@babel/template": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
-			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
+			"integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.18.6"
+				"@babel/types": "^7.24.7"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
@@ -28029,7 +28000,7 @@
 				"@babel/helper-split-export-declaration": "^7.18.6",
 				"@babel/helper-validator-identifier": "^7.19.1",
 				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.21.2",
+				"@babel/traverse": "7.23.2",
 				"@babel/types": "^7.21.2"
 			}
 		},
@@ -28070,7 +28041,7 @@
 				"@babel/helper-member-expression-to-functions": "^7.20.7",
 				"@babel/helper-optimise-call-expression": "^7.18.6",
 				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.20.7",
+				"@babel/traverse": "7.23.2",
 				"@babel/types": "^7.20.7"
 			}
 		},
@@ -28093,23 +28064,23 @@
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
-			"integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+			"integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.18.6"
+				"@babel/types": "^7.24.7"
 			}
 		},
 		"@babel/helper-string-parser": {
-			"version": "7.19.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
-			"integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw=="
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+			"integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.19.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="
 		},
 		"@babel/helper-validator-option": {
 			"version": "7.21.0",
@@ -28125,7 +28096,7 @@
 			"requires": {
 				"@babel/helper-function-name": "^7.19.0",
 				"@babel/template": "^7.18.10",
-				"@babel/traverse": "^7.20.5",
+				"@babel/traverse": "7.23.2",
 				"@babel/types": "^7.20.5"
 			}
 		},
@@ -28136,25 +28107,18 @@
 			"dev": true,
 			"requires": {
 				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.21.0",
+				"@babel/traverse": "7.23.2",
 				"@babel/types": "^7.21.0"
 			}
 		},
-		"@babel/highlight": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-			"requires": {
-				"@babel/helper-validator-identifier": "^7.18.6",
-				"chalk": "^2.0.0",
-				"js-tokens": "^4.0.0"
-			}
-		},
 		"@babel/parser": {
-			"version": "7.21.4",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.4.tgz",
-			"integrity": "sha512-alVJj7k7zIxqBZ7BTRhz0IqJFxW1VJbm6N8JbcYhQ186df9ZBPbZBmWSqAMXwHGsCJdYks7z/voa3ibiS5bCIw==",
-			"dev": true
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+			"integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.29.7"
+			}
 		},
 		"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
 			"version": "7.18.6",
@@ -29035,42 +28999,41 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
-			"integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+			"integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.18.6",
-				"@babel/parser": "^7.20.7",
-				"@babel/types": "^7.20.7"
+				"@babel/code-frame": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.21.4",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.4.tgz",
-			"integrity": "sha512-eyKrRHKdyZxqDm+fV1iqL9UAHMoIg0nDaGqfIOd8rKH17m5snv7Gn4qgjBoFfLz9APvjFU/ICT00NVCv1Epp8Q==",
+			"version": "7.23.2",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+			"integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.21.4",
-				"@babel/generator": "^7.21.4",
-				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.21.0",
-				"@babel/helper-hoist-variables": "^7.18.6",
-				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/parser": "^7.21.4",
-				"@babel/types": "^7.21.4",
+				"@babel/code-frame": "^7.22.13",
+				"@babel/generator": "^7.23.0",
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-function-name": "^7.23.0",
+				"@babel/helper-hoist-variables": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/parser": "^7.23.0",
+				"@babel/types": "^7.23.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			}
 		},
 		"@babel/types": {
-			"version": "7.21.4",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.4.tgz",
-			"integrity": "sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+			"integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
 			"requires": {
-				"@babel/helper-string-parser": "^7.19.4",
-				"@babel/helper-validator-identifier": "^7.19.1",
-				"to-fast-properties": "^2.0.0"
+				"@babel/helper-string-parser": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7"
 			}
 		},
 		"@bcoe/v8-coverage": {
@@ -29974,26 +29937,19 @@
 			}
 		},
 		"@jridgewell/gen-mapping": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/set-array": "^1.0.1",
-				"@jridgewell/sourcemap-codec": "^1.4.10",
-				"@jridgewell/trace-mapping": "^0.3.9"
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
 			}
 		},
 		"@jridgewell/resolve-uri": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
 			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-			"dev": true
-		},
-		"@jridgewell/set-array": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
 			"dev": true
 		},
 		"@jridgewell/source-map": {
@@ -30007,27 +29963,19 @@
 			}
 		},
 		"@jridgewell/sourcemap-codec": {
-			"version": "1.4.15",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
 			"dev": true
 		},
 		"@jridgewell/trace-mapping": {
-			"version": "0.3.18",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
-			"integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/resolve-uri": "3.1.0",
-				"@jridgewell/sourcemap-codec": "1.4.14"
-			},
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": {
-					"version": "1.4.14",
-					"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-					"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-					"dev": true
-				}
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
 		"@kwsites/file-exists": {
@@ -30252,6 +30200,19 @@
 			"resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
 			"integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
 			"dev": true
+		},
+		"@simple-git/args-pathspec": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+			"integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA=="
+		},
+		"@simple-git/argv-parser": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+			"integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
+			"requires": {
+				"@simple-git/args-pathspec": "^1.0.3"
+			}
 		},
 		"@sinclair/typebox": {
 			"version": "0.25.24",
@@ -31980,7 +31941,7 @@
 			"resolved": "https://registry.npmjs.org/@woocommerce/number/-/number-2.4.0.tgz",
 			"integrity": "sha512-SmEgad2zZ9fGZtpujrdk0/toSXjNuDOUxDKQutJ++ASID17bGKZtLxXcu/E7mvF1tTgszpiToPvqZlyC+vjOlg==",
 			"requires": {
-				"locutus": "^2.0.16"
+				"locutus": "3.0.36"
 			}
 		},
 		"@woocommerce/onboarding": {
@@ -35362,23 +35323,6 @@
 				"upper-case-first": "^2.0.2"
 			}
 		},
-		"chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"dependencies": {
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
-				}
-			}
-		},
 		"change-case": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
@@ -38186,14 +38130,16 @@
 			}
 		},
 		"form-data": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-			"integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
+			"integrity": "sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==",
 			"dev": true,
 			"requires": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
+				"mime-types": "^2.1.35"
 			}
 		},
 		"forwarded": {
@@ -38564,11 +38510,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
 			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ=="
-		},
-		"has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
 		},
 		"has-property-descriptors": {
 			"version": "1.0.2",
@@ -40545,7 +40486,7 @@
 				"@babel/core": "^7.7.2",
 				"@babel/generator": "^7.7.2",
 				"@babel/plugin-syntax-typescript": "^7.7.2",
-				"@babel/traverse": "^7.7.2",
+				"@babel/traverse": "7.23.2",
 				"@babel/types": "^7.0.0",
 				"@jest/transform": "^27.5.1",
 				"@jest/types": "^27.5.1",
@@ -40920,7 +40861,7 @@
 				"decimal.js": "^10.2.1",
 				"domexception": "^2.0.1",
 				"escodegen": "^2.0.0",
-				"form-data": "^3.0.0",
+				"form-data": "3.0.4",
 				"html-encoding-sniffer": "^2.0.1",
 				"http-proxy-agent": "^4.0.1",
 				"https-proxy-agent": "^5.0.0",
@@ -40941,9 +40882,9 @@
 			}
 		},
 		"jsesc": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
 			"dev": true
 		},
 		"json-parse-even-better-errors": {
@@ -41120,9 +41061,9 @@
 			}
 		},
 		"locutus": {
-			"version": "2.0.39",
-			"resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.39.tgz",
-			"integrity": "sha512-v2iub44UtGpbIv+pFkkYhZ+JsbIM0bJsQcQ1+VayUNGVA/YhM8+CkBiRACcpuuE9Q0xI1pgNzGNwzZDCp1MCww=="
+			"version": "3.0.36",
+			"resolved": "https://registry.npmjs.org/locutus/-/locutus-3.0.36.tgz",
+			"integrity": "sha512-ilsz33lqEd+KerV9JnSHM9EApVYOZ86/JTGKyafmWvhTFtjYauzT1WmZgdJ4JBGR3dY0N0PTfIq2uLvazw5QsQ=="
 		},
 		"lodash": {
 			"version": "4.17.21",
@@ -42512,8 +42453,7 @@
 		"picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-			"dev": true
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
 		},
 		"picomatch": {
 			"version": "2.3.1",
@@ -43865,13 +43805,21 @@
 				"chalk": "^5.2.0",
 				"inquirer": "^8.0.0",
 				"semver": "^7.3.5",
-				"simple-git": "^3.18.0"
+				"simple-git": "^3.36.0"
 			},
 			"dependencies": {
 				"chalk": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
 					"integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA=="
+				},
+				"debug": {
+					"version": "4.4.3",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+					"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+					"requires": {
+						"ms": "^2.1.3"
+					}
 				},
 				"lru-cache": {
 					"version": "6.0.0",
@@ -43881,12 +43829,29 @@
 						"yallist": "^4.0.0"
 					}
 				},
+				"ms": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+				},
 				"semver": {
 					"version": "7.5.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
 					"integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
 					"requires": {
 						"lru-cache": "^6.0.0"
+					}
+				},
+				"simple-git": {
+					"version": "3.36.0",
+					"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+					"integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
+					"requires": {
+						"@kwsites/file-exists": "^1.1.1",
+						"@kwsites/promise-deferred": "^1.1.1",
+						"@simple-git/args-pathspec": "^1.0.3",
+						"@simple-git/argv-parser": "^1.1.0",
+						"debug": "^4.4.0"
 					}
 				},
 				"yallist": {
@@ -44614,16 +44579,6 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
 		},
-		"simple-git": {
-			"version": "3.18.0",
-			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.18.0.tgz",
-			"integrity": "sha512-Yt0GJ5aYrpPci3JyrYcsPz8Xc05Hi4JPSOb+Sgn/BmPX35fn/6Fp9Mef8eMBCrL2siY5w4j49TA5Q+bxPpri1Q==",
-			"requires": {
-				"@kwsites/file-exists": "^1.1.1",
-				"@kwsites/promise-deferred": "^1.1.1",
-				"debug": "^4.3.4"
-			}
-		},
 		"simple-html-tokenizer": {
 			"version": "0.5.11",
 			"resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz",
@@ -45283,14 +45238,6 @@
 			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
 			"integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
 		},
-		"supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"requires": {
-				"has-flag": "^3.0.0"
-			}
-		},
 		"supports-hyperlinks": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
@@ -45540,11 +45487,6 @@
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
 			"integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
 			"dev": true
-		},
-		"to-fast-properties": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog=="
 		},
 		"to-regex-range": {
 			"version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -61,5 +61,11 @@
 		"gridicons": "^3.4.2",
 		"react-transition-group": "^4.4.5",
 		"which": "^5.0.0"
+	},
+	"overrides": {
+		"@babel/traverse": "7.23.2",
+		"form-data": "3.0.4",
+		"locutus": "3.0.36",
+		"simple-git": "3.36.0"
 	}
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -11,6 +11,6 @@
 		"chalk": "^5.2.0",
 		"inquirer": "^8.0.0",
 		"semver": "^7.3.5",
-		"simple-git": "^3.18.0"
+		"simple-git": "^3.36.0"
 	}
 }


### PR DESCRIPTION
## Summary
- adds npm overrides for the current critical transitive paths: `@babel/traverse`, `form-data`, `locutus`, and `simple-git`
- updates the `scripts` workspace to use `simple-git` 3.36.x
- keeps the change scoped to the lockfile/package metadata needed to clear the critical alerts

## Notes for reviewers
- `locutus` is pulled through the WooCommerce number/currency package path. The patched 3.x line declares Node >=22, while this repo still installs with the Node version from `.nvmrc`. `npm ci --no-optional` and `npm run build` passed locally under the repo Node version, but this deserves owner review because it touches a runtime dependency path.

## Validation
- `npm install --package-lock-only --ignore-scripts`
- `npm ci --no-optional`
- `npm audit --audit-level=critical`
- `npm run build`
- `git diff --check`