### PR TITLE
Correct permission expectations in data counts coverage

### DIFF
--- a/store-on-wpcom/tests/unit-tests/data-counts-controller.php
+++ b/store-on-wpcom/tests/unit-tests/data-counts-controller.php
@@ -168,10 +168,22 @@ class Data_Counts_Controller extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * A customer cannot read the endpoint.
+	 * A customer is signed in but lacks the capability, so the request is
+	 * forbidden rather than unauthorized.
 	 */
 	public function test_get_items_as_customer_is_denied() {
 		wp_set_current_user( $this->customer );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/data/counts' ) );
+
+		$this->assertEquals( 403, $response->get_status() );
+	}
+
+	/**
+	 * A signed-out request is unauthorized.
+	 */
+	public function test_get_items_when_signed_out_is_denied() {
+		wp_set_current_user( 0 );
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/data/counts' ) );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up to #1643, correcting a wrong expectation in the tests added there.

`test_get_items_as_customer_is_denied` signs in a customer and then asserts a `401`. That's not what the route returns. `rest_authorization_required_code()` returns `403` when there is a signed-in user who lacks the capability, and `401` only when there is no user at all. The assertion should be `403`.

This corrects it, and adds `test_get_items_when_signed_out_is_denied` to cover the `401` case properly, so both sides of the permission check are asserted rather than being conflated into one case that happened to be wrong.

No production code changes; this touches only `store-on-wpcom/tests/unit-tests/data-counts-controller.php`.

Worth knowing for review: this was not caught by CI, because no workflow in this repo invokes PHPUnit. `ci.yml` runs `php-coding-standards`, `setup` and `bundle_size` only, `composer test` uses the root `phpunit.xml` whose testsuite is limited to `./tests/unit-tests`, and nothing references `store-on-wpcom/phpunit.xml`. I found this by running the suite locally instead. Restoring PHP unit test CI is worth doing separately.

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

Running the `store-on-wpcom` suite needs a 2020-era stack, because the bootstrap requires WooCommerce's old `tests/framework/` layout with no `/legacy` fallback, and the existing cases use the pre-PHPUnit 8 `setUp()` signature:

- PHP 7.4
- WordPress 5.4
- WooCommerce 4.0.0, the last release with `tests/framework/`
- PHPUnit 7.5
- A `WP_TESTS_PHPUNIT_POLYFILLS_PATH` constant in `wp-tests-config.php` pointing at `vendor/yoast/phpunit-polyfills`

Then:

1. Check out `master` (before this PR) and run `phpunit -c store-on-wpcom/phpunit.xml --filter Data_Counts`. Confirm `test_get_items_as_customer_is_denied` fails with `Failed asserting that 403 matches expected 401`.
2. Check out this branch and run the same command. Confirm all 14 cases pass: `OK (14 tests, 27 assertions)`.
3. Confirm the two permission cases assert the right things: a signed-in customer gets `403`, and a signed-out request gets `401`.

Note that the suite has 3 pre-existing failures on `master` unrelated to this change, in `Email_Groups_Controller` and `Paypal_Method_supports`. They reproduce with these changes fully removed, so filter with `--filter Data_Counts` to see this PR's cases in isolation.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.