### PR TITLE
Treat stock thresholds as integers in product count queries

### DIFF
--- a/store-on-wpcom/api/class-wc-calypso-bridge-data-counts-controller.php
+++ b/store-on-wpcom/api/class-wc-calypso-bridge-data-counts-controller.php
@@ -101,11 +101,15 @@ class WC_Calypso_Bridge_Data_Counts_Controller extends WC_REST_Controller {
 				AND posts.post_status = 'publish'"
 		);
 
-		$low_stock_amount = get_option( 'woocommerce_notify_low_stock_amount' );
-		$no_stock_amount = get_option( 'woocommerce_notify_no_stock_amount' );
+		// Both thresholds are stock levels, so coerce them to integers and bind them
+		// as integers below. This keeps the comparisons numeric even when an option
+		// holds an unexpected value.
+		$low_stock_amount = absint( get_option( 'woocommerce_notify_low_stock_amount' ) );
+		$no_stock_amount = absint( get_option( 'woocommerce_notify_no_stock_amount' ) );
 
 		$counts['out-of-stock'] = (int) $wpdb->get_var(
-			"SELECT COUNT( DISTINCT posts.ID )
+			$wpdb->prepare(
+				"SELECT COUNT( DISTINCT posts.ID )
 				FROM {$wpdb->posts} as posts
 				INNER JOIN {$wpdb->postmeta} AS postmeta ON posts.ID = postmeta.post_id
 				INNER JOIN {$wpdb->postmeta} AS postmeta2 ON posts.ID = postmeta2.post_id
@@ -113,11 +117,14 @@ class WC_Calypso_Bridge_Data_Counts_Controller extends WC_REST_Controller {
 				AND posts.post_type IN ( 'product', 'product_variation' )
 				AND posts.post_status = 'publish'
 				AND postmeta2.meta_key = '_manage_stock' AND postmeta2.meta_value = 'yes'
-				AND postmeta.meta_key = '_stock' AND CAST(postmeta.meta_value AS SIGNED) <= '{$no_stock_amount}'"
+				AND postmeta.meta_key = '_stock' AND CAST(postmeta.meta_value AS SIGNED) <= %d",
+				$no_stock_amount
+			)
 		);
 
 		$counts['low-inventory'] = (int) $wpdb->get_var(
-			"SELECT COUNT( DISTINCT posts.ID )
+			$wpdb->prepare(
+				"SELECT COUNT( DISTINCT posts.ID )
 				FROM {$wpdb->posts} as posts
 				INNER JOIN {$wpdb->postmeta} AS postmeta ON posts.ID = postmeta.post_id
 				INNER JOIN {$wpdb->postmeta} AS postmeta2 ON posts.ID = postmeta2.post_id
@@ -125,8 +132,11 @@ class WC_Calypso_Bridge_Data_Counts_Controller extends WC_REST_Controller {
 				AND posts.post_type IN ( 'product', 'product_variation' )
 				AND posts.post_status = 'publish'
 				AND postmeta2.meta_key = '_manage_stock' AND postmeta2.meta_value = 'yes'
-				AND postmeta.meta_key = '_stock' AND CAST(postmeta.meta_value AS SIGNED) <= '{$low_stock_amount}'
-				AND postmeta.meta_key = '_stock' AND CAST(postmeta.meta_value AS SIGNED) > '{$no_stock_amount}'"
+				AND postmeta.meta_key = '_stock' AND CAST(postmeta.meta_value AS SIGNED) <= %d
+				AND postmeta.meta_key = '_stock' AND CAST(postmeta.meta_value AS SIGNED) > %d",
+				$low_stock_amount,
+				$no_stock_amount
+			)
 		);
 
 		wp_cache_set( 'wc-counts-products', $counts );

--- a/store-on-wpcom/tests/unit-tests/data-counts-controller.php
+++ b/store-on-wpcom/tests/unit-tests/data-counts-controller.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Tests for the Data Counts endpoint in the REST API.
+ *
+ * The product counts compare stock levels against the WooCommerce low-stock and
+ * no-stock thresholds. Those thresholds come from options, which are not
+ * guaranteed to hold plain integers, so the counts need to stay correct and
+ * stable whatever the stored value looks like.
+ */
+class Data_Counts_Controller extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Setup our test server, endpoint, and user info.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->endpoint = new WC_Calypso_Bridge_Data_Counts_Controller();
+
+		$this->user = $this->factory->user->create( array(
+			'role' => 'administrator',
+		) );
+
+		$this->shop_manager = $this->factory->user->create( array(
+			'role' => 'shop_manager',
+		) );
+
+		$this->customer = $this->factory->user->create( array(
+			'role' => 'customer',
+		) );
+
+		// Three published products that manage stock, one at each interesting
+		// level relative to the thresholds used below.
+		$this->create_stock_product( 0 );  // Out of stock.
+		$this->create_stock_product( 1 );  // Low inventory.
+		$this->create_stock_product( 50 ); // Neither.
+
+		update_option( 'woocommerce_notify_no_stock_amount', 0 );
+		update_option( 'woocommerce_notify_low_stock_amount', 2 );
+	}
+
+	/**
+	 * Create a published product with stock management on and a known level.
+	 *
+	 * @param int $stock Stock quantity.
+	 * @return WC_Product
+	 */
+	protected function create_stock_product( $stock ) {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( $stock );
+		$product->set_status( 'publish' );
+		$product->save();
+
+		return $product;
+	}
+
+	/**
+	 * The counts are cached for the request, so drop the cache between reads.
+	 *
+	 * @return array
+	 */
+	protected function get_fresh_product_counts() {
+		wp_cache_delete( 'wc-counts-products' );
+
+		return $this->endpoint->get_product_counts();
+	}
+
+	/**
+	 * Threshold values that are not plain integers. Each one should be reduced
+	 * to its leading integer and used as an ordinary stock level.
+	 *
+	 * @return array
+	 */
+	public function malformed_threshold_provider() {
+		return array(
+			'trailing text'      => array( '2 items' ),
+			'leading whitespace' => array( ' 2' ),
+			'decimal'            => array( '2.9' ),
+			'negative'           => array( '-2' ),
+			'quoted fragment'    => array( "2' OR 1=1 OR '" ),
+			'inverted fragment'  => array( "2' OR 1=2 OR '" ),
+			'nested select'      => array( "2' OR ( SELECT 1 ) OR '" ),
+		);
+	}
+
+	/**
+	 * Benign thresholds produce the counts the fixtures imply.
+	 */
+	public function test_product_counts_with_integer_thresholds() {
+		$counts = $this->get_fresh_product_counts();
+
+		$this->assertEquals( 3, $counts['all'] );
+		$this->assertEquals( 1, $counts['out-of-stock'] );
+		$this->assertEquals( 1, $counts['low-inventory'] );
+	}
+
+	/**
+	 * A low-stock threshold that is not a plain integer is reduced to 2, which
+	 * is the value the benign case uses, so the counts do not move.
+	 *
+	 * @dataProvider malformed_threshold_provider
+	 * @param string $threshold Stored threshold value.
+	 */
+	public function test_malformed_low_stock_threshold_keeps_counts_stable( $threshold ) {
+		$expected = $this->get_fresh_product_counts();
+
+		update_option( 'woocommerce_notify_low_stock_amount', $threshold );
+		$actual = $this->get_fresh_product_counts();
+
+		$this->assertEquals( $expected['low-inventory'], $actual['low-inventory'] );
+		$this->assertEquals( $expected['out-of-stock'], $actual['out-of-stock'] );
+	}
+
+	/**
+	 * The no-stock threshold is the same kind of value and behaves the same way.
+	 */
+	public function test_malformed_no_stock_threshold_keeps_counts_stable() {
+		$expected = $this->get_fresh_product_counts();
+
+		update_option( 'woocommerce_notify_no_stock_amount', "0' OR 1=1 OR '" );
+		$actual = $this->get_fresh_product_counts();
+
+		$this->assertEquals( $expected['out-of-stock'], $actual['out-of-stock'] );
+		$this->assertEquals( $expected['low-inventory'], $actual['low-inventory'] );
+	}
+
+	/**
+	 * Two thresholds that reduce to the same integer must produce the same
+	 * counts, whatever text follows the integer.
+	 */
+	public function test_thresholds_with_equal_integer_value_agree() {
+		update_option( 'woocommerce_notify_low_stock_amount', "2' OR 1=1 OR '" );
+		$first = $this->get_fresh_product_counts();
+
+		update_option( 'woocommerce_notify_low_stock_amount', "2' OR 1=2 OR '" );
+		$second = $this->get_fresh_product_counts();
+
+		$this->assertEquals( $first['low-inventory'], $second['low-inventory'] );
+	}
+
+	/**
+	 * A threshold with no leading integer degrades to zero rather than
+	 * producing a broken query, so the endpoint keeps answering.
+	 */
+	public function test_non_numeric_threshold_degrades_to_zero() {
+		update_option( 'woocommerce_notify_low_stock_amount', 'not a number' );
+
+		$counts = $this->get_fresh_product_counts();
+
+		$this->assertEquals( 3, $counts['all'] );
+		$this->assertEquals( 0, $counts['low-inventory'] );
+	}
+
+	/**
+	 * The route answers a shop manager and returns the product counts.
+	 */
+	public function test_get_items_as_shop_manager() {
+		wp_set_current_user( $this->shop_manager );
+		wp_cache_delete( 'wc-counts-products' );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/data/counts' ) );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 3, $data['products']['all'] );
+		$this->assertEquals( 1, $data['products']['low-inventory'] );
+	}
+
+	/**
+	 * A customer cannot read the endpoint.
+	 */
+	public function test_get_items_as_customer_is_denied() {
+		wp_set_current_user( $this->customer );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/data/counts' ) );
+
+		$this->assertEquals( 401, $response->get_status() );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The `data/counts` product counts compare stock levels against the low-stock and out-of-stock thresholds. Both thresholds are stock levels, but they were read from options and interpolated into the count queries as strings, so a stored value that is not a plain integer produced a comparison that was not numeric.

This coerces both thresholds with `absint()` at the read and binds them as integers in the two `COUNT` statements, so the comparisons stay numeric regardless of what the stored option value looks like.

Behaviour on the normal path is unchanged: an unset option coerces to `0`, which matches what the previous empty-string comparison already evaluated to.

Also adds unit coverage for the product counts, which had none.

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. On a store-on-wpcom site, create three published products with **Manage stock** enabled, with stock quantities of `0`, `1` and `50`.
2. Go to **WooCommerce → Settings → Products → Inventory** and set **Out of stock threshold** to `0` and **Low stock threshold** to `2`. Save.
3. Request `GET /wp-json/wc/v3/data/counts` as a user who can manage WooCommerce. Confirm the response contains `"all": 3`, `"out-of-stock": 1` and `"low-inventory": 1`.
4. Set **Low stock threshold** to `10`, save, and repeat the request. Confirm `"low-inventory"` is now `2`, since the product with a stock of `1` and the one with `50` are both at or below the new threshold... (verify against your own fixtures if you use different quantities).
5. Set **Low stock threshold** to a value that is not a plain integer, for example `2 items`, `2.9`, or leave it empty. Save, then repeat the request.
6. Confirm the endpoint still returns a well-formed response with sensible counts, and that no database errors or PHP notices appear in the logs.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?

New unit tests are added in `store-on-wpcom/tests/unit-tests/data-counts-controller.php`, covering the counts against integer, malformed and non-numeric threshold values, plus the permission boundaries on the route.

Note that the `store-on-wpcom` suite appears dormant and I was not able to run it: its `phpunit.xml` still uses the `syntaxCheck` attribute that was removed in PHPUnit 8, the existing cases use the pre-PHPUnit 8 `setUp()` signature, and the test jobs in `.github/workflows/ci.yml` are commented out. The new cases follow the conventions of the existing files in that directory, so they will need the same treatment as the rest of the suite whenever it is revived.

