### PR TITLE
Enable the Jetpack Stats module by default on WoW stores

### DIFF
--- a/includes/class-wc-calypso-bridge-setup.php
+++ b/includes/class-wc-calypso-bridge-setup.php
@@ -544,6 +544,7 @@ class WC_Calypso_Bridge_Setup {
 				'blocks',
 				'blaze',
 				'account-protection',
+				'stats',
 			);
 
 			$sharing_options = array(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

[Linear task](https://linear.app/a8c/issue/WOOA7S-1741/site-visitor-stats-are-missing-on-wow-sites)

**TLDR**: Site visitor stats are missing on WooCommerce on WordPress.com (WoW) stores. There is no Jetpack Stats entry in wp-admin, and the `Analytics` menu is Woo-specific (products, orders, etc.), so there is nowhere to see visitor stats at all.

**Solution**: Add `stats` to the list of Jetpack modules we enable by default when a store is set up. Same approach as #1559, which added `blocks`, `blaze` and `account-protection`.

**Why this happens?**
When a brand new store initializes, [we override the whole `jetpack_active_modules` option](https://github.com/Automattic/wc-calypso-bridge/blob/master/includes/class-wc-calypso-bridge-setup.php#L514-L547) with our own list. `stats` has never been in that list, so the Stats module ends up deactivated and its wp-admin entry never appears.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

As with #1559, this is easiest to verify on an Atomic site rather than from this repository:

1. Create a new site on the Business plan.
2. Add it as a dev site using the internal wpcom dev blogs tool on MC.
3. Convert it to Atomic by enabling the Hosting features.
4. SSH into the new server.
5. Edit `/htdocs/wp-content/mu-plugins/wpcomsh/vendor/automattic/wc-calypso-bridge/includes/class-wc-calypso-bridge-setup.php` and add `'stats',` to the `$active_modules` array (after `'account-protection'`).
6. Open that site's plans page: `https://wordpress.com/plans/{blogId}` and buy the Commerce plan.
7. Wait for the migration to complete (WooCommerce should be visible in /wp-admin).
8. Confirm the Stats entry is present in wp-admin and shows site visitor stats.
9. Also confirm `get_option( 'jetpack_active_modules' )` contains `stats` — e.g. via WP-CLI: `wp option get jetpack_active_modules`.

**Before**: no visitor stats anywhere in wp-admin — only the Woo-specific Analytics menu.
**After**: the Jetpack Stats screen is available on a freshly created store.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
